### PR TITLE
feat: migrate ImageEditor state to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/imageEditor.ts
+++ b/apps/desktop/src/atoms/imageEditor.ts
@@ -1,0 +1,19 @@
+import { atom } from 'jotai'
+import { DEFAULT_WALLPAPER_PATH } from '@/lib/wallpapers'
+
+export type ImageBackgroundType = 'wallpaper' | 'gradient' | 'color' | 'transparent'
+
+const DEFAULT_IMAGE_GRADIENT = 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
+
+export const imageSrcAtom = atom<string | null>(null)
+export const imageNaturalWidthAtom = atom<number>(0)
+export const imageNaturalHeightAtom = atom<number>(0)
+export const imageBackgroundTypeAtom = atom<ImageBackgroundType>('wallpaper')
+export const imageWallpaperAtom = atom<string>(DEFAULT_WALLPAPER_PATH)
+export const imageGradientAtom = atom<string>(DEFAULT_IMAGE_GRADIENT)
+export const imageSolidColorAtom = atom<string>('#2563EB')
+export const imagePaddingAtom = atom<number>(48)
+export const imageBorderRadiusAtom = atom<number>(12)
+export const imageShadowIntensityAtom = atom<number>(0.6)
+export const imageWallpaperPreviewPathsAtom = atom<string[]>([])
+export const imageExportingAtom = atom<boolean>(false)

--- a/apps/desktop/src/components/image-editor/ImageEditor.tsx
+++ b/apps/desktop/src/components/image-editor/ImageEditor.tsx
@@ -1,6 +1,22 @@
 import Block from "@uiw/react-color-block";
 import { ArrowLeft, Check, ClipboardCopy, Download, Palette } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
+import {
+	imageBackgroundTypeAtom,
+	imageBorderRadiusAtom,
+	imageExportingAtom,
+	imageGradientAtom,
+	imageNaturalHeightAtom,
+	imageNaturalWidthAtom,
+	imagePaddingAtom,
+	imageShadowIntensityAtom,
+	imageSolidColorAtom,
+	imageSrcAtom,
+	imageWallpaperAtom,
+	imageWallpaperPreviewPathsAtom,
+	type ImageBackgroundType,
+} from "@/atoms/imageEditor";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
@@ -55,30 +71,28 @@ const COLOR_PALETTE = [
 	"#795548",
 ];
 
-type BackgroundType = "wallpaper" | "gradient" | "color" | "transparent";
-
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function ImageEditor() {
 	// Image state
-	const [imageSrc, setImageSrc] = useState<string | null>(null);
-	const [imageNaturalWidth, setImageNaturalWidth] = useState(0);
-	const [imageNaturalHeight, setImageNaturalHeight] = useState(0);
+	const [imageSrc, setImageSrc] = useAtom(imageSrcAtom);
+	const [imageNaturalWidth, setImageNaturalWidth] = useAtom(imageNaturalWidthAtom);
+	const [imageNaturalHeight, setImageNaturalHeight] = useAtom(imageNaturalHeightAtom);
 
 	// Settings
-	const [backgroundType, setBackgroundType] = useState<BackgroundType>("wallpaper");
-	const [wallpaper, setWallpaper] = useState(WALLPAPER_PATHS[0]);
-	const [gradient, setGradient] = useState(GRADIENTS[0]);
-	const [solidColor, setSolidColor] = useState("#2563EB");
-	const [padding, setPadding] = useState(48);
-	const [borderRadius, setBorderRadius] = useState(12);
-	const [shadowIntensity, setShadowIntensity] = useState(0.6);
+	const [backgroundType, setBackgroundType] = useAtom(imageBackgroundTypeAtom);
+	const [wallpaper, setWallpaper] = useAtom(imageWallpaperAtom);
+	const [gradient, setGradient] = useAtom(imageGradientAtom);
+	const [solidColor, setSolidColor] = useAtom(imageSolidColorAtom);
+	const [padding, setPadding] = useAtom(imagePaddingAtom);
+	const [borderRadius, setBorderRadius] = useAtom(imageBorderRadiusAtom);
+	const [shadowIntensity, setShadowIntensity] = useAtom(imageShadowIntensityAtom);
 
 	// Wallpaper previews
-	const [wallpaperPreviewPaths, setWallpaperPreviewPaths] = useState<string[]>([]);
+	const [wallpaperPreviewPaths, setWallpaperPreviewPaths] = useAtom(imageWallpaperPreviewPathsAtom);
 
 	// Export state
-	const [exporting, setExporting] = useState(false);
+	const [exporting, setExporting] = useAtom(imageExportingAtom);
 
 	const imageRef = useRef<HTMLImageElement | null>(null);
 
@@ -445,7 +459,7 @@ export default function ImageEditor() {
 						</div>
 						<Tabs
 							value={backgroundType}
-							onValueChange={(v) => setBackgroundType(v as BackgroundType)}
+							onValueChange={(v) => setBackgroundType(v as ImageBackgroundType)}
 						>
 							<TabsList className="grid grid-cols-4 bg-white/5 rounded-lg mb-3 h-7">
 								<TabsTrigger


### PR DESCRIPTION
## Summary
- Create `src/atoms/imageEditor.ts` with 11 atoms + `ImageBackgroundType` type
- Replace all `useState` calls in `ImageEditor.tsx` with `useAtom`

## Test plan
- [ ] Build passes
- [ ] Image loads correctly from backend
- [ ] Background type switching (wallpaper/gradient/color/transparent) works
- [ ] Export functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)