### PR TITLE
fix: consolidate duplicate isMac atoms into single isMacOSAtom

### DIFF
--- a/apps/desktop/src/atoms/shortcuts.ts
+++ b/apps/desktop/src/atoms/shortcuts.ts
@@ -2,5 +2,4 @@ import { atom } from "jotai";
 import { DEFAULT_SHORTCUTS, type ShortcutsConfig } from "@/lib/shortcuts";
 
 export const shortcutsAtom = atom<ShortcutsConfig>(DEFAULT_SHORTCUTS);
-export const isMacAtom = atom<boolean>(false);
 export const isShortcutsConfigOpenAtom = atom<boolean>(false);

--- a/apps/desktop/src/contexts/ShortcutsContext.tsx
+++ b/apps/desktop/src/contexts/ShortcutsContext.tsx
@@ -3,7 +3,8 @@ import { createContext, useCallback, useContext, useEffect, useMemo, type ReactN
 import { DEFAULT_SHORTCUTS, mergeWithDefaults, type ShortcutsConfig } from '@/lib/shortcuts'
 import { isMac as getIsMac } from '@/utils/platformUtils'
 import { getShortcuts as backendGetShortcuts, saveShortcuts as backendSaveShortcuts } from '@/lib/backend'
-import { isMacAtom, isShortcutsConfigOpenAtom, shortcutsAtom } from '@/atoms/shortcuts'
+import { isMacOSAtom } from '@/atoms/app'
+import { isShortcutsConfigOpenAtom, shortcutsAtom } from '@/atoms/shortcuts'
 
 interface ShortcutsContextValue {
   shortcuts: ShortcutsConfig
@@ -25,7 +26,7 @@ export function useShortcuts(): ShortcutsContextValue {
 
 export function ShortcutsProvider({ children }: { children: ReactNode }) {
   const [shortcuts, setShortcuts] = useAtom(shortcutsAtom)
-  const [isMac, setIsMac] = useAtom(isMacAtom)
+  const [isMac, setIsMac] = useAtom(isMacOSAtom)
   const [isConfigOpen, setIsConfigOpen] = useAtom(isShortcutsConfigOpenAtom)
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes Bug #11 — two separate Jotai atoms were representing the same concept (whether the platform is macOS), which could cause components to see inconsistent values.

- Removed `isMacAtom` from `apps/desktop/src/atoms/shortcuts.ts`
- Updated `ShortcutsContext` to import and use `isMacOSAtom` from `atoms/app.ts` instead
- `isMacOSAtom` in `atoms/app.ts` is now the single source of truth for macOS platform detection

## Changes

| File | Change |
|------|--------|
| `atoms/shortcuts.ts` | Removed `isMacAtom` export |
| `contexts/ShortcutsContext.tsx` | Switched import from `isMacAtom` → `isMacOSAtom` from `@/atoms/app` |

## Test plan
- [ ] Verify no TypeScript errors (`tsc --noEmit`)
- [ ] Confirm existing `stateDefaults.test.ts` tests still pass (they already cover `isMacOSAtom`)
- [ ] Confirm shortcut key display (⌘ vs Ctrl) renders correctly on macOS and non-macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)