### PR TITLE
fix: avoid reading localStorage/window.location at atom module load time

### DIFF
--- a/apps/desktop/src/atoms/i18n.ts
+++ b/apps/desktop/src/atoms/i18n.ts
@@ -20,4 +20,4 @@ export function getInitialLocale(): AppLocale {
 	return normalizeLocale(window.navigator.language);
 }
 
-export const localeAtom = atomWithStorage<AppLocale>(LOCALE_STORAGE_KEY, getInitialLocale());
+export const localeAtom = atomWithStorage<AppLocale>(LOCALE_STORAGE_KEY, DEFAULT_LOCALE);

--- a/apps/desktop/src/atoms/launch.ts
+++ b/apps/desktop/src/atoms/launch.ts
@@ -11,7 +11,7 @@ export function getInitialLaunchView(): LaunchView {
 	}
 }
 
-export const launchViewAtom = atom<LaunchView>(getInitialLaunchView());
+export const launchViewAtom = atom<LaunchView>("choice");
 export const screenshotModeAtom = atom<ScreenshotMode | null>(null);
 export const isCapturingAtom = atom<boolean>(false);
 export const recordingStartAtom = atom<number | null>(null);

--- a/apps/desktop/src/atoms/sourceSelector.ts
+++ b/apps/desktop/src/atoms/sourceSelector.ts
@@ -15,6 +15,6 @@ export function getInitialTab(): SourceSelectorTab {
 
 export const sourcesAtom = atom<DesktopSource[]>([]);
 export const selectedDesktopSourceAtom = atom<DesktopSource | null>(null);
-export const sourceSelectorTabAtom = atom<SourceSelectorTab>(getInitialTab());
+export const sourceSelectorTabAtom = atom<SourceSelectorTab>("screens");
 export const sourcesLoadingAtom = atom<boolean>(true);
 export const windowsLoadingAtom = atom<boolean>(true);

--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -100,6 +100,16 @@ export function LaunchWindow() {
 	const [screenshotMode, setScreenshotMode] = useAtom(screenshotModeAtom);
 	const [isCapturing, setIsCapturing] = useAtom(isCapturingAtom);
 
+	useEffect(() => {
+		try {
+			if (localStorage.getItem("open-recorder-onboarding-v1") !== "true") {
+				setView("onboarding");
+			}
+		} catch {
+			// ignore
+		}
+	}, [setView]);
+
 	const permissionsHook = usePermissions();
 
 	const {

--- a/apps/desktop/src/components/launch/SourceSelector.tsx
+++ b/apps/desktop/src/components/launch/SourceSelector.tsx
@@ -113,6 +113,13 @@ export function SourceSelector() {
 	const [windowsLoading, setWindowsLoading] = useAtom(windowsLoadingAtom);
 
 	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		if (params.get("tab") === "windows") {
+			setActiveTab("windows");
+		}
+	}, [setActiveTab]);
+
+	useEffect(() => {
 		let cancelled = false;
 
 		async function fetchSources() {


### PR DESCRIPTION
## Summary

Fixes bugs #2, #3, and #4 — all sharing the same anti-pattern of calling side-effectful initializer functions at Jotai atom definition time, which captures a stale value at module load and prevents proper re-hydration.

- **Bug #2** (`atoms/i18n.ts`): `localeAtom` was calling `getInitialLocale()` (which reads `localStorage`) at definition time. Fixed by using `DEFAULT_LOCALE` as the `atomWithStorage` default — letting `atomWithStorage` handle hydration itself.
- **Bug #3** (`atoms/sourceSelector.ts`): `sourceSelectorTabAtom` was calling `getInitialTab()` (which reads `window.location.search`) at definition time. Fixed by defaulting to `'screens'` and moving the URL param read into a `useEffect` in `SourceSelector.tsx`.
- **Bug #4** (`atoms/launch.ts`): `launchViewAtom` was calling `getInitialLaunchView()` (which reads `localStorage`) at definition time. Fixed by defaulting to `'choice'` and moving the onboarding check into a `useEffect` in `LaunchWindow.tsx`.

## Test plan

- [ ] All existing atom default tests pass (`src/atoms/stateDefaults.test.ts` — `source selector tab` expects `"screens"`, still correct)
- [ ] `src/atoms/i18n.test.ts` passes (6 tests)
- [ ] `src/components/launch/sourceSelector.test.ts` passes (5 tests)
- [ ] `src/components/launch/LaunchWindow.test.ts` passes (4 tests)
- [ ] 236 total tests pass (pre-existing `gifExporter` failure is unrelated)
- [ ] On first launch (no `open-recorder-onboarding-v1` in localStorage), `LaunchWindow` shows onboarding
- [ ] When opened with `?tab=windows` query param, `SourceSelector` switches to the Windows tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)