### PR TITLE
fix: wrap Jotai root with explicit Provider and fresh store per window

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { Provider, createStore } from "jotai";
 import App from "./App.tsx";
 import { I18nProvider } from "./contexts/I18nContext.tsx";
 import { ensurePixiRuntime } from "./lib/pixiRuntime.ts";
@@ -10,11 +11,15 @@ async function bootstrap() {
 
 	await ensurePixiRuntime();
 
+	const store = createStore();
+
 	ReactDOM.createRoot(document.getElementById("root")!).render(
 		<React.StrictMode>
-			<I18nProvider>
-				<App />
-			</I18nProvider>
+			<Provider store={store}>
+				<I18nProvider>
+					<App />
+				</I18nProvider>
+			</Provider>
 		</React.StrictMode>,
 	);
 }


### PR DESCRIPTION
## Summary

- Imported `Provider` and `createStore` from `jotai` in `apps/desktop/src/main.tsx`
- Created a fresh Jotai store per window via `createStore()` inside `bootstrap()`
- Wrapped the render tree with `<Provider store={store}>` to isolate each window's atom state

**Root cause:** Without an explicit `<Provider>`, all Tauri windows (editor, hud-overlay, source-selector, image-editor) fell back to the default global Jotai store, allowing atom state to bleed across windows.

## Test plan
- [ ] Verify each window type (editor, hud-overlay, source-selector, image-editor) initializes with its own isolated Jotai store
- [ ] Confirm no state bleeds between windows (e.g. windowTypeAtom in one window does not affect another)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)