### PR TITLE
chore: fix biome lint warnings from jotai atom migrations

### DIFF
--- a/apps/desktop/src/atoms/permissions.ts
+++ b/apps/desktop/src/atoms/permissions.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai'
+import { atom } from "jotai";
 
 export type PermissionStatus =
 	| "granted"
@@ -22,5 +22,5 @@ const INITIAL_PERMISSIONS: PermissionState = {
 	accessibility: "checking",
 };
 
-export const permissionsAtom = atom<PermissionState>(INITIAL_PERMISSIONS)
-export const isCheckingPermissionsAtom = atom<boolean>(true)
+export const permissionsAtom = atom<PermissionState>(INITIAL_PERMISSIONS);
+export const isCheckingPermissionsAtom = atom<boolean>(true);

--- a/apps/desktop/src/atoms/recording.ts
+++ b/apps/desktop/src/atoms/recording.ts
@@ -1,15 +1,15 @@
-import { atom } from 'jotai'
+import { atom } from "jotai";
 
 // --- Active recording state ---
-export const recordingActiveAtom = atom<boolean>(false)
+export const recordingActiveAtom = atom<boolean>(false);
 
 // --- Microphone configuration ---
-export const microphoneEnabledAtom = atom<boolean>(false)
-export const microphoneDeviceIdAtom = atom<string | undefined>(undefined)
+export const microphoneEnabledAtom = atom<boolean>(false);
+export const microphoneDeviceIdAtom = atom<string | undefined>(undefined);
 
 // --- System audio configuration ---
-export const systemAudioEnabledAtom = atom<boolean>(false)
+export const systemAudioEnabledAtom = atom<boolean>(false);
 
 // --- Camera / facecam configuration ---
-export const cameraEnabledAtom = atom<boolean>(false)
-export const cameraDeviceIdAtom = atom<string | undefined>(undefined)
+export const cameraEnabledAtom = atom<boolean>(false);
+export const cameraDeviceIdAtom = atom<string | undefined>(undefined);

--- a/apps/desktop/src/atoms/updater.ts
+++ b/apps/desktop/src/atoms/updater.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai'
+import { atom } from "jotai";
 
 export type UpdateStatus =
 	| "idle"
@@ -9,9 +9,9 @@ export type UpdateStatus =
 	| "ready"
 	| "error";
 
-export const updaterStatusAtom = atom<UpdateStatus>("idle")
-export const updaterDialogOpenAtom = atom<boolean>(false)
-export const updaterVersionAtom = atom<string | null>(null)
-export const updaterReleaseNotesAtom = atom<string | null>(null)
-export const updaterDownloadProgressAtom = atom<number>(0)
-export const updaterErrorAtom = atom<string | null>(null)
+export const updaterStatusAtom = atom<UpdateStatus>("idle");
+export const updaterDialogOpenAtom = atom<boolean>(false);
+export const updaterVersionAtom = atom<string | null>(null);
+export const updaterReleaseNotesAtom = atom<string | null>(null);
+export const updaterDownloadProgressAtom = atom<number>(0);
+export const updaterErrorAtom = atom<string | null>(null);

--- a/apps/desktop/src/hooks/useAppUpdater.ts
+++ b/apps/desktop/src/hooks/useAppUpdater.ts
@@ -1,9 +1,8 @@
 import { getIdentifier } from "@tauri-apps/api/app";
-import { useAtom } from "jotai";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
+import { useAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
-import * as backend from "@/lib/backend";
 import {
 	type UpdateStatus,
 	updaterDialogOpenAtom,
@@ -13,6 +12,8 @@ import {
 	updaterStatusAtom,
 	updaterVersionAtom,
 } from "@/atoms/updater";
+import * as backend from "@/lib/backend";
+
 export type { UpdateStatus } from "@/atoms/updater";
 
 const AUTO_CHECK_DELAY_MS = 10_000;
@@ -135,7 +136,16 @@ export function useAppUpdater({
 				setIsDialogOpen(showDialog);
 			}
 		},
-		[status, updatesEnabled],
+		[
+			status,
+			updatesEnabled,
+			setIsDialogOpen,
+			setVersion,
+			setReleaseNotes,
+			setDownloadProgress,
+			setError,
+			setStatus,
+		],
 	);
 
 	const downloadAndInstall = useCallback(async () => {
@@ -174,7 +184,7 @@ export function useAppUpdater({
 			setError(getErrorMessage(err, "Failed to download update"));
 			setStatus("error");
 		}
-	}, [status]);
+	}, [status, setIsDialogOpen, setStatus, setDownloadProgress, setError]);
 
 	const restartApp = useCallback(async () => {
 		await relaunch();
@@ -188,7 +198,7 @@ export function useAppUpdater({
 		setDownloadProgress(0);
 		setError(null);
 		updateRef.current = null;
-	}, []);
+	}, [setIsDialogOpen, setStatus, setVersion, setReleaseNotes, setDownloadProgress, setError]);
 
 	useEffect(() => {
 		if (import.meta.env.DEV) {

--- a/apps/desktop/src/hooks/usePermissions.ts
+++ b/apps/desktop/src/hooks/usePermissions.ts
@@ -9,14 +9,14 @@
 
 import { useAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
-import * as backend from "@/lib/backend";
 import { isMacOSAtom } from "@/atoms/app";
 import {
+	isCheckingPermissionsAtom,
 	type PermissionState,
 	type PermissionStatus,
-	isCheckingPermissionsAtom,
 	permissionsAtom,
 } from "@/atoms/permissions";
+import * as backend from "@/lib/backend";
 
 export type { PermissionState, PermissionStatus } from "@/atoms/permissions";
 
@@ -90,7 +90,7 @@ export function usePermissions(): UsePermissionsResult {
 		}
 
 		return state;
-	}, []);
+	}, [setIsMacOS, setPermissions, setIsChecking]);
 
 	const requestBrowserMediaAccess = useCallback(
 		async (constraints: MediaStreamConstraints, permission: "microphone" | "camera") => {

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -2,9 +2,6 @@ import { fixParsedWebmDuration } from "@fix-webm-duration/fix";
 import { WebmFile } from "@fix-webm-duration/parser";
 import { useAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { buildEditorWindowQuery } from "@/components/video-editor/editorWindowParams";
-import * as backend from "@/lib/backend";
-import { createDefaultFacecamSettings, type RecordingSession } from "@/lib/recordingSession";
 import { isMacOSAtom } from "@/atoms/app";
 import {
 	cameraDeviceIdAtom,
@@ -14,6 +11,9 @@ import {
 	recordingActiveAtom,
 	systemAudioEnabledAtom,
 } from "@/atoms/recording";
+import { buildEditorWindowQuery } from "@/components/video-editor/editorWindowParams";
+import * as backend from "@/lib/backend";
+import { createDefaultFacecamSettings, type RecordingSession } from "@/lib/recordingSession";
 
 const TARGET_FRAME_RATE = 60;
 const TARGET_WIDTH = 3840;
@@ -575,6 +575,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			queueRecordingChunkWrite,
 			resetStagedFileState,
 			selectMimeType,
+			setCameraEnabled,
 		],
 	);
 
@@ -641,14 +642,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			setRecording(false);
 			void backend.setRecordingState(false);
 		}
-	}, [buildRecordingSession, cleanupCapturedMedia, stopFacecamCapture]);
+	}, [buildRecordingSession, cleanupCapturedMedia, stopFacecamCapture, setRecording]);
 
 	useEffect(() => {
 		void (async () => {
 			const platform = await backend.getPlatform();
 			setIsMacOS(platform === "darwin");
 		})();
-	}, []);
+	}, [setIsMacOS]);
 
 	useEffect(() => {
 		let unlistenTray: (() => void) | undefined;
@@ -722,7 +723,13 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				facecamHasData,
 			);
 		};
-	}, [cleanupCapturedMedia, resetStagedFileState, stopLinuxCursorTelemetryCapture, stopRecording]);
+	}, [
+		cleanupCapturedMedia,
+		resetStagedFileState,
+		stopLinuxCursorTelemetryCapture,
+		stopRecording,
+		setRecording,
+	]);
 
 	const startRecording = async () => {
 		if (startInFlight.current) {


### PR DESCRIPTION
## Summary

Cleanup PR following #30, #31, #32 (useState → jotai migrations):

- Format new `atoms/recording.ts`, `atoms/updater.ts`, `atoms/permissions.ts` to biome style (double-quotes, semicolons, tab indentation)
- Add jotai setter functions to `useCallback`/`useEffect` dependency arrays in `useScreenRecorder`, `useAppUpdater`, and `usePermissions` — jotai setters are stable references so adding them to deps is safe and silences `useExhaustiveDependencies` warnings
- Fix import ordering in `useAppUpdater.ts` and `usePermissions.ts`

## Test plan

- [x] `npx tsc --noEmit` — no new errors (3 pre-existing errors in unrelated files unchanged)
- [x] `biome check` on all 6 changed files — no errors, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)