### PR TITLE
fix: reset recording atoms on LaunchWindow unmount (Bug #8)

### DIFF
--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -273,6 +273,15 @@ export function LaunchWindow() {
 		};
 	}, [recording, recordingStart, setElapsed, setRecordingStart]);
 
+	// Reset recording state atoms on unmount so the HUD never inherits stale
+	// elapsed time or a stale start timestamp when the window is reopened.
+	useEffect(() => {
+		return () => {
+			setRecordingStart(null);
+			setElapsed(0);
+		};
+	}, [setRecordingStart, setElapsed]);
+
 	const formatTime = (seconds: number) => {
 		const m = Math.floor(seconds / 60)
 			.toString()


### PR DESCRIPTION
## Summary

- Adds a cleanup `useEffect` in `LaunchWindow` that resets `recordingStartAtom` to `null` and `recordingElapsedAtom` to `0` when the component unmounts.
- Fixes the stale-state bug where closing and reopening the HUD window caused it to show a wrong elapsed time and a stale start timestamp from the previous recording session.

## Root cause

`recordingStartAtom` and `recordingElapsedAtom` were set during recording but never cleared on component unmount, so the next mount of `LaunchWindow` read the leftover values immediately.

## Fix

```tsx
// Reset recording state atoms on unmount so the HUD never inherits stale
// elapsed time or a stale start timestamp when the window is reopened.
useEffect(() => {
  return () => {
    setRecordingStart(null);
    setElapsed(0);
  };
}, [setRecordingStart, setElapsed]);
```

## Test plan

- [ ] Start a recording, let the timer run for several seconds, then close the HUD window.
- [ ] Reopen the HUD window — elapsed time should display `00:00`, not a carry-over value.
- [ ] Start a new recording — timer should begin from zero with a fresh start timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)