### PR TITLE
Prepare release v0.0.22

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.21",
-  "releaseName": "Open Recorder v0.0.21",
+  "tagName": "v0.0.22",
+  "releaseName": "Open Recorder v0.0.22",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "open-recorder"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "block",
  "cocoa",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder"
-version = "0.0.21"
+version = "0.0.22"
 description = "A free, creator-focused screen recorder"
 authors = ["imbhargav5"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Open Recorder",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "identifier": "dev.openrecorder.app",
   "build": {
     "beforeDevCommand": "pnpm exec vite",


### PR DESCRIPTION
## Release Summary
- Release type: patch
- Base version: 0.0.21 (apps/desktop/package.json)
- Next version: 0.0.22
- Tag: v0.0.22
- Release title: Open Recorder v0.0.22
- Mark as latest: true

Bumps the desktop app version from `0.0.21` to `0.0.22` and synchronizes the version across:
- `apps/desktop/package.json`
- `apps/desktop/src-tauri/Cargo.toml`
- `apps/desktop/src-tauri/Cargo.lock`
- `apps/desktop/src-tauri/tauri.conf.json`
- `.github/release-plan.json`

Build verified locally: `pnpm build` (cargo tauri build) compiles successfully and produces deb, rpm, and AppImage bundles. The final signing step requires `TAURI_SIGNING_PRIVATE_KEY`, which is only available in CI.

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

https://claude.ai/code/session_01RdL9WAbpSjspCNCz4Uqy1a