### PR TITLE
ci: add GitHub Actions workflow to run vitest test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run vitest suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm --filter @open-recorder/desktop exec npx vitest run --reporter=verbose


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` that runs the vitest test suite on every push to `main` and every PR targeting `main`
- Uses pnpm 10.17.1 (pinned to match `package.json`) with Node.js 22 (matches existing workflows)
- Installs dependencies with `pnpm install --frozen-lockfile` and runs `vitest run --reporter=verbose` for the `@open-recorder/desktop` package
- Workflow fails if any test fails

## Test plan
- [ ] Verify the workflow triggers on push to main and PRs targeting main
- [ ] Verify tests run and output is visible in CI logs
- [ ] Verify workflow fails if a test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)