### PR TITLE
feat: migrate usePermissions useState to jotai atoms

### DIFF
--- a/apps/desktop/src/atoms/permissions.ts
+++ b/apps/desktop/src/atoms/permissions.ts
@@ -1,0 +1,26 @@
+import { atom } from 'jotai'
+
+export type PermissionStatus =
+	| "granted"
+	| "denied"
+	| "not_determined"
+	| "restricted"
+	| "unknown"
+	| "checking";
+
+export interface PermissionState {
+	screenRecording: PermissionStatus;
+	microphone: PermissionStatus;
+	camera: PermissionStatus;
+	accessibility: PermissionStatus;
+}
+
+const INITIAL_PERMISSIONS: PermissionState = {
+	screenRecording: "checking",
+	microphone: "checking",
+	camera: "checking",
+	accessibility: "checking",
+};
+
+export const permissionsAtom = atom<PermissionState>(INITIAL_PERMISSIONS)
+export const isCheckingPermissionsAtom = atom<boolean>(true)

--- a/apps/desktop/src/hooks/usePermissions.ts
+++ b/apps/desktop/src/hooks/usePermissions.ts
@@ -7,17 +7,18 @@
  * transparently via getUserMedia / getDisplayMedia prompts).
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
 import * as backend from "@/lib/backend";
+import { isMacOSAtom } from "@/atoms/app";
+import {
+	type PermissionState,
+	type PermissionStatus,
+	isCheckingPermissionsAtom,
+	permissionsAtom,
+} from "@/atoms/permissions";
 
-export type PermissionStatus = "granted" | "denied" | "not_determined" | "restricted" | "unknown" | "checking";
-
-export interface PermissionState {
-	screenRecording: PermissionStatus;
-	microphone: PermissionStatus;
-	camera: PermissionStatus;
-	accessibility: PermissionStatus;
-}
+export type { PermissionState, PermissionStatus } from "@/atoms/permissions";
 
 export interface UsePermissionsResult {
 	permissions: PermissionState;
@@ -39,17 +40,10 @@ export interface UsePermissionsResult {
 	allPermissionsGranted: boolean;
 }
 
-const INITIAL_STATE: PermissionState = {
-	screenRecording: "checking",
-	microphone: "checking",
-	camera: "checking",
-	accessibility: "checking",
-};
-
 export function usePermissions(): UsePermissionsResult {
-	const [permissions, setPermissions] = useState<PermissionState>(INITIAL_STATE);
-	const [isMacOS, setIsMacOS] = useState(false);
-	const [isChecking, setIsChecking] = useState(true);
+	const [permissions, setPermissions] = useAtom(permissionsAtom);
+	const [isMacOS, setIsMacOS] = useAtom(isMacOSAtom);
+	const [isChecking, setIsChecking] = useAtom(isCheckingPermissionsAtom);
 	const mountedRef = useRef(true);
 
 	const refreshPermissions = useCallback(async (): Promise<PermissionState> => {


### PR DESCRIPTION
## Summary

- Creates `atoms/permissions.ts` with `permissionsAtom` (initial state = all "checking") and `isCheckingPermissionsAtom`
- Relocates `PermissionState` and `PermissionStatus` types to the atoms file; re-exports from the hook for backward compat
- Updates `usePermissions.ts` to use `useAtom` for all three state values
- `isMacOSAtom` from `atoms/app.ts` is now **shared** between `usePermissions` and `useScreenRecorder` — platform is detected once

## What stays (no useState in this hook anymore)

All three state values are now atoms. The `mountedRef` ref is kept for guarding state updates across async calls.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Verify permission onboarding flow works correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)