### PR TITLE
Add Linux cursor telemetry capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Open Recorder is a **desktop video editor with a renderer-driven motion pipeline
 - Tauri orchestrates recording
 - macOS uses native ScreenCaptureKit helpers for capture and cursor telemetry
 - Windows uses native WGC for screen capture
-- Linux uses FFmpeg-based capture with browser fallback
+- Linux uses FFmpeg-based capture with browser fallback and cursor telemetry sampling
 
 **Motion**
 - Zoom regions
@@ -376,7 +376,7 @@ Open Recorder bypasses slow browser-based capture APIs wherever possible by usin
 
 - **macOS**: Uses Apple's **ScreenCaptureKit** framework directly via a native Swift sidecar, delivering hardware-optimized screen capture with cursor telemetry at minimal CPU cost
 - **Windows**: Uses the native **Windows.Graphics.Capture (WGC)** API through a dedicated sidecar for display and app-window capture, plus native **WASAPI** for system and microphone audio
-- **Linux**: FFmpeg-based capture pipeline with browser fallback
+- **Linux**: FFmpeg-based capture pipeline with browser fallback and cursor telemetry sampling
 
 These native capture paths run outside the main application process as lightweight sidecar binaries, keeping the UI thread responsive during recording.
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "uuid",
+ "x11rb",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "5"
 open = "5"
 percent-encoding = "2"
 tauri-plugin-clipboard-manager = "2.3.2"
+x11rb = "0.13"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block = "0.1"

--- a/apps/desktop/src-tauri/src/commands/cursor.rs
+++ b/apps/desktop/src-tauri/src/commands/cursor.rs
@@ -1,23 +1,197 @@
-use std::sync::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
-use crate::state::AppState;
+use crate::state::{AppState, CursorTelemetryCapture, CursorTelemetryPoint};
 
-#[tauri::command]
-pub async fn get_cursor_telemetry(video_path: String) -> Result<serde_json::Value, String> {
-    // Cursor telemetry is stored as a JSON sidecar next to the video file
-    let telemetry_path = format!(
+fn telemetry_path_for_video(video_path: &str) -> String {
+    format!(
         "{}.cursor.json",
         video_path
             .trim_end_matches(".mov")
             .trim_end_matches(".mp4")
             .trim_end_matches(".webm")
-    );
+    )
+}
 
-    if let Ok(data) = tokio::fs::read_to_string(&telemetry_path).await {
-        serde_json::from_str(&data).map_err(|e| e.to_string())
+fn cursor_telemetry_payload(samples: Vec<CursorTelemetryPoint>) -> serde_json::Value {
+    serde_json::json!({ "samples": samples, "clicks": [] })
+}
+
+#[cfg(target_os = "linux")]
+fn validate_linux_cursor_sampler() -> Result<(), String> {
+    x11rb::connect(None).map(|_| ()).map_err(|error| {
+        format!("Failed to connect to the X11 display for cursor telemetry: {error}")
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_linux_cursor_sampler(
+    stop: Arc<AtomicBool>,
+    samples: Arc<Mutex<Vec<CursorTelemetryPoint>>>,
+) -> Result<JoinHandle<()>, String> {
+    validate_linux_cursor_sampler()?;
+
+    Ok(std::thread::spawn(move || {
+        use x11rb::connection::Connection;
+        use x11rb::protocol::xproto::ConnectionExt;
+
+        let Ok((conn, screen_num)) = x11rb::connect(None) else {
+            return;
+        };
+
+        let root = conn.setup().roots[screen_num].root;
+        let started_at = Instant::now();
+        let mut last_position: Option<(i16, i16)> = None;
+
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+
+            match conn.query_pointer(root) {
+                Ok(cookie) => match cookie.reply() {
+                    Ok(reply) => {
+                        let position = (reply.root_x, reply.root_y);
+                        if last_position != Some(position) {
+                            let point = CursorTelemetryPoint {
+                                x: f64::from(reply.root_x),
+                                y: f64::from(reply.root_y),
+                                timestamp: started_at.elapsed().as_secs_f64() * 1000.0,
+                                cursor_type: Some("arrow".to_string()),
+                                click_type: None,
+                            };
+
+                            if let Ok(mut guard) = samples.lock() {
+                                guard.push(point);
+                            }
+
+                            last_position = Some(position);
+                        }
+                    }
+                    Err(_) => {
+                        // Ignore transient sampling failures and try again on the next tick.
+                    }
+                },
+                Err(_) => {
+                    // Ignore transient sampling failures and try again on the next tick.
+                }
+            }
+
+            std::thread::sleep(Duration::from_millis(33));
+        }
+    }))
+}
+
+async fn write_cursor_telemetry_sidecar(
+    video_path: &str,
+    samples: &[CursorTelemetryPoint],
+) -> Result<(), String> {
+    let telemetry_path = telemetry_path_for_video(video_path);
+    let payload = cursor_telemetry_payload(samples.to_vec());
+    let serialized = serde_json::to_vec_pretty(&payload).map_err(|error| error.to_string())?;
+    tokio::fs::write(&telemetry_path, serialized)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn get_cursor_telemetry(video_path: String) -> Result<serde_json::Value, String> {
+    let telemetry_path = telemetry_path_for_video(&video_path);
+
+    if let Ok(data) = std::fs::read_to_string(&telemetry_path) {
+        serde_json::from_str(&data).map_err(|error| error.to_string())
     } else {
-        Ok(serde_json::json!({ "samples": [], "clicks": [] }))
+        Ok(cursor_telemetry_payload(Vec::new()))
     }
+}
+
+#[tauri::command]
+pub fn start_cursor_telemetry_capture(
+    state: tauri::State<'_, Mutex<AppState>>,
+) -> Result<(), String> {
+    let mut app_state = state.lock().map_err(|error| error.to_string())?;
+
+    if app_state.cursor_telemetry_capture.is_some() {
+        return Err("Cursor telemetry capture is already running".to_string());
+    }
+
+    app_state.cursor_telemetry.clear();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let samples = Arc::new(Mutex::new(Vec::new()));
+
+    #[cfg(target_os = "linux")]
+    let handle = spawn_linux_cursor_sampler(stop.clone(), samples.clone())?;
+
+    app_state.cursor_telemetry_capture = Some(CursorTelemetryCapture {
+        stop,
+        samples,
+        handle: {
+            #[cfg(target_os = "linux")]
+            {
+                Some(handle)
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                None
+            }
+        },
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_cursor_telemetry_capture(
+    state: tauri::State<'_, Mutex<AppState>>,
+    video_path: Option<String>,
+) -> Result<(), String> {
+    let capture = {
+        let mut app_state = state.lock().map_err(|error| error.to_string())?;
+        app_state.cursor_telemetry_capture.take()
+    };
+
+    let Some(capture) = capture else {
+        if let Some(video_path) = video_path.filter(|path| !path.trim().is_empty()) {
+            write_cursor_telemetry_sidecar(&video_path, &Vec::<CursorTelemetryPoint>::new())
+                .await?;
+        }
+        return Ok(());
+    };
+
+    let CursorTelemetryCapture {
+        stop,
+        samples,
+        handle,
+    } = capture;
+
+    stop.store(true, Ordering::SeqCst);
+    if let Some(handle) = handle {
+        handle
+            .join()
+            .map_err(|_| "Cursor telemetry capture thread panicked".to_string())?;
+    }
+
+    let samples = samples.lock().map_err(|error| error.to_string())?.clone();
+
+    if let Some(video_path) = video_path.filter(|path| !path.trim().is_empty()) {
+        {
+            let mut app_state = state.lock().map_err(|error| error.to_string())?;
+            app_state.cursor_telemetry = samples.clone();
+        }
+
+        write_cursor_telemetry_sidecar(&video_path, &samples).await?;
+    } else {
+        let mut app_state = state.lock().map_err(|error| error.to_string())?;
+        app_state.cursor_telemetry.clear();
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -25,7 +199,7 @@ pub fn set_cursor_scale(
     state: tauri::State<'_, Mutex<AppState>>,
     scale: f64,
 ) -> Result<(), String> {
-    let mut s = state.lock().map_err(|e| e.to_string())?;
+    let mut s = state.lock().map_err(|error| error.to_string())?;
     s.cursor_scale = scale;
     Ok(())
 }
@@ -34,9 +208,8 @@ pub fn set_cursor_scale(
 pub async fn get_system_cursor_assets(
     state: tauri::State<'_, Mutex<AppState>>,
 ) -> Result<serde_json::Value, String> {
-    // Check cache first
     {
-        let s = state.lock().map_err(|e| e.to_string())?;
+        let s = state.lock().map_err(|error| error.to_string())?;
         if let Some(ref cached) = s.cached_system_cursor_assets {
             return Ok(cached.clone());
         }
@@ -44,7 +217,7 @@ pub async fn get_system_cursor_assets(
 
     #[cfg(target_os = "macos")]
     {
-        let exe_path = std::env::current_exe().map_err(|e| e.to_string())?;
+        let exe_path = std::env::current_exe().map_err(|error| error.to_string())?;
         let bin_dir = exe_path.parent().ok_or("Cannot find binary directory")?;
 
         let triple = if cfg!(target_arch = "aarch64") {
@@ -60,15 +233,14 @@ pub async fn get_system_cursor_assets(
             let output = tokio::process::Command::new(&sidecar_path)
                 .output()
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|error| error.to_string())?;
 
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let assets: serde_json::Value =
-                    serde_json::from_str(&stdout).map_err(|e| e.to_string())?;
+                    serde_json::from_str(&stdout).map_err(|error| error.to_string())?;
 
-                // Cache the result
-                let mut s = state.lock().map_err(|e| e.to_string())?;
+                let mut s = state.lock().map_err(|error| error.to_string())?;
                 s.cached_system_cursor_assets = Some(assets.clone());
 
                 return Ok(assets);
@@ -82,17 +254,6 @@ pub async fn get_system_cursor_assets(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Helper: replicate the telemetry path construction logic for testing
-    fn telemetry_path_for_video(video_path: &str) -> String {
-        format!(
-            "{}.cursor.json",
-            video_path
-                .trim_end_matches(".mov")
-                .trim_end_matches(".mp4")
-                .trim_end_matches(".webm")
-        )
-    }
 
     #[test]
     fn test_telemetry_path_from_mov() {
@@ -113,39 +274,31 @@ mod tests {
     }
 
     #[test]
-    fn test_telemetry_path_no_recognized_extension() {
-        let path = telemetry_path_for_video("/path/to/recording.avi");
-        assert_eq!(path, "/path/to/recording.avi.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_no_extension() {
-        let path = telemetry_path_for_video("/path/to/recording");
-        assert_eq!(path, "/path/to/recording.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_double_extension_mov_mp4() {
-        // trim_end_matches strips sequentially: .mov → .mp4 → result
-        let path = telemetry_path_for_video("/path/to/file.mp4.mov");
+    fn test_telemetry_path_chain_strips_extensions_in_order() {
+        let path = telemetry_path_for_video("/path/to/file.webm.mp4.mov");
         assert_eq!(path, "/path/to/file.cursor.json");
     }
 
     #[test]
-    fn test_telemetry_path_with_spaces() {
-        let path = telemetry_path_for_video("/path/to/my recording.mov");
-        assert_eq!(path, "/path/to/my recording.cursor.json");
-    }
+    fn test_cursor_telemetry_payload_structure() {
+        let payload = cursor_telemetry_payload(vec![CursorTelemetryPoint {
+            x: 12.5,
+            y: 24.0,
+            timestamp: 33.0,
+            cursor_type: Some("arrow".to_string()),
+            click_type: None,
+        }]);
 
-    #[test]
-    fn test_telemetry_path_empty_string() {
-        let path = telemetry_path_for_video("");
-        assert_eq!(path, ".cursor.json");
+        assert_eq!(
+            payload["samples"].as_array().map(|samples| samples.len()),
+            Some(1)
+        );
+        assert_eq!(payload["clicks"], serde_json::json!([]));
     }
 
     #[tokio::test]
     async fn test_get_cursor_telemetry_missing_file_returns_fallback() {
-        let result = get_cursor_telemetry("/nonexistent/path/video.mov".to_string()).await;
+        let result = get_cursor_telemetry("/nonexistent/path/video.mov".to_string());
         assert!(result.is_ok());
         let value = result.unwrap();
         assert_eq!(value["samples"], serde_json::json!([]));
@@ -159,8 +312,8 @@ mod tests {
         let telemetry_path = dir.join("open_recorder_test_cursor.cursor.json");
 
         let telemetry_data = serde_json::json!({
-            "samples": [{"x": 100, "y": 200, "t": 0}],
-            "clicks": [{"x": 100, "y": 200, "t": 0, "type": "left"}]
+            "samples": [{"x": 100, "y": 200, "timestamp": 0}],
+            "clicks": [{"x": 100, "y": 200, "timestamp": 0, "type": "left"}]
         });
         tokio::fs::write(
             &telemetry_path,
@@ -169,76 +322,13 @@ mod tests {
         .await
         .unwrap();
 
-        let result = get_cursor_telemetry(video_path.to_string_lossy().to_string()).await;
+        let result = get_cursor_telemetry(video_path.to_string_lossy().to_string());
         let _ = tokio::fs::remove_file(&telemetry_path).await;
 
         assert!(result.is_ok());
         let value = result.unwrap();
         assert!(value["samples"].is_array());
         assert_eq!(value["samples"].as_array().unwrap().len(), 1);
-    }
-
-    // ==================== Extension stripping edge cases ====================
-
-    #[test]
-    fn test_telemetry_path_reverse_order_mov_mp4() {
-        // .mov appears before .mp4 in the string — only .mp4 is stripped
-        let path = telemetry_path_for_video("/path/to/file.mov.mp4");
-        assert_eq!(path, "/path/to/file.mov.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_uppercase_extension_not_stripped() {
-        // trim_end_matches is case-sensitive
-        let path = telemetry_path_for_video("/path/to/recording.MOV");
-        assert_eq!(path, "/path/to/recording.MOV.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_uppercase_mp4_not_stripped() {
-        let path = telemetry_path_for_video("/path/to/recording.MP4");
-        assert_eq!(path, "/path/to/recording.MP4.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_double_mp4_extension() {
-        // trim_end_matches strips repeatedly for the same suffix
-        let path = telemetry_path_for_video("/path/to/file.mp4.mp4");
-        assert_eq!(path, "/path/to/file.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_all_three_extensions_chained() {
-        // .webm stripped first (innermost), then .mp4, then .mov
-        let path = telemetry_path_for_video("/path/to/file.webm.mp4.mov");
-        assert_eq!(path, "/path/to/file.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_dots_in_directory() {
-        // Dots in directory components should be unaffected
-        let path = telemetry_path_for_video("/path/to/my.project/recording.mov");
-        assert_eq!(path, "/path/to/my.project/recording.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_mixed_case_partial_match() {
-        let path = telemetry_path_for_video("/path/to/recording.Mov");
-        assert_eq!(path, "/path/to/recording.Mov.cursor.json");
-    }
-
-    #[test]
-    fn test_telemetry_path_webm_then_mov() {
-        // .mov stripped, then .webm is at end → stripped too
-        let path = telemetry_path_for_video("/path/to/file.mov.webm");
-        // Chain: trim .mov (doesn't end with .mov — ends with .webm) → no-op
-        //        trim .mp4 → no-op
-        //        trim .webm → strips .webm → "file.mov"
-        // Wait, the chain is: trim_end_matches(".mov").trim_end_matches(".mp4").trim_end_matches(".webm")
-        // "file.mov.webm" → trim ".mov" → "file.mov.webm" (ends with .webm, not .mov) → no change
-        //                  → trim ".mp4" → no change
-        //                  → trim ".webm" → "file.mov"
-        assert_eq!(path, "/path/to/file.mov.cursor.json");
     }
 
     #[tokio::test]
@@ -251,7 +341,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = get_cursor_telemetry(video_path.to_string_lossy().to_string()).await;
+        let result = get_cursor_telemetry(video_path.to_string_lossy().to_string());
         let _ = tokio::fs::remove_file(&telemetry_path).await;
 
         assert!(result.is_err());

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -112,6 +112,8 @@ pub fn run() {
             commands::recording::select_screen_area,
             // Cursor
             commands::cursor::get_cursor_telemetry,
+            commands::cursor::start_cursor_telemetry_capture,
+            commands::cursor::stop_cursor_telemetry_capture,
             commands::cursor::set_cursor_scale,
             commands::cursor::get_system_cursor_assets,
             // Permissions

--- a/apps/desktop/src-tauri/src/state/mod.rs
+++ b/apps/desktop/src-tauri/src/state/mod.rs
@@ -2,6 +2,8 @@ mod recording_state;
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use std::thread::JoinHandle;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -67,6 +69,12 @@ pub struct CursorTelemetryPoint {
     pub click_type: Option<String>,
 }
 
+pub struct CursorTelemetryCapture {
+    pub stop: Arc<AtomicBool>,
+    pub samples: Arc<Mutex<Vec<CursorTelemetryPoint>>>,
+    pub handle: Option<JoinHandle<()>>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShortcutConfig {
     pub start_stop_recording: Option<String>,
@@ -83,6 +91,7 @@ pub struct AppState {
     pub custom_recordings_dir: Option<String>,
     pub native_screen_recording_active: bool,
     pub cursor_telemetry: Vec<CursorTelemetryPoint>,
+    pub cursor_telemetry_capture: Option<CursorTelemetryCapture>,
     pub cached_system_cursor_assets: Option<serde_json::Value>,
     pub has_unsaved_changes: bool,
     pub unsaved_editor_windows: BTreeSet<String>,
@@ -102,6 +111,7 @@ impl Default for AppState {
             custom_recordings_dir: None,
             native_screen_recording_active: false,
             cursor_telemetry: Vec::new(),
+            cursor_telemetry_capture: None,
             cached_system_cursor_assets: None,
             has_unsaved_changes: false,
             unsaved_editor_windows: BTreeSet::new(),
@@ -164,6 +174,12 @@ mod tests {
     fn test_app_state_default_cursor_telemetry_is_empty() {
         let state = AppState::default();
         assert!(state.cursor_telemetry.is_empty());
+    }
+
+    #[test]
+    fn test_app_state_default_cursor_telemetry_capture_is_none() {
+        let state = AppState::default();
+        assert!(state.cursor_telemetry_capture.is_none());
     }
 
     #[test]

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -142,6 +142,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	const startTime = useRef<number>(0);
 	const nativeScreenRecording = useRef(false);
 	const wgcRecording = useRef(false);
+	const linuxCursorTelemetryCaptureActive = useRef(false);
 	const startInFlight = useRef(false);
 	const hasPromptedForReselect = useRef(false);
 	const selectedSourceName = useRef<string | undefined>(undefined);
@@ -239,6 +240,20 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		},
 		[resetStagedFileState],
 	);
+
+	const stopLinuxCursorTelemetryCapture = useCallback(async (videoPath?: string | null) => {
+		if (!linuxCursorTelemetryCaptureActive.current) {
+			return;
+		}
+
+		linuxCursorTelemetryCaptureActive.current = false;
+
+		try {
+			await backend.stopCursorTelemetryCapture(videoPath ?? null);
+		} catch (error) {
+			console.warn("Failed to persist Linux cursor telemetry:", error);
+		}
+	}, []);
 
 	const preparePermissions = useCallback(
 		async (options: { startup?: boolean } = {}) => {
@@ -649,6 +664,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			.onRecordingInterrupted(() => {
 				setRecording(false);
 				nativeScreenRecording.current = false;
+				void stopLinuxCursorTelemetryCapture(null);
 				cleanupCapturedMedia();
 				void backend.setRecordingState(false);
 			})
@@ -787,6 +803,16 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 
+			if (platform === "linux") {
+				try {
+					await backend.startCursorTelemetryCapture();
+					linuxCursorTelemetryCaptureActive.current = true;
+				} catch (error) {
+					linuxCursorTelemetryCaptureActive.current = false;
+					console.warn("Linux cursor telemetry capture is unavailable:", error);
+				}
+			}
+
 			const wantsAudioCapture = microphoneEnabled || systemAudioEnabled;
 
 			try {
@@ -910,7 +936,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
 						height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
 						frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-						cursor: "never",
+						cursor: linuxCursorTelemetryCaptureActive.current ? "never" : "always",
 					},
 					selfBrowserSurface: "exclude",
 					surfaceSwitching: "exclude",
@@ -1003,10 +1029,12 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					);
 					if (!storedPath) {
 						console.error("Failed to store video");
+						await stopLinuxCursorTelemetryCapture(null);
 						return;
 					}
 
 					await backend.setCurrentVideoPath(storedPath).catch(() => null);
+					await stopLinuxCursorTelemetryCapture(storedPath);
 					const facecamResult = pendingFacecamResult.current
 						? await pendingFacecamResult.current
 						: null;
@@ -1026,6 +1054,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					);
 				} catch (error) {
 					console.error("Error saving recording:", error);
+					await stopLinuxCursorTelemetryCapture(null);
 					if (recordingFilePath.current) {
 						await backend.deleteRecordingFile(recordingFilePath.current).catch(() => null);
 					}
@@ -1053,6 +1082,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			);
 			setRecording(false);
 			const facecamResultPromise = stopFacecamCapture();
+			await stopLinuxCursorTelemetryCapture(recordingFilePath.current);
 			cleanupCapturedMedia();
 			if (recordingFilePath.current) {
 				await backend.deleteRecordingFile(recordingFilePath.current).catch(() => null);

--- a/apps/desktop/src/lib/backend.ts
+++ b/apps/desktop/src/lib/backend.ts
@@ -157,6 +157,14 @@ export function stopNativeScreenRecording(): Promise<string> {
 	return invoke("stop_native_screen_recording");
 }
 
+export function startCursorTelemetryCapture(): Promise<void> {
+	return invoke("start_cursor_telemetry_capture");
+}
+
+export function stopCursorTelemetryCapture(videoPath?: string | null): Promise<void> {
+	return invoke("stop_cursor_telemetry_capture", { videoPath });
+}
+
 export function selectScreenArea(): Promise<{ x: number; y: number; width: number; height: number; displayId: number } | null> {
 	return invoke("select_screen_area");
 }


### PR DESCRIPTION
## Summary
- Added a Linux cursor telemetry sampler in the Tauri backend and writes `.cursor.json` sidecars alongside recordings.
- Wired Linux browser capture to hide the cursor only when telemetry capture is active, with an always-visible fallback if telemetry cannot start.
- Updated the README to match the new Linux behavior.

## Validation
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --lib`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml cursor -- --nocapture` (blocked by pre-existing unrelated Tauri test gating errors)
