### PR TITLE
Harden Linux cursor telemetry capture flow

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,12 +30,14 @@ dirs = "5"
 open = "5"
 percent-encoding = "2"
 tauri-plugin-clipboard-manager = "2.3.2"
-x11rb = "0.13"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block = "0.1"
 cocoa = "0.26"
 objc = "0.2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+x11rb = "0.13"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/apps/desktop/src-tauri/src/commands/cursor.rs
+++ b/apps/desktop/src-tauri/src/commands/cursor.rs
@@ -280,6 +280,12 @@ mod tests {
     }
 
     #[test]
+    fn test_telemetry_path_without_known_extension() {
+        let path = telemetry_path_for_video("/path/to/recording.avi");
+        assert_eq!(path, "/path/to/recording.avi.cursor.json");
+    }
+
+    #[test]
     fn test_cursor_telemetry_payload_structure() {
         let payload = cursor_telemetry_payload(vec![CursorTelemetryPoint {
             x: 12.5,
@@ -345,5 +351,37 @@ mod tests {
         let _ = tokio::fs::remove_file(&telemetry_path).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_write_cursor_telemetry_sidecar_persists_samples() {
+        let dir = std::env::temp_dir();
+        let video_path = dir.join("open_recorder_test_write_cursor.mov");
+        let telemetry_path = dir.join("open_recorder_test_write_cursor.cursor.json");
+
+        let samples = vec![CursorTelemetryPoint {
+            x: 320.0,
+            y: 200.0,
+            timestamp: 16.7,
+            cursor_type: Some("arrow".to_string()),
+            click_type: None,
+        }];
+
+        let result = write_cursor_telemetry_sidecar(
+            video_path.to_string_lossy().as_ref(),
+            &samples,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let written = tokio::fs::read_to_string(&telemetry_path).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(
+            payload["samples"].as_array().map(|entries| entries.len()),
+            Some(1)
+        );
+        assert_eq!(payload["clicks"], serde_json::json!([]));
+
+        let _ = tokio::fs::remove_file(&telemetry_path).await;
     }
 }

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -49,6 +49,7 @@ type ChromeDesktopVideoConstraints = {
 		maxHeight: number;
 		maxFrameRate: number;
 		minFrameRate: number;
+		cursor?: "always" | "motion" | "never";
 	};
 };
 
@@ -690,6 +691,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				cameraRecorder.current.stop();
 			}
 
+			void stopLinuxCursorTelemetryCapture(null);
 			cleanupCapturedMedia();
 			if (recordingFilePath.current) {
 				void backend.deleteRecordingFile(recordingFilePath.current).catch(() => null);
@@ -710,7 +712,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				facecamHasData,
 			);
 		};
-	}, [cleanupCapturedMedia, resetStagedFileState, stopRecording]);
+	}, [cleanupCapturedMedia, resetStagedFileState, stopLinuxCursorTelemetryCapture, stopRecording]);
 
 	const startRecording = async () => {
 		if (startInFlight.current) {
@@ -814,6 +816,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			}
 
 			const wantsAudioCapture = microphoneEnabled || systemAudioEnabled;
+			const shouldHideSourceCursor = linuxCursorTelemetryCaptureActive.current;
 
 			try {
 				await backend.hideCursor();
@@ -833,6 +836,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						maxHeight: TARGET_HEIGHT,
 						maxFrameRate: TARGET_FRAME_RATE,
 						minFrameRate: MIN_FRAME_RATE,
+						cursor: shouldHideSourceCursor ? "never" : "always",
 					},
 				};
 
@@ -936,7 +940,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
 						height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
 						frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-						cursor: linuxCursorTelemetryCaptureActive.current ? "never" : "always",
+						cursor: shouldHideSourceCursor ? "never" : "always",
 					},
 					selfBrowserSurface: "exclude",
 					surfaceSwitching: "exclude",


### PR DESCRIPTION
## Summary
- unify Linux browser-capture cursor suppression across both capture branches
- stop Linux cursor telemetry sampling during teardown to avoid leaked capture state
- add regression tests for cursor telemetry sidecar writing and unknown extensions

## Test plan
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --lib
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml cursor -- --nocapture *(fails due pre-existing tauri::test gating in unrelated modules)*
- pnpm exec vitest --run src/components/video-editor/cursorTelemetryPayload.test.ts src/lib/exporter/videoExporter.test.ts src/components/video-editor/VideoPlayback.test.ts
