### PR TITLE
feat: migrate SettingsPanel state to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/settingsPanel.ts
+++ b/apps/desktop/src/atoms/settingsPanel.ts
@@ -1,0 +1,14 @@
+import { atom } from 'jotai'
+
+export type SettingsSidebarTab = 'appearance' | 'cursor' | 'camera' | 'background' | 'audio'
+export type BackgroundTab = 'image' | 'color' | 'gradient'
+
+const DEFAULT_GRADIENT =
+  'linear-gradient( 111.6deg,  rgba(114,167,232,1) 9.4%, rgba(253,129,82,1) 43.9%, rgba(253,129,82,1) 54.8%, rgba(249,202,86,1) 86.3% )'
+
+export const settingsActiveTabAtom = atom<SettingsSidebarTab>('appearance')
+export const settingsBackgroundTabAtom = atom<BackgroundTab>('image')
+export const settingsCustomImagesAtom = atom<string[]>([])
+export const settingsSelectedColorAtom = atom<string>('#ADADAD')
+export const settingsGradientAtom = atom<string>(DEFAULT_GRADIENT)
+export const settingsShowCropModalAtom = atom<boolean>(false)

--- a/apps/desktop/src/components/video-editor/SettingsPanel.tsx
+++ b/apps/desktop/src/components/video-editor/SettingsPanel.tsx
@@ -13,7 +13,17 @@ import {
 	Volume2,
 	X,
 } from "lucide-react";
-import { memo, type ReactNode, useMemo, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import { memo, type ReactNode, useMemo, useRef } from "react";
+import {
+	settingsActiveTabAtom,
+	settingsBackgroundTabAtom,
+	settingsCustomImagesAtom,
+	settingsGradientAtom,
+	settingsSelectedColorAtom,
+	settingsShowCropModalAtom,
+	type SettingsSidebarTab,
+} from "@/atoms/settingsPanel";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
@@ -87,7 +97,6 @@ const COLOR_PALETTE = [
 	"#795548",
 ];
 
-type SettingsSidebarTab = "appearance" | "cursor" | "camera" | "background" | "audio";
 
 type SettingsTabDefinition = {
 	id: SettingsSidebarTab;
@@ -310,13 +319,13 @@ function SettingsPanelInner({
 	onSpeedChange,
 	onSpeedDelete,
 }: SettingsPanelProps) {
-	const [activeTab, setActiveTab] = useState<SettingsSidebarTab>("appearance");
-	const [backgroundTab, setBackgroundTab] = useState<"image" | "color" | "gradient">("image");
-	const [customImages, setCustomImages] = useState<string[]>([]);
+	const [activeTab, setActiveTab] = useAtom(settingsActiveTabAtom);
+	const [backgroundTab, setBackgroundTab] = useAtom(settingsBackgroundTabAtom);
+	const [customImages, setCustomImages] = useAtom(settingsCustomImagesAtom);
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const [selectedColor, setSelectedColor] = useState("#ADADAD");
-	const [gradient, setGradient] = useState<string>(GRADIENTS[0]);
-	const [showCropModal, setShowCropModal] = useState(false);
+	const [selectedColor, setSelectedColor] = useAtom(settingsSelectedColorAtom);
+	const [gradient, setGradient] = useAtom(settingsGradientAtom);
+	const [showCropModal, setShowCropModal] = useAtom(settingsShowCropModalAtom);
 	const cropSnapshotRef = useRef<CropRegion | null>(null);
 	const activeTabDefinition = useMemo(
 		() => SETTINGS_SIDEBAR_TABS.find((tab) => tab.id === activeTab) ?? SETTINGS_SIDEBAR_TABS[0],


### PR DESCRIPTION
## Summary
- Create `src/atoms/settingsPanel.ts` with 6 atoms + `SettingsSidebarTab` type
- Replace all `useState` calls in `SettingsPanel.tsx` with `useAtom`

## Test plan
- [ ] Build passes
- [ ] Settings tab switching works
- [ ] Background type/color/gradient selection works
- [ ] Crop modal opens/closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)