### PR TITLE
feat: migrate I18nContext locale state to jotai atom

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -75,6 +75,7 @@
 		"fix-webm-duration": "^1.0.6",
 		"gif.js": "^0.2.0",
 		"gsap": "^3.13.0",
+		"jotai": "^2.19.1",
 		"lucide-react": "^0.545.0",
 		"mediabunny": "^1.25.1",
 		"motion": "^12.23.24",

--- a/apps/desktop/src/atoms/i18n.ts
+++ b/apps/desktop/src/atoms/i18n.ts
@@ -1,0 +1,30 @@
+import { atomWithStorage } from 'jotai/utils'
+import {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  type AppLocale,
+} from '@/i18n/config'
+
+const LOCALE_STORAGE_KEY = 'open-recorder.locale'
+
+function normalizeLocale(locale: string | null | undefined): AppLocale {
+  if (!locale) return DEFAULT_LOCALE
+  const normalized = locale.toLowerCase().split('-')[0]
+  return SUPPORTED_LOCALES.includes(normalized as AppLocale)
+    ? (normalized as AppLocale)
+    : DEFAULT_LOCALE
+}
+
+function getInitialLocale(): AppLocale {
+  if (typeof window === 'undefined') return DEFAULT_LOCALE
+  const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY)
+  if (stored && SUPPORTED_LOCALES.includes(stored as AppLocale)) {
+    return stored as AppLocale
+  }
+  return normalizeLocale(window.navigator.language)
+}
+
+export const localeAtom = atomWithStorage<AppLocale>(
+  LOCALE_STORAGE_KEY,
+  getInitialLocale(),
+)

--- a/apps/desktop/src/contexts/I18nContext.tsx
+++ b/apps/desktop/src/contexts/I18nContext.tsx
@@ -4,9 +4,9 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useState,
   type ReactNode,
 } from 'react'
+import { useAtom } from 'jotai'
 import {
   DEFAULT_LOCALE,
   I18N_NAMESPACES,
@@ -14,6 +14,7 @@ import {
   type AppLocale,
   type I18nNamespace,
 } from '@/i18n/config'
+import { localeAtom } from '@/atoms/i18n'
 import enCommon from '@/i18n/locales/en/common.json'
 import enDialogs from '@/i18n/locales/en/dialogs.json'
 import enEditor from '@/i18n/locales/en/editor.json'
@@ -28,8 +29,6 @@ import esLaunch from '@/i18n/locales/es/launch.json'
 import esSettings from '@/i18n/locales/es/settings.json'
 import esShortcuts from '@/i18n/locales/es/shortcuts.json'
 import esTimeline from '@/i18n/locales/es/timeline.json'
-
-const LOCALE_STORAGE_KEY = 'open-recorder.locale'
 
 type LocaleBundle = Record<I18nNamespace, Record<string, unknown>>
 
@@ -66,28 +65,6 @@ function isSupportedLocale(locale: string): locale is AppLocale {
   return SUPPORTED_LOCALES.includes(locale as AppLocale)
 }
 
-function normalizeLocale(locale: string | null | undefined): AppLocale {
-  if (!locale) {
-    return DEFAULT_LOCALE
-  }
-
-  const normalized = locale.toLowerCase().split('-')[0]
-  return isSupportedLocale(normalized) ? normalized : DEFAULT_LOCALE
-}
-
-function getInitialLocale(): AppLocale {
-  if (typeof window === 'undefined') {
-    return DEFAULT_LOCALE
-  }
-
-  const storedLocale = window.localStorage.getItem(LOCALE_STORAGE_KEY)
-  if (storedLocale && isSupportedLocale(storedLocale)) {
-    return storedLocale
-  }
-
-  return normalizeLocale(window.navigator.language)
-}
-
 function getMessageValue(source: unknown, key: string): string | undefined {
   const parts = key.split('.')
   let current: unknown = source
@@ -96,7 +73,6 @@ function getMessageValue(source: unknown, key: string): string | undefined {
     if (!current || typeof current !== 'object' || !(part in current)) {
       return undefined
     }
-
     current = (current as Record<string, unknown>)[part]
   }
 
@@ -137,28 +113,23 @@ function translateForLocale(
 }
 
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<AppLocale>(getInitialLocale)
-
-  const setLocale = useCallback((nextLocale: AppLocale) => {
-    setLocaleState(nextLocale)
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(LOCALE_STORAGE_KEY, nextLocale)
-    }
-  }, [])
+  const [locale, setLocale] = useAtom(localeAtom)
 
   useEffect(() => {
     document.documentElement.lang = locale
   }, [locale])
 
-  const t = useCallback((key: string, fallback?: string, vars?: Record<string, string | number>) => {
-    return translateForLocale(locale, key, fallback, vars)
-  }, [locale])
+  const t = useCallback(
+    (key: string, fallback?: string, vars?: Record<string, string | number>) => {
+      return translateForLocale(locale, key, fallback, vars)
+    },
+    [locale],
+  )
 
-  const value = useMemo<I18nContextValue>(() => ({
-    locale,
-    setLocale,
-    t,
-  }), [locale, setLocale, t])
+  const value = useMemo<I18nContextValue>(
+    () => ({ locale, setLocale, t }),
+    [locale, setLocale, t],
+  )
 
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
 }
@@ -173,7 +144,10 @@ export function useI18n() {
 
 export function useScopedT(namespace: I18nNamespace) {
   const { t } = useI18n()
-  return useCallback((key: string, fallback?: string, vars?: Record<string, string | number>) => {
-    return t(`${namespace}.${key}`, fallback, vars)
-  }, [namespace, t])
+  return useCallback(
+    (key: string, fallback?: string, vars?: Record<string, string | number>) => {
+      return t(`${namespace}.${key}`, fallback, vars)
+    },
+    [namespace, t],
+  )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       gsap:
         specifier: ^3.13.0
         version: 3.14.2
+      jotai:
+        specifier: ^2.19.1
+        version: 2.19.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
       lucide-react:
         specifier: ^0.545.0
         version: 0.545.0(react@18.3.1)
@@ -1891,6 +1894,24 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  jotai@2.19.1:
+    resolution: {integrity: sha512-sqm9lVZiqBHZH8aSRk32DSiZDHY3yUIlulXYn9GQj7/LvoUdYXSMti7ZPJGo+6zjzKFt5a25k/I6iBCi43PJcw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-binary-schema-parser@2.0.3:
     resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
@@ -4100,6 +4121,13 @@ snapshots:
   ismobilejs@1.1.1: {}
 
   jiti@1.21.7: {}
+
+  jotai@2.19.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@babel/template': 7.28.6
+      '@types/react': 18.3.28
+      react: 18.3.1
 
   js-binary-schema-parser@2.0.3: {}
 


### PR DESCRIPTION
## Summary
- Install jotai package
- Create `src/atoms/i18n.ts` with `localeAtom` using `atomWithStorage` for automatic localStorage persistence
- Refactor `I18nContext.tsx` to use `useAtom(localeAtom)` instead of `useState`

## Test plan
- [ ] Build passes (`vite build`)
- [ ] Locale switching still works
- [ ] Locale is persisted across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)