### PR TITLE
chore: patch release v0.0.22

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "open-recorder"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "block",
  "cocoa",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder"
-version = "0.0.21"
+version = "0.0.22"
 description = "A free, creator-focused screen recorder"
 authors = ["imbhargav5"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Open Recorder",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "identifier": "dev.openrecorder.app",
   "build": {
     "beforeDevCommand": "pnpm exec vite",


### PR DESCRIPTION
## Summary

- Bumps version from `0.0.21` to `0.0.22` across all version files (package.json, tauri.conf.json, Cargo.toml, Cargo.lock)
- All tests pass (20 test files, 119 tests)

## Test plan

- [x] Verified `pnpm run test` passes (119 tests across 20 files)
- [x] Version bumped consistently in `apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`, `apps/desktop/src-tauri/Cargo.toml`, and `apps/desktop/src-tauri/Cargo.lock`

https://claude.ai/code/session_01TdVVieUKkZootMWSDdoja7