### PR TITLE
Prepare release v0.0.21

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.20",
-  "releaseName": "Open Recorder v0.0.20",
+  "tagName": "v0.0.21",
+  "releaseName": "Open Recorder v0.0.21",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "open-recorder"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "block",
  "cocoa",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder"
-version = "0.0.20"
+version = "0.0.21"
 description = "A free, creator-focused screen recorder"
 authors = ["imbhargav5"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Open Recorder",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "identifier": "dev.openrecorder.app",
   "build": {
     "beforeDevCommand": "pnpm exec vite",


### PR DESCRIPTION
## Release Summary
- Release type: patch
- Base version: 0.0.20
- Next version: 0.0.21
- Tag: v0.0.21
- Release title: Open Recorder v0.0.21
- Mark as latest: true

Bumps the desktop app version to 0.0.21 across `apps/desktop/package.json`, `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/Cargo.lock`, `apps/desktop/src-tauri/tauri.conf.json`, and updates `.github/release-plan.json`.

Build verification:
- Frontend build (vite) passes cleanly
- All 119 tests across 20 test files pass
- Note: full `cargo tauri build` requires Rust native deps (webkit2gtk, etc.) not available in this environment; CI will validate the full Tauri build.

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.