### PR TITLE
feat: migrate useAppUpdater useState to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/updater.ts
+++ b/apps/desktop/src/atoms/updater.ts
@@ -1,0 +1,17 @@
+import { atom } from 'jotai'
+
+export type UpdateStatus =
+	| "idle"
+	| "checking"
+	| "up-to-date"
+	| "available"
+	| "downloading"
+	| "ready"
+	| "error";
+
+export const updaterStatusAtom = atom<UpdateStatus>("idle")
+export const updaterDialogOpenAtom = atom<boolean>(false)
+export const updaterVersionAtom = atom<string | null>(null)
+export const updaterReleaseNotesAtom = atom<string | null>(null)
+export const updaterDownloadProgressAtom = atom<number>(0)
+export const updaterErrorAtom = atom<string | null>(null)

--- a/apps/desktop/src/hooks/useAppUpdater.ts
+++ b/apps/desktop/src/hooks/useAppUpdater.ts
@@ -1,19 +1,21 @@
 import { getIdentifier } from "@tauri-apps/api/app";
+import { useAtom } from "jotai";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as backend from "@/lib/backend";
+import {
+	type UpdateStatus,
+	updaterDialogOpenAtom,
+	updaterDownloadProgressAtom,
+	updaterErrorAtom,
+	updaterReleaseNotesAtom,
+	updaterStatusAtom,
+	updaterVersionAtom,
+} from "@/atoms/updater";
+export type { UpdateStatus } from "@/atoms/updater";
 
 const AUTO_CHECK_DELAY_MS = 10_000;
-
-export type UpdateStatus =
-	| "idle"
-	| "checking"
-	| "up-to-date"
-	| "available"
-	| "downloading"
-	| "ready"
-	| "error";
 
 type CheckForUpdateOptions = {
 	showDialog?: boolean;
@@ -71,13 +73,13 @@ function getErrorMessage(error: unknown, fallback: string): string {
 export function useAppUpdater({
 	enableAutoCheck = true,
 }: UseAppUpdaterOptions = {}): UseAppUpdaterReturn {
-	const [updatesEnabled, setUpdatesEnabled] = useState(!import.meta.env.DEV);
-	const [status, setStatus] = useState<UpdateStatus>("idle");
-	const [isDialogOpen, setIsDialogOpen] = useState(false);
-	const [version, setVersion] = useState<string | null>(null);
-	const [releaseNotes, setReleaseNotes] = useState<string | null>(null);
-	const [downloadProgress, setDownloadProgress] = useState(0);
-	const [error, setError] = useState<string | null>(null);
+	const [updatesEnabled, setUpdatesEnabled] = useState(!import.meta.env.DEV); // internal only
+	const [status, setStatus] = useAtom(updaterStatusAtom);
+	const [isDialogOpen, setIsDialogOpen] = useAtom(updaterDialogOpenAtom);
+	const [version, setVersion] = useAtom(updaterVersionAtom);
+	const [releaseNotes, setReleaseNotes] = useAtom(updaterReleaseNotesAtom);
+	const [downloadProgress, setDownloadProgress] = useAtom(updaterDownloadProgressAtom);
+	const [error, setError] = useAtom(updaterErrorAtom);
 	const updateRef = useRef<Update | null>(null);
 
 	const checkForUpdate = useCallback(


### PR DESCRIPTION
## Summary

- Creates `atoms/updater.ts` with 6 atoms: `updaterStatusAtom`, `updaterDialogOpenAtom`, `updaterVersionAtom`, `updaterReleaseNotesAtom`, `updaterDownloadProgressAtom`, `updaterErrorAtom`
- Relocates `UpdateStatus` type from the hook to `atoms/updater.ts`; re-exports it from the hook for backward compat
- Updates `useAppUpdater.ts` to use `useAtom` for all shared state

## What stays as useState

- `updatesEnabled` — internal one-time flag set from app identifier, never consumed outside the hook

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Verify update dialog still appears and progress updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)