### PR TITLE
feat: migrate useScreenRecorder useState to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/app.ts
+++ b/apps/desktop/src/atoms/app.ts
@@ -2,3 +2,4 @@ import { atom } from 'jotai'
 
 export const windowTypeAtom = atom<string>('')
 export const appNameAtom = atom<string>('Open Recorder')
+export const isMacOSAtom = atom<boolean>(false)

--- a/apps/desktop/src/atoms/recording.ts
+++ b/apps/desktop/src/atoms/recording.ts
@@ -1,0 +1,15 @@
+import { atom } from 'jotai'
+
+// --- Active recording state ---
+export const recordingActiveAtom = atom<boolean>(false)
+
+// --- Microphone configuration ---
+export const microphoneEnabledAtom = atom<boolean>(false)
+export const microphoneDeviceIdAtom = atom<string | undefined>(undefined)
+
+// --- System audio configuration ---
+export const systemAudioEnabledAtom = atom<boolean>(false)
+
+// --- Camera / facecam configuration ---
+export const cameraEnabledAtom = atom<boolean>(false)
+export const cameraDeviceIdAtom = atom<string | undefined>(undefined)

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -1,9 +1,19 @@
 import { fixParsedWebmDuration } from "@fix-webm-duration/fix";
 import { WebmFile } from "@fix-webm-duration/parser";
+import { useAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { buildEditorWindowQuery } from "@/components/video-editor/editorWindowParams";
 import * as backend from "@/lib/backend";
 import { createDefaultFacecamSettings, type RecordingSession } from "@/lib/recordingSession";
+import { isMacOSAtom } from "@/atoms/app";
+import {
+	cameraDeviceIdAtom,
+	cameraEnabledAtom,
+	microphoneDeviceIdAtom,
+	microphoneEnabledAtom,
+	recordingActiveAtom,
+	systemAudioEnabledAtom,
+} from "@/atoms/recording";
 
 const TARGET_FRAME_RATE = 60;
 const TARGET_WIDTH = 3840;
@@ -122,14 +132,14 @@ function getSelectedSourceName(source: unknown) {
 }
 
 export function useScreenRecorder(): UseScreenRecorderReturn {
-	const [recording, setRecording] = useState(false);
-	const [starting, setStarting] = useState(false);
-	const [isMacOS, setIsMacOS] = useState(false);
-	const [microphoneEnabled, setMicrophoneEnabled] = useState(false);
-	const [microphoneDeviceId, setMicrophoneDeviceId] = useState<string | undefined>(undefined);
-	const [systemAudioEnabled, setSystemAudioEnabled] = useState(false);
-	const [cameraEnabled, setCameraEnabled] = useState(false);
-	const [cameraDeviceId, setCameraDeviceId] = useState<string | undefined>(undefined);
+	const [recording, setRecording] = useAtom(recordingActiveAtom);
+	const [starting, setStarting] = useState(false); // internal guard – not shared
+	const [isMacOS, setIsMacOS] = useAtom(isMacOSAtom);
+	const [microphoneEnabled, setMicrophoneEnabled] = useAtom(microphoneEnabledAtom);
+	const [microphoneDeviceId, setMicrophoneDeviceId] = useAtom(microphoneDeviceIdAtom);
+	const [systemAudioEnabled, setSystemAudioEnabled] = useAtom(systemAudioEnabledAtom);
+	const [cameraEnabled, setCameraEnabled] = useAtom(cameraEnabledAtom);
+	const [cameraDeviceId, setCameraDeviceId] = useAtom(cameraDeviceIdAtom);
 	const mediaRecorder = useRef<MediaRecorder | null>(null);
 	const stream = useRef<MediaStream | null>(null);
 	const screenStream = useRef<MediaStream | null>(null);


### PR DESCRIPTION
## Summary

- Adds `atoms/recording.ts` with 6 new atoms: `recordingActiveAtom`, `microphoneEnabledAtom`, `microphoneDeviceIdAtom`, `systemAudioEnabledAtom`, `cameraEnabledAtom`, `cameraDeviceIdAtom`
- Adds `isMacOSAtom` to `atoms/app.ts` (shared platform detection)
- Updates `useScreenRecorder.ts` to use `useAtom` for all shared state; keeps `starting` as local `useState` (internal guard flag)
- Hook public interface is **unchanged** — existing call sites work without modification

## What stays as useState

- `starting` — purely internal double-start guard, never returned or read by other components

## Test plan

- [x] `npx tsc --noEmit` passes (no type errors)
- [ ] Smoke-test recording start/stop in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)