### PR TITLE
feat: migrate TimelineEditor state to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/timeline.ts
+++ b/apps/desktop/src/atoms/timeline.ts
@@ -1,0 +1,12 @@
+import { atom } from 'jotai'
+import type { Range } from 'dnd-timeline'
+
+export const timelineRangeAtom = atom<Range>({ start: 0, end: 0 })
+export const timelineKeyframesAtom = atom<{ id: string; time: number }[]>([])
+export const timelineSelectedKeyframeIdAtom = atom<string | null>(null)
+export const timelineCustomAspectWidthAtom = atom<string>('16')
+export const timelineCustomAspectHeightAtom = atom<string>('9')
+export const timelineScrollLabelsAtom = atom<{ pan: string; zoom: string }>({
+  pan: 'Shift + Ctrl + Scroll',
+  zoom: 'Ctrl + Scroll',
+})

--- a/apps/desktop/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/apps/desktop/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1,4 +1,13 @@
+import { useAtom } from "jotai";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type WheelEvent } from "react";
+import {
+  timelineCustomAspectHeightAtom,
+  timelineCustomAspectWidthAtom,
+  timelineKeyframesAtom,
+  timelineRangeAtom,
+  timelineScrollLabelsAtom,
+  timelineSelectedKeyframeIdAtom,
+} from "@/atoms/timeline";
 import { useTimelineContext } from "dnd-timeline";
 import { Button } from "@/components/ui/button";
 import { type TimeStore, useTimeValue } from "../useTimeStore";
@@ -630,15 +639,12 @@ function TimelineEditorInner({
     [timelineScale.minItemDurationMs, totalMs],
   );
 
-  const [range, setRange] = useState<Range>(() => createInitialRange(totalMs));
-  const [keyframes, setKeyframes] = useState<{ id: string; time: number }[]>([]);
-  const [selectedKeyframeId, setSelectedKeyframeId] = useState<string | null>(null);
-  const [customAspectWidth, setCustomAspectWidth] = useState('16');
-  const [customAspectHeight, setCustomAspectHeight] = useState('9');
-  const [scrollLabels, setScrollLabels] = useState({
-    pan: 'Shift + Ctrl + Scroll',
-    zoom: 'Ctrl + Scroll'
-  });
+  const [range, setRange] = useAtom(timelineRangeAtom);
+  const [keyframes, setKeyframes] = useAtom(timelineKeyframesAtom);
+  const [selectedKeyframeId, setSelectedKeyframeId] = useAtom(timelineSelectedKeyframeIdAtom);
+  const [customAspectWidth, setCustomAspectWidth] = useAtom(timelineCustomAspectWidthAtom);
+  const [customAspectHeight, setCustomAspectHeight] = useAtom(timelineCustomAspectHeightAtom);
+  const [scrollLabels, setScrollLabels] = useAtom(timelineScrollLabelsAtom);
   const timelineContainerRef = useRef<HTMLDivElement>(null);
   const { shortcuts: keyShortcuts, isMac } = useShortcuts();
 


### PR DESCRIPTION
## Summary
- Create `src/atoms/timeline.ts` with 6 atoms for timeline state
- Replace 6 `useState` calls in main `TimelineEditor` component with `useAtom`
- Local `isDragging` in `PlaybackCursor` sub-component stays as `useState` (trivial drag tracking)

## Test plan
- [ ] Build passes
- [ ] Timeline range/zoom updates correctly when video loads
- [ ] Keyframe markers can be added/selected/deleted
- [ ] Custom aspect ratio input works

🤖 Generated with [Claude Code](https://claude.com/claude-code)