### PR TITLE
Fix insecure export wallpaper asset handling

### DIFF
--- a/apps/desktop/src/components/video-editor/VideoPlayback.test.tsx
+++ b/apps/desktop/src/components/video-editor/VideoPlayback.test.tsx
@@ -174,6 +174,14 @@ const mockState = vi.hoisted(() => {
 		updateOverlayIndicator: vi.fn(),
 		getAssetPath: vi.fn(async () => "/wallpaper.png"),
 		getRenderableAssetUrl: vi.fn(async (value: string) => value),
+		isRenderableAssetUrl: vi.fn(
+			(value: string) =>
+				value.startsWith("data:") ||
+				value.startsWith("asset:") ||
+				value.startsWith("http") ||
+				value.startsWith("file://") ||
+				value.startsWith("/"),
+		),
 	};
 });
 
@@ -234,6 +242,7 @@ vi.mock("./videoPlayback/overlayUtils", () => ({
 vi.mock("@/lib/assetPath", () => ({
 	getAssetPath: mockState.getAssetPath,
 	getRenderableAssetUrl: mockState.getRenderableAssetUrl,
+	isRenderableAssetUrl: mockState.isRenderableAssetUrl,
 }));
 
 vi.mock("./AnnotationOverlay", () => ({

--- a/apps/desktop/src/components/video-editor/VideoPlayback.tsx
+++ b/apps/desktop/src/components/video-editor/VideoPlayback.tsx
@@ -10,7 +10,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { getAssetPath, getRenderableAssetUrl } from "@/lib/assetPath";
+import { getAssetPath, getRenderableAssetUrl, isRenderableAssetUrl } from "@/lib/assetPath";
 import {
 	Application,
 	BlurFilter,
@@ -97,10 +97,7 @@ function isDirectlyRenderableWallpaper(wallpaper: string): boolean {
 		wallpaper.startsWith("#") ||
 		wallpaper.startsWith("linear-gradient") ||
 		wallpaper.startsWith("radial-gradient") ||
-		wallpaper.startsWith("data:") ||
-		wallpaper.startsWith("http") ||
-		wallpaper.startsWith("file://") ||
-		wallpaper.startsWith("/")
+		isRenderableAssetUrl(wallpaper)
 	);
 }
 
@@ -1584,13 +1581,7 @@ const VideoPlayback = memo(
 				};
 			}, [clearFirstFrameTimeout]);
 
-			const isImageUrl = Boolean(
-				resolvedWallpaper &&
-					(resolvedWallpaper.startsWith("file://") ||
-						resolvedWallpaper.startsWith("http") ||
-						resolvedWallpaper.startsWith("/") ||
-						resolvedWallpaper.startsWith("data:")),
-			);
+			const isImageUrl = Boolean(resolvedWallpaper && isRenderableAssetUrl(resolvedWallpaper));
 			const backgroundStyle = isImageUrl
 				? { backgroundImage: `url(${resolvedWallpaper || ""})` }
 				: { background: resolvedWallpaper || "" };

--- a/apps/desktop/src/lib/assetPath.test.ts
+++ b/apps/desktop/src/lib/assetPath.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/backend", () => ({
+	convertFileToSrc: vi.fn((path: string) => `asset://localhost/${encodeURIComponent(path)}`),
+}));
+
+const { getRenderableAssetUrl, isRenderableAssetUrl } = await import("./assetPath");
+
+describe("assetPath", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("treats Tauri asset URLs as renderable image URLs", () => {
+		expect(isRenderableAssetUrl("asset://localhost/%2FUsers%2Fdemo%2Fwallpaper.jpg")).toBe(true);
+		expect(isRenderableAssetUrl("https://asset.localhost/%2FUsers%2Fdemo%2Fwallpaper.jpg")).toBe(
+			true,
+		);
+	});
+
+	it("converts file URLs into Tauri asset URLs before rendering", async () => {
+		await expect(getRenderableAssetUrl("file:///Users/demo/Pictures/wallpaper.jpg")).resolves.toBe(
+			"asset://localhost/%2FUsers%2Fdemo%2FPictures%2Fwallpaper.jpg",
+		);
+	});
+
+	it("preserves existing Tauri asset URLs", async () => {
+		const assetUrl = "asset://localhost/%2FUsers%2Fdemo%2FPictures%2Fwallpaper.jpg";
+		await expect(getRenderableAssetUrl(assetUrl)).resolves.toBe(assetUrl);
+	});
+});

--- a/apps/desktop/src/lib/assetPath.ts
+++ b/apps/desktop/src/lib/assetPath.ts
@@ -1,47 +1,63 @@
-import { convertFileToSrc } from '@/lib/backend'
+import { convertFileToSrc } from "@/lib/backend";
+
+const RENDERABLE_ASSET_PROTOCOL =
+	/^(data:|asset:|https?:\/\/asset\.localhost\/|https?:|file:\/\/|\/)/i;
 
 function encodeRelativeAssetPath(relativePath: string): string {
-  return relativePath
-    .replace(/^\/+/, '')
-    .split('/')
-    .filter(Boolean)
-    .map((part) => encodeURIComponent(part))
-    .join('/')
+	return relativePath
+		.replace(/^\/+/, "")
+		.split("/")
+		.filter(Boolean)
+		.map((part) => encodeURIComponent(part))
+		.join("/");
 }
 
 export async function getAssetPath(relativePath: string): Promise<string> {
-  const encodedRelativePath = encodeRelativeAssetPath(relativePath)
-  return `/${encodedRelativePath}`
+	const encodedRelativePath = encodeRelativeAssetPath(relativePath);
+	return `/${encodedRelativePath}`;
+}
+
+export function isRenderableAssetUrl(asset: string): boolean {
+	return RENDERABLE_ASSET_PROTOCOL.test(asset);
 }
 
 function toLocalFilePath(resourceUrl: string) {
-  if (!resourceUrl.startsWith('file://')) {
-    return null
-  }
+	if (!resourceUrl.startsWith("file://")) {
+		return null;
+	}
 
-  const decodedPath = decodeURIComponent(resourceUrl.replace(/^file:\/\//, ''))
-  if (/^\/[A-Za-z]:/.test(decodedPath)) {
-    return decodedPath.slice(1)
-  }
+	const decodedPath = decodeURIComponent(resourceUrl.replace(/^file:\/\//, ""));
+	if (/^\/[A-Za-z]:/.test(decodedPath)) {
+		return decodedPath.slice(1);
+	}
 
-  return decodedPath
+	return decodedPath;
 }
 
 export async function getRenderableAssetUrl(asset: string): Promise<string> {
-  if (!asset || asset.startsWith('data:') || asset.startsWith('http') || asset.startsWith('#') || asset.startsWith('linear-gradient') || asset.startsWith('radial-gradient')) {
-    return asset
-  }
+	if (
+		!asset ||
+		asset.startsWith("data:") ||
+		asset.startsWith("asset:") ||
+		asset.startsWith("http") ||
+		asset.startsWith("#") ||
+		asset.startsWith("linear-gradient") ||
+		asset.startsWith("radial-gradient")
+	) {
+		return asset;
+	}
 
-  const resolvedAsset = asset.startsWith('/') && !asset.startsWith('//')
-    ? await getAssetPath(asset.replace(/^\//, ''))
-    : asset
+	const resolvedAsset =
+		asset.startsWith("/") && !asset.startsWith("//")
+			? await getAssetPath(asset.replace(/^\//, ""))
+			: asset;
 
-  const localFilePath = toLocalFilePath(resolvedAsset)
-  if (localFilePath) {
-    return convertFileToSrc(localFilePath)
-  }
+	const localFilePath = toLocalFilePath(resolvedAsset);
+	if (localFilePath) {
+		return convertFileToSrc(localFilePath);
+	}
 
-  return resolvedAsset
+	return resolvedAsset;
 }
 
 export default getAssetPath;

--- a/apps/desktop/src/lib/exporter/frameRenderer.ts
+++ b/apps/desktop/src/lib/exporter/frameRenderer.ts
@@ -10,7 +10,7 @@ import type {
 } from "@/components/video-editor/types";
 import { getFacecamLayout, type FacecamSettings } from "@/lib/recordingSession";
 import { ZOOM_DEPTH_SCALES } from "@/components/video-editor/types";
-import { getAssetPath, getRenderableAssetUrl } from "@/lib/assetPath";
+import { getAssetPath, getRenderableAssetUrl, isRenderableAssetUrl } from "@/lib/assetPath";
 import { findDominantRegion } from "@/components/video-editor/videoPlayback/zoomRegionUtils";
 import {
 	applyZoomTransform,
@@ -236,12 +236,7 @@ export class FrameRenderer {
 
 		try {
 			// Render background based on type
-			if (
-				wallpaper.startsWith("file://") ||
-				wallpaper.startsWith("data:") ||
-				wallpaper.startsWith("/") ||
-				wallpaper.startsWith("http")
-			) {
+			if (isRenderableAssetUrl(wallpaper)) {
 				// Image background
 				const img = new Image();
 				const imageUrl = await this.resolveWallpaperImageUrl(wallpaper);
@@ -346,15 +341,9 @@ export class FrameRenderer {
 	}
 
 	private async resolveWallpaperImageUrl(wallpaper: string): Promise<string> {
-		if (
-			wallpaper.startsWith("file://") ||
-			wallpaper.startsWith("data:") ||
-			wallpaper.startsWith("http")
-		) {
-			return wallpaper;
-		}
-
-		const resolved = await getAssetPath(wallpaper.replace(/^\/+/, ""));
+		const resolved = wallpaper.startsWith("/")
+			? await getAssetPath(wallpaper.replace(/^\/+/, ""))
+			: await getRenderableAssetUrl(wallpaper);
 		if (resolved.startsWith("/") && window.location.protocol.startsWith("http")) {
 			return `${window.location.origin}${resolved}`;
 		}


### PR DESCRIPTION
## Summary
- normalize wallpaper asset detection so export and preview both treat Tauri asset URLs as image sources
- convert local file wallpaper URLs through Tauri asset rendering before drawing them into the export canvas
- add regression coverage for asset/file wallpaper URL handling and update the existing VideoPlayback asset-path mock

## Test plan
- pnpm --filter @open-recorder/desktop exec vitest --run src/lib/assetPath.test.ts src/lib/mediaPlaybackUrl.test.ts src/lib/exporter/videoExporter.test.ts src/components/video-editor/VideoPlayback.test.tsx
