### PR TITLE
feat: migrate ShortcutsContext state to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/shortcuts.ts
+++ b/apps/desktop/src/atoms/shortcuts.ts
@@ -1,0 +1,6 @@
+import { atom } from 'jotai'
+import { DEFAULT_SHORTCUTS, type ShortcutsConfig } from '@/lib/shortcuts'
+
+export const shortcutsAtom = atom<ShortcutsConfig>(DEFAULT_SHORTCUTS)
+export const isMacAtom = atom<boolean>(false)
+export const isShortcutsConfigOpenAtom = atom<boolean>(false)

--- a/apps/desktop/src/contexts/ShortcutsContext.tsx
+++ b/apps/desktop/src/contexts/ShortcutsContext.tsx
@@ -1,62 +1,59 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { DEFAULT_SHORTCUTS, mergeWithDefaults, type ShortcutsConfig } from '@/lib/shortcuts';
-import { isMac as getIsMac } from '@/utils/platformUtils';
-import { getShortcuts as backendGetShortcuts, saveShortcuts as backendSaveShortcuts } from '@/lib/backend';
+import { useAtom } from 'jotai'
+import { createContext, useCallback, useContext, useEffect, useMemo, type ReactNode } from 'react'
+import { DEFAULT_SHORTCUTS, mergeWithDefaults, type ShortcutsConfig } from '@/lib/shortcuts'
+import { isMac as getIsMac } from '@/utils/platformUtils'
+import { getShortcuts as backendGetShortcuts, saveShortcuts as backendSaveShortcuts } from '@/lib/backend'
+import { isMacAtom, isShortcutsConfigOpenAtom, shortcutsAtom } from '@/atoms/shortcuts'
 
 interface ShortcutsContextValue {
-  shortcuts: ShortcutsConfig;
-  isMac: boolean;
-  setShortcuts: (config: ShortcutsConfig) => void;
-  persistShortcuts: (config?: ShortcutsConfig) => Promise<void>;
-  isConfigOpen: boolean;
-  openConfig: () => void;
-  closeConfig: () => void;
+  shortcuts: ShortcutsConfig
+  isMac: boolean
+  setShortcuts: (config: ShortcutsConfig) => void
+  persistShortcuts: (config?: ShortcutsConfig) => Promise<void>
+  isConfigOpen: boolean
+  openConfig: () => void
+  closeConfig: () => void
 }
 
-const ShortcutsContext = createContext<ShortcutsContextValue | null>(null);
+const ShortcutsContext = createContext<ShortcutsContextValue | null>(null)
 
 export function useShortcuts(): ShortcutsContextValue {
-  const ctx = useContext(ShortcutsContext);
-  if (!ctx) throw new Error('useShortcuts must be used within <ShortcutsProvider>');
-  return ctx;
+  const ctx = useContext(ShortcutsContext)
+  if (!ctx) throw new Error('useShortcuts must be used within <ShortcutsProvider>')
+  return ctx
 }
 
 export function ShortcutsProvider({ children }: { children: ReactNode }) {
-  const [shortcuts, setShortcuts] = useState<ShortcutsConfig>(DEFAULT_SHORTCUTS);
-  const [isMac, setIsMac] = useState(false);
-  const [isConfigOpen, setIsConfigOpen] = useState(false);
+  const [shortcuts, setShortcuts] = useAtom(shortcutsAtom)
+  const [isMac, setIsMac] = useAtom(isMacAtom)
+  const [isConfigOpen, setIsConfigOpen] = useAtom(isShortcutsConfigOpenAtom)
 
   useEffect(() => {
-    getIsMac().then(setIsMac).catch(() => {});
+    getIsMac().then(setIsMac).catch(() => {})
 
     backendGetShortcuts()
       .then((saved) => {
         if (saved) {
-          setShortcuts(mergeWithDefaults(saved as Partial<ShortcutsConfig>));
+          setShortcuts(mergeWithDefaults(saved as Partial<ShortcutsConfig>))
         }
       })
-      .catch(() => {});
-  }, []);
+      .catch(() => {})
+  }, [setIsMac, setShortcuts])
 
   const persistShortcuts = useCallback(
     async (config?: ShortcutsConfig) => {
-      await backendSaveShortcuts(config ?? shortcuts);
+      await backendSaveShortcuts(config ?? shortcuts)
     },
     [shortcuts],
-  );
+  )
 
-  const openConfig = useCallback(() => setIsConfigOpen(true), []);
-  const closeConfig = useCallback(() => setIsConfigOpen(false), []);
+  const openConfig = useCallback(() => setIsConfigOpen(true), [setIsConfigOpen])
+  const closeConfig = useCallback(() => setIsConfigOpen(false), [setIsConfigOpen])
 
   const value = useMemo<ShortcutsContextValue>(
     () => ({ shortcuts, isMac, setShortcuts, persistShortcuts, isConfigOpen, openConfig, closeConfig }),
-    [shortcuts, isMac, persistShortcuts, isConfigOpen, openConfig, closeConfig],
-  );
+    [shortcuts, isMac, setShortcuts, persistShortcuts, isConfigOpen, openConfig, closeConfig],
+  )
 
-  return (
-    <ShortcutsContext.Provider value={value}>
-      {children}
-    </ShortcutsContext.Provider>
-  );
+  return <ShortcutsContext.Provider value={value}>{children}</ShortcutsContext.Provider>
 }
-


### PR DESCRIPTION
## Summary
- Create `src/atoms/shortcuts.ts` with `shortcutsAtom`, `isMacAtom`, `isShortcutsConfigOpenAtom`
- Refactor `ShortcutsContext.tsx` to use `useAtom` instead of `useState` for all three state values
- Provider is kept for initialization side effects (loading shortcuts from backend, detecting platform)

## Test plan
- [ ] Build passes
- [ ] Shortcuts config dialog opens/closes correctly
- [ ] Saved shortcuts are loaded on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)