### PR TITLE
fix: capture stable startTime before setInterval to avoid stale closure

### DIFF
--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -249,10 +249,9 @@ export function LaunchWindow() {
 		let timer: NodeJS.Timeout | null = null;
 		if (recording) {
 			if (!recordingStart) setRecordingStart(Date.now());
+			const startTime = recordingStart || Date.now();
 			timer = setInterval(() => {
-				if (recordingStart) {
-					setElapsed(Math.floor((Date.now() - recordingStart) / 1000));
-				}
+				setElapsed(Math.floor((Date.now() - startTime) / 1000));
 			}, 1000);
 		} else {
 			setRecordingStart(null);


### PR DESCRIPTION
## Summary
- Fixed stale closure bug in the elapsed recording timer in `LaunchWindow.tsx`
- The `setInterval` callback was closing over `recordingStart` from the outer `useEffect` scope, which could be stale by the time the interval fired
- Captured `startTime` as a local `const` before creating the interval so the closure always references a stable value

## Root Cause
In React, when a `useEffect` closure reads state/atom values, those values are captured at the time the effect runs. If `recordingStart` changed between renders, the old interval callback would still reference the old (stale) value. This meant the elapsed time calculation could be wrong or the guard `if (recordingStart)` could evaluate against a stale `null`.

## Fix
```ts
// Before (stale closure risk)
timer = setInterval(() => {
  if (recordingStart) {
    setElapsed(Math.floor((Date.now() - recordingStart) / 1000));
  }
}, 1000);

// After (stable local reference)
const startTime = recordingStart || Date.now();
timer = setInterval(() => {
  setElapsed(Math.floor((Date.now() - startTime) / 1000));
}, 1000);
```

## Test plan
- [ ] Start a recording and verify the elapsed timer increments correctly every second
- [ ] Stop and restart recording; verify timer resets and counts up again from 0