### PR TITLE
test: expand Jotai atom test suite with 173 new test cases

### DIFF
--- a/apps/desktop/src/atoms/app.test.ts
+++ b/apps/desktop/src/atoms/app.test.ts
@@ -1,0 +1,67 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import { appNameAtom, isMacOSAtom, windowTypeAtom } from "./app";
+
+describe("app atoms – write / read", () => {
+  it("windowTypeAtom can be set to a non-empty string", () => {
+    const store = createStore();
+    store.set(windowTypeAtom, "main");
+    expect(store.get(windowTypeAtom)).toBe("main");
+  });
+
+  it("windowTypeAtom can be set back to empty string", () => {
+    const store = createStore();
+    store.set(windowTypeAtom, "editor");
+    store.set(windowTypeAtom, "");
+    expect(store.get(windowTypeAtom)).toBe("");
+  });
+
+  it("windowTypeAtom accepts arbitrary strings", () => {
+    const store = createStore();
+    for (const value of ["launch", "settings", "preview", "about"]) {
+      store.set(windowTypeAtom, value);
+      expect(store.get(windowTypeAtom)).toBe(value);
+    }
+  });
+
+  it("appNameAtom can be updated", () => {
+    const store = createStore();
+    store.set(appNameAtom, "My Recorder");
+    expect(store.get(appNameAtom)).toBe("My Recorder");
+  });
+
+  it("appNameAtom survives being set to empty string", () => {
+    const store = createStore();
+    store.set(appNameAtom, "");
+    expect(store.get(appNameAtom)).toBe("");
+  });
+
+  it("isMacOSAtom can be toggled true then false", () => {
+    const store = createStore();
+    store.set(isMacOSAtom, true);
+    expect(store.get(isMacOSAtom)).toBe(true);
+    store.set(isMacOSAtom, false);
+    expect(store.get(isMacOSAtom)).toBe(false);
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(windowTypeAtom, "editor");
+    storeA.set(appNameAtom, "Fork Recorder");
+    storeA.set(isMacOSAtom, true);
+
+    expect(storeB.get(windowTypeAtom)).toBe("");
+    expect(storeB.get(appNameAtom)).toBe("Open Recorder");
+    expect(storeB.get(isMacOSAtom)).toBe(false);
+  });
+
+  it("multiple successive writes reflect the last value", () => {
+    const store = createStore();
+    store.set(windowTypeAtom, "a");
+    store.set(windowTypeAtom, "b");
+    store.set(windowTypeAtom, "c");
+    expect(store.get(windowTypeAtom)).toBe("c");
+  });
+});

--- a/apps/desktop/src/atoms/imageEditor.test.ts
+++ b/apps/desktop/src/atoms/imageEditor.test.ts
@@ -1,0 +1,158 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  type ImageBackgroundType,
+  imageBackgroundTypeAtom,
+  imageBorderRadiusAtom,
+  imageExportingAtom,
+  imageGradientAtom,
+  imageNaturalHeightAtom,
+  imageNaturalWidthAtom,
+  imagePaddingAtom,
+  imageShadowIntensityAtom,
+  imageSolidColorAtom,
+  imageSrcAtom,
+  imageWallpaperAtom,
+  imageWallpaperPreviewPathsAtom,
+} from "./imageEditor";
+
+describe("imageEditor atoms – write / read", () => {
+  it("imageSrcAtom can be set to a file path", () => {
+    const store = createStore();
+    store.set(imageSrcAtom, "/screenshots/capture.png");
+    expect(store.get(imageSrcAtom)).toBe("/screenshots/capture.png");
+  });
+
+  it("imageSrcAtom can be cleared back to null", () => {
+    const store = createStore();
+    store.set(imageSrcAtom, "/screenshots/capture.png");
+    store.set(imageSrcAtom, null);
+    expect(store.get(imageSrcAtom)).toBeNull();
+  });
+
+  it("imageNaturalWidthAtom can be set to a positive integer", () => {
+    const store = createStore();
+    store.set(imageNaturalWidthAtom, 1920);
+    expect(store.get(imageNaturalWidthAtom)).toBe(1920);
+  });
+
+  it("imageNaturalHeightAtom can be set to a positive integer", () => {
+    const store = createStore();
+    store.set(imageNaturalHeightAtom, 1080);
+    expect(store.get(imageNaturalHeightAtom)).toBe(1080);
+  });
+
+  it("width and height can be set independently", () => {
+    const store = createStore();
+    store.set(imageNaturalWidthAtom, 800);
+    store.set(imageNaturalHeightAtom, 600);
+    expect(store.get(imageNaturalWidthAtom)).toBe(800);
+    expect(store.get(imageNaturalHeightAtom)).toBe(600);
+  });
+
+  it("imageBackgroundTypeAtom can cycle through all types", () => {
+    const types: ImageBackgroundType[] = [
+      "wallpaper",
+      "gradient",
+      "color",
+      "transparent",
+    ];
+    const store = createStore();
+    for (const type of types) {
+      store.set(imageBackgroundTypeAtom, type);
+      expect(store.get(imageBackgroundTypeAtom)).toBe(type);
+    }
+  });
+
+  it("imageWallpaperAtom can be set to a custom path", () => {
+    const store = createStore();
+    store.set(imageWallpaperAtom, "/assets/wallpapers/custom.jpg");
+    expect(store.get(imageWallpaperAtom)).toBe("/assets/wallpapers/custom.jpg");
+  });
+
+  it("imageGradientAtom can be replaced with a new gradient", () => {
+    const store = createStore();
+    const newGradient = "radial-gradient(circle, #ff6b6b, #4ecdc4)";
+    store.set(imageGradientAtom, newGradient);
+    expect(store.get(imageGradientAtom)).toBe(newGradient);
+  });
+
+  it("imageSolidColorAtom can be updated to any hex color", () => {
+    const store = createStore();
+    store.set(imageSolidColorAtom, "#FF5733");
+    expect(store.get(imageSolidColorAtom)).toBe("#FF5733");
+  });
+
+  it("imagePaddingAtom can be set to zero (no padding)", () => {
+    const store = createStore();
+    store.set(imagePaddingAtom, 0);
+    expect(store.get(imagePaddingAtom)).toBe(0);
+  });
+
+  it("imagePaddingAtom can be set to a large value", () => {
+    const store = createStore();
+    store.set(imagePaddingAtom, 200);
+    expect(store.get(imagePaddingAtom)).toBe(200);
+  });
+
+  it("imageBorderRadiusAtom can be set to 0 for sharp corners", () => {
+    const store = createStore();
+    store.set(imageBorderRadiusAtom, 0);
+    expect(store.get(imageBorderRadiusAtom)).toBe(0);
+  });
+
+  it("imageBorderRadiusAtom can be set to a large value for round corners", () => {
+    const store = createStore();
+    store.set(imageBorderRadiusAtom, 50);
+    expect(store.get(imageBorderRadiusAtom)).toBe(50);
+  });
+
+  it("imageShadowIntensityAtom can be set to 0 (no shadow)", () => {
+    const store = createStore();
+    store.set(imageShadowIntensityAtom, 0);
+    expect(store.get(imageShadowIntensityAtom)).toBe(0);
+  });
+
+  it("imageShadowIntensityAtom can be set to 1.0 (max shadow)", () => {
+    const store = createStore();
+    store.set(imageShadowIntensityAtom, 1.0);
+    expect(store.get(imageShadowIntensityAtom)).toBe(1.0);
+  });
+
+  it("imageWallpaperPreviewPathsAtom can have paths added", () => {
+    const store = createStore();
+    const paths = ["/wall/a.jpg", "/wall/b.jpg", "/wall/c.jpg"];
+    store.set(imageWallpaperPreviewPathsAtom, paths);
+    expect(store.get(imageWallpaperPreviewPathsAtom)).toEqual(paths);
+  });
+
+  it("imageExportingAtom can be set to true during export", () => {
+    const store = createStore();
+    store.set(imageExportingAtom, true);
+    expect(store.get(imageExportingAtom)).toBe(true);
+  });
+
+  it("imageExportingAtom resets to false after export completes", () => {
+    const store = createStore();
+    store.set(imageExportingAtom, true);
+    store.set(imageExportingAtom, false);
+    expect(store.get(imageExportingAtom)).toBe(false);
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(imageSrcAtom, "/screenshots/foo.png");
+    storeA.set(imageNaturalWidthAtom, 1920);
+    storeA.set(imageNaturalHeightAtom, 1080);
+    storeA.set(imageBackgroundTypeAtom, "color");
+    storeA.set(imageExportingAtom, true);
+
+    expect(storeB.get(imageSrcAtom)).toBeNull();
+    expect(storeB.get(imageNaturalWidthAtom)).toBe(0);
+    expect(storeB.get(imageNaturalHeightAtom)).toBe(0);
+    expect(storeB.get(imageBackgroundTypeAtom)).toBe("wallpaper");
+    expect(storeB.get(imageExportingAtom)).toBe(false);
+  });
+});

--- a/apps/desktop/src/atoms/launch.test.ts
+++ b/apps/desktop/src/atoms/launch.test.ts
@@ -1,0 +1,110 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  hasSelectedSourceAtom,
+  isCapturingAtom,
+  launchViewAtom,
+  type LaunchView,
+  recordingElapsedAtom,
+  recordingStartAtom,
+  screenshotModeAtom,
+  type ScreenshotMode,
+  selectedSourceAtom,
+} from "./launch";
+
+describe("launch atoms – write / read", () => {
+  it("launchViewAtom can be set to every LaunchView value", () => {
+    const views: LaunchView[] = ["onboarding", "choice", "screenshot", "recording"];
+    const store = createStore();
+    for (const view of views) {
+      store.set(launchViewAtom, view);
+      expect(store.get(launchViewAtom)).toBe(view);
+    }
+  });
+
+  it("screenshotModeAtom can be set to every ScreenshotMode value", () => {
+    const modes: ScreenshotMode[] = ["screen", "window", "area"];
+    const store = createStore();
+    for (const mode of modes) {
+      store.set(screenshotModeAtom, mode);
+      expect(store.get(screenshotModeAtom)).toBe(mode);
+    }
+  });
+
+  it("screenshotModeAtom can be cleared back to null", () => {
+    const store = createStore();
+    store.set(screenshotModeAtom, "screen");
+    store.set(screenshotModeAtom, null);
+    expect(store.get(screenshotModeAtom)).toBeNull();
+  });
+
+  it("isCapturingAtom can be toggled to true and back", () => {
+    const store = createStore();
+    store.set(isCapturingAtom, true);
+    expect(store.get(isCapturingAtom)).toBe(true);
+    store.set(isCapturingAtom, false);
+    expect(store.get(isCapturingAtom)).toBe(false);
+  });
+
+  it("recordingStartAtom can be set to a Unix timestamp", () => {
+    const store = createStore();
+    const now = Date.now();
+    store.set(recordingStartAtom, now);
+    expect(store.get(recordingStartAtom)).toBe(now);
+  });
+
+  it("recordingStartAtom can be reset to null when recording stops", () => {
+    const store = createStore();
+    store.set(recordingStartAtom, Date.now());
+    store.set(recordingStartAtom, null);
+    expect(store.get(recordingStartAtom)).toBeNull();
+  });
+
+  it("recordingElapsedAtom can be incremented", () => {
+    const store = createStore();
+    store.set(recordingElapsedAtom, 1000);
+    expect(store.get(recordingElapsedAtom)).toBe(1000);
+    store.set(recordingElapsedAtom, 2000);
+    expect(store.get(recordingElapsedAtom)).toBe(2000);
+  });
+
+  it("recordingElapsedAtom can be reset to 0", () => {
+    const store = createStore();
+    store.set(recordingElapsedAtom, 5000);
+    store.set(recordingElapsedAtom, 0);
+    expect(store.get(recordingElapsedAtom)).toBe(0);
+  });
+
+  it("selectedSourceAtom can be changed to a different display", () => {
+    const store = createStore();
+    store.set(selectedSourceAtom, "Display 2");
+    expect(store.get(selectedSourceAtom)).toBe("Display 2");
+  });
+
+  it("selectedSourceAtom accepts empty string", () => {
+    const store = createStore();
+    store.set(selectedSourceAtom, "");
+    expect(store.get(selectedSourceAtom)).toBe("");
+  });
+
+  it("hasSelectedSourceAtom can be set to false when no source is selected", () => {
+    const store = createStore();
+    store.set(hasSelectedSourceAtom, false);
+    expect(store.get(hasSelectedSourceAtom)).toBe(false);
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(launchViewAtom, "recording");
+    storeA.set(isCapturingAtom, true);
+    storeA.set(recordingStartAtom, 12345);
+    storeA.set(recordingElapsedAtom, 3000);
+
+    expect(storeB.get(launchViewAtom)).toBe("choice");
+    expect(storeB.get(isCapturingAtom)).toBe(false);
+    expect(storeB.get(recordingStartAtom)).toBeNull();
+    expect(storeB.get(recordingElapsedAtom)).toBe(0);
+  });
+});

--- a/apps/desktop/src/atoms/permissions.test.ts
+++ b/apps/desktop/src/atoms/permissions.test.ts
@@ -1,0 +1,170 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  isCheckingPermissionsAtom,
+  type PermissionState,
+  type PermissionStatus,
+  permissionsAtom,
+} from "./permissions";
+
+describe("permissions atoms – write / read", () => {
+  it("can update screenRecording permission to granted", () => {
+    const store = createStore();
+    const updated: PermissionState = {
+      ...store.get(permissionsAtom),
+      screenRecording: "granted",
+    };
+    store.set(permissionsAtom, updated);
+    expect(store.get(permissionsAtom).screenRecording).toBe("granted");
+  });
+
+  it("can update microphone permission to denied", () => {
+    const store = createStore();
+    const updated: PermissionState = {
+      ...store.get(permissionsAtom),
+      microphone: "denied",
+    };
+    store.set(permissionsAtom, updated);
+    expect(store.get(permissionsAtom).microphone).toBe("denied");
+  });
+
+  it("can set all permissions to granted at once", () => {
+    const store = createStore();
+    const allGranted: PermissionState = {
+      screenRecording: "granted",
+      microphone: "granted",
+      camera: "granted",
+      accessibility: "granted",
+    };
+    store.set(permissionsAtom, allGranted);
+    const result = store.get(permissionsAtom);
+    expect(result.screenRecording).toBe("granted");
+    expect(result.microphone).toBe("granted");
+    expect(result.camera).toBe("granted");
+    expect(result.accessibility).toBe("granted");
+  });
+
+  it("can set all permissions to denied at once", () => {
+    const store = createStore();
+    store.set(permissionsAtom, {
+      screenRecording: "denied",
+      microphone: "denied",
+      camera: "denied",
+      accessibility: "denied",
+    });
+    const result = store.get(permissionsAtom);
+    expect(result.screenRecording).toBe("denied");
+    expect(result.microphone).toBe("denied");
+  });
+
+  it("supports every PermissionStatus value", () => {
+    const statuses: PermissionStatus[] = [
+      "granted",
+      "denied",
+      "not_determined",
+      "restricted",
+      "unknown",
+      "checking",
+    ];
+    const store = createStore();
+    for (const status of statuses) {
+      store.set(permissionsAtom, {
+        screenRecording: status,
+        microphone: status,
+        camera: status,
+        accessibility: status,
+      });
+      expect(store.get(permissionsAtom).screenRecording).toBe(status);
+    }
+  });
+
+  it("isCheckingPermissionsAtom can be set to false", () => {
+    const store = createStore();
+    store.set(isCheckingPermissionsAtom, false);
+    expect(store.get(isCheckingPermissionsAtom)).toBe(false);
+  });
+
+  it("isCheckingPermissionsAtom can be toggled back to true", () => {
+    const store = createStore();
+    store.set(isCheckingPermissionsAtom, false);
+    store.set(isCheckingPermissionsAtom, true);
+    expect(store.get(isCheckingPermissionsAtom)).toBe(true);
+  });
+
+  it("updating one permission key leaves others unchanged", () => {
+    const store = createStore();
+    const before = store.get(permissionsAtom);
+    store.set(permissionsAtom, { ...before, camera: "granted" });
+    const after = store.get(permissionsAtom);
+    expect(after.screenRecording).toBe(before.screenRecording);
+    expect(after.microphone).toBe(before.microphone);
+    expect(after.accessibility).toBe(before.accessibility);
+    expect(after.camera).toBe("granted");
+  });
+
+  it("permissionsAtom holds an object with the four expected keys", () => {
+    const store = createStore();
+    const state = store.get(permissionsAtom);
+    expect(state).toHaveProperty("screenRecording");
+    expect(state).toHaveProperty("microphone");
+    expect(state).toHaveProperty("camera");
+    expect(state).toHaveProperty("accessibility");
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(permissionsAtom, {
+      screenRecording: "granted",
+      microphone: "granted",
+      camera: "granted",
+      accessibility: "granted",
+    });
+    storeA.set(isCheckingPermissionsAtom, false);
+
+    expect(storeB.get(permissionsAtom).screenRecording).toBe("checking");
+    expect(storeB.get(isCheckingPermissionsAtom)).toBe(true);
+  });
+
+  it("can transition from checking → not_determined → granted", () => {
+    const store = createStore();
+    const base: PermissionState = store.get(permissionsAtom);
+
+    store.set(permissionsAtom, { ...base, screenRecording: "not_determined" });
+    expect(store.get(permissionsAtom).screenRecording).toBe("not_determined");
+
+    store.set(permissionsAtom, {
+      ...store.get(permissionsAtom),
+      screenRecording: "granted",
+    });
+    expect(store.get(permissionsAtom).screenRecording).toBe("granted");
+  });
+
+  it("can set restricted status for accessibility", () => {
+    const store = createStore();
+    const base = store.get(permissionsAtom);
+    store.set(permissionsAtom, { ...base, accessibility: "restricted" });
+    expect(store.get(permissionsAtom).accessibility).toBe("restricted");
+  });
+
+  it("can set unknown status", () => {
+    const store = createStore();
+    const base = store.get(permissionsAtom);
+    store.set(permissionsAtom, { ...base, microphone: "unknown" });
+    expect(store.get(permissionsAtom).microphone).toBe("unknown");
+  });
+
+  it("isCheckingPermissionsAtom is independent of permissionsAtom", () => {
+    const store = createStore();
+    store.set(isCheckingPermissionsAtom, false);
+    // Changing permissions should not reset isChecking
+    store.set(permissionsAtom, {
+      screenRecording: "granted",
+      microphone: "granted",
+      camera: "granted",
+      accessibility: "granted",
+    });
+    expect(store.get(isCheckingPermissionsAtom)).toBe(false);
+  });
+});

--- a/apps/desktop/src/atoms/recording.test.ts
+++ b/apps/desktop/src/atoms/recording.test.ts
@@ -1,0 +1,102 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  cameraDeviceIdAtom,
+  cameraEnabledAtom,
+  microphoneDeviceIdAtom,
+  microphoneEnabledAtom,
+  recordingActiveAtom,
+  systemAudioEnabledAtom,
+} from "./recording";
+
+describe("recording atoms – write / read", () => {
+  it("recordingActiveAtom can be set to true", () => {
+    const store = createStore();
+    store.set(recordingActiveAtom, true);
+    expect(store.get(recordingActiveAtom)).toBe(true);
+  });
+
+  it("recordingActiveAtom can be toggled back to false", () => {
+    const store = createStore();
+    store.set(recordingActiveAtom, true);
+    store.set(recordingActiveAtom, false);
+    expect(store.get(recordingActiveAtom)).toBe(false);
+  });
+
+  it("microphoneEnabledAtom can be enabled then disabled", () => {
+    const store = createStore();
+    store.set(microphoneEnabledAtom, true);
+    expect(store.get(microphoneEnabledAtom)).toBe(true);
+    store.set(microphoneEnabledAtom, false);
+    expect(store.get(microphoneEnabledAtom)).toBe(false);
+  });
+
+  it("microphoneDeviceIdAtom can be set to a device ID string", () => {
+    const store = createStore();
+    store.set(microphoneDeviceIdAtom, "device-abc-123");
+    expect(store.get(microphoneDeviceIdAtom)).toBe("device-abc-123");
+  });
+
+  it("microphoneDeviceIdAtom can be cleared back to undefined", () => {
+    const store = createStore();
+    store.set(microphoneDeviceIdAtom, "device-abc-123");
+    store.set(microphoneDeviceIdAtom, undefined);
+    expect(store.get(microphoneDeviceIdAtom)).toBeUndefined();
+  });
+
+  it("microphoneDeviceIdAtom accepts empty string", () => {
+    const store = createStore();
+    store.set(microphoneDeviceIdAtom, "");
+    expect(store.get(microphoneDeviceIdAtom)).toBe("");
+  });
+
+  it("systemAudioEnabledAtom can be toggled", () => {
+    const store = createStore();
+    store.set(systemAudioEnabledAtom, true);
+    expect(store.get(systemAudioEnabledAtom)).toBe(true);
+    store.set(systemAudioEnabledAtom, false);
+    expect(store.get(systemAudioEnabledAtom)).toBe(false);
+  });
+
+  it("cameraEnabledAtom can be toggled", () => {
+    const store = createStore();
+    store.set(cameraEnabledAtom, true);
+    expect(store.get(cameraEnabledAtom)).toBe(true);
+  });
+
+  it("cameraDeviceIdAtom can be set to a device ID string", () => {
+    const store = createStore();
+    store.set(cameraDeviceIdAtom, "cam-xyz-456");
+    expect(store.get(cameraDeviceIdAtom)).toBe("cam-xyz-456");
+  });
+
+  it("cameraDeviceIdAtom can be cleared to undefined", () => {
+    const store = createStore();
+    store.set(cameraDeviceIdAtom, "cam-xyz-456");
+    store.set(cameraDeviceIdAtom, undefined);
+    expect(store.get(cameraDeviceIdAtom)).toBeUndefined();
+  });
+
+  it("microphone and camera device IDs are independent", () => {
+    const store = createStore();
+    store.set(microphoneDeviceIdAtom, "mic-1");
+    store.set(cameraDeviceIdAtom, "cam-2");
+    expect(store.get(microphoneDeviceIdAtom)).toBe("mic-1");
+    expect(store.get(cameraDeviceIdAtom)).toBe("cam-2");
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(recordingActiveAtom, true);
+    storeA.set(microphoneEnabledAtom, true);
+    storeA.set(microphoneDeviceIdAtom, "mic-1");
+    storeA.set(cameraEnabledAtom, true);
+
+    expect(storeB.get(recordingActiveAtom)).toBe(false);
+    expect(storeB.get(microphoneEnabledAtom)).toBe(false);
+    expect(storeB.get(microphoneDeviceIdAtom)).toBeUndefined();
+    expect(storeB.get(cameraEnabledAtom)).toBe(false);
+  });
+});

--- a/apps/desktop/src/atoms/settingsPanel.test.ts
+++ b/apps/desktop/src/atoms/settingsPanel.test.ts
@@ -1,0 +1,119 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  type BackgroundTab,
+  type SettingsSidebarTab,
+  settingsActiveTabAtom,
+  settingsBackgroundTabAtom,
+  settingsCustomImagesAtom,
+  settingsGradientAtom,
+  settingsSelectedColorAtom,
+  settingsShowCropModalAtom,
+} from "./settingsPanel";
+
+describe("settingsPanel atoms – write / read", () => {
+  it("settingsActiveTabAtom can cycle through all sidebar tabs", () => {
+    const tabs: SettingsSidebarTab[] = [
+      "appearance",
+      "cursor",
+      "camera",
+      "background",
+      "audio",
+    ];
+    const store = createStore();
+    for (const tab of tabs) {
+      store.set(settingsActiveTabAtom, tab);
+      expect(store.get(settingsActiveTabAtom)).toBe(tab);
+    }
+  });
+
+  it("settingsBackgroundTabAtom can cycle through all background tabs", () => {
+    const tabs: BackgroundTab[] = ["image", "color", "gradient"];
+    const store = createStore();
+    for (const tab of tabs) {
+      store.set(settingsBackgroundTabAtom, tab);
+      expect(store.get(settingsBackgroundTabAtom)).toBe(tab);
+    }
+  });
+
+  it("settingsCustomImagesAtom can have images added", () => {
+    const store = createStore();
+    store.set(settingsCustomImagesAtom, ["/img/bg1.png"]);
+    expect(store.get(settingsCustomImagesAtom)).toEqual(["/img/bg1.png"]);
+  });
+
+  it("settingsCustomImagesAtom can hold multiple paths", () => {
+    const store = createStore();
+    const paths = ["/img/bg1.png", "/img/bg2.jpg", "/img/bg3.webp"];
+    store.set(settingsCustomImagesAtom, paths);
+    expect(store.get(settingsCustomImagesAtom)).toHaveLength(3);
+    expect(store.get(settingsCustomImagesAtom)).toEqual(paths);
+  });
+
+  it("settingsCustomImagesAtom can be cleared back to empty", () => {
+    const store = createStore();
+    store.set(settingsCustomImagesAtom, ["/img/bg1.png"]);
+    store.set(settingsCustomImagesAtom, []);
+    expect(store.get(settingsCustomImagesAtom)).toEqual([]);
+  });
+
+  it("settingsSelectedColorAtom can be set to various hex colors", () => {
+    const store = createStore();
+    for (const color of ["#FF0000", "#00FF00", "#0000FF", "#000000", "#FFFFFF"]) {
+      store.set(settingsSelectedColorAtom, color);
+      expect(store.get(settingsSelectedColorAtom)).toBe(color);
+    }
+  });
+
+  it("settingsSelectedColorAtom accepts rgba strings", () => {
+    const store = createStore();
+    store.set(settingsSelectedColorAtom, "rgba(255, 0, 0, 0.5)");
+    expect(store.get(settingsSelectedColorAtom)).toBe("rgba(255, 0, 0, 0.5)");
+  });
+
+  it("settingsGradientAtom can be updated to a new gradient", () => {
+    const store = createStore();
+    const gradient = "linear-gradient(90deg, #ff0000, #0000ff)";
+    store.set(settingsGradientAtom, gradient);
+    expect(store.get(settingsGradientAtom)).toBe(gradient);
+  });
+
+  it("settingsShowCropModalAtom can be opened", () => {
+    const store = createStore();
+    store.set(settingsShowCropModalAtom, true);
+    expect(store.get(settingsShowCropModalAtom)).toBe(true);
+  });
+
+  it("settingsShowCropModalAtom can be closed after opening", () => {
+    const store = createStore();
+    store.set(settingsShowCropModalAtom, true);
+    store.set(settingsShowCropModalAtom, false);
+    expect(store.get(settingsShowCropModalAtom)).toBe(false);
+  });
+
+  it("switching active tab does not affect background tab", () => {
+    const store = createStore();
+    store.set(settingsActiveTabAtom, "cursor");
+    store.set(settingsBackgroundTabAtom, "gradient");
+
+    store.set(settingsActiveTabAtom, "audio");
+    expect(store.get(settingsBackgroundTabAtom)).toBe("gradient");
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(settingsActiveTabAtom, "cursor");
+    storeA.set(settingsBackgroundTabAtom, "color");
+    storeA.set(settingsCustomImagesAtom, ["/img/bg.png"]);
+    storeA.set(settingsSelectedColorAtom, "#123456");
+    storeA.set(settingsShowCropModalAtom, true);
+
+    expect(storeB.get(settingsActiveTabAtom)).toBe("appearance");
+    expect(storeB.get(settingsBackgroundTabAtom)).toBe("image");
+    expect(storeB.get(settingsCustomImagesAtom)).toEqual([]);
+    expect(storeB.get(settingsSelectedColorAtom)).toBe("#ADADAD");
+    expect(storeB.get(settingsShowCropModalAtom)).toBe(false);
+  });
+});

--- a/apps/desktop/src/atoms/shortcuts.test.ts
+++ b/apps/desktop/src/atoms/shortcuts.test.ts
@@ -1,0 +1,98 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SHORTCUTS, SHORTCUT_ACTIONS, type ShortcutsConfig } from "@/lib/shortcuts";
+import { isShortcutsConfigOpenAtom, shortcutsAtom } from "./shortcuts";
+
+describe("shortcuts atoms – write / read", () => {
+  it("shortcutsAtom contains all SHORTCUT_ACTIONS keys", () => {
+    const store = createStore();
+    const config = store.get(shortcutsAtom);
+    for (const action of SHORTCUT_ACTIONS) {
+      expect(config).toHaveProperty(action);
+    }
+  });
+
+  it("DEFAULT_SHORTCUTS has a key binding for every action", () => {
+    for (const action of SHORTCUT_ACTIONS) {
+      expect(DEFAULT_SHORTCUTS[action]).toBeDefined();
+      expect(DEFAULT_SHORTCUTS[action].key).toBeTruthy();
+    }
+  });
+
+  it("deleteSelected default binding has ctrl modifier", () => {
+    expect(DEFAULT_SHORTCUTS.deleteSelected.ctrl).toBe(true);
+  });
+
+  it("playPause default binding is space", () => {
+    expect(DEFAULT_SHORTCUTS.playPause.key).toBe(" ");
+  });
+
+  it("shortcutsAtom can be updated with a new binding for addZoom", () => {
+    const store = createStore();
+    const before = store.get(shortcutsAtom);
+    const updated: ShortcutsConfig = {
+      ...before,
+      addZoom: { key: "e", ctrl: true },
+    };
+    store.set(shortcutsAtom, updated);
+    expect(store.get(shortcutsAtom).addZoom).toEqual({ key: "e", ctrl: true });
+  });
+
+  it("shortcutsAtom can be updated with a new binding for playPause", () => {
+    const store = createStore();
+    const before = store.get(shortcutsAtom);
+    store.set(shortcutsAtom, { ...before, playPause: { key: "p" } });
+    expect(store.get(shortcutsAtom).playPause).toEqual({ key: "p" });
+  });
+
+  it("updating one binding does not affect other bindings", () => {
+    const store = createStore();
+    const before = store.get(shortcutsAtom);
+    store.set(shortcutsAtom, { ...before, addTrim: { key: "q" } });
+    const after = store.get(shortcutsAtom);
+
+    // addZoom should still be the default
+    expect(after.addZoom).toEqual(before.addZoom);
+    expect(after.playPause).toEqual(before.playPause);
+  });
+
+  it("isShortcutsConfigOpenAtom can be opened", () => {
+    const store = createStore();
+    store.set(isShortcutsConfigOpenAtom, true);
+    expect(store.get(isShortcutsConfigOpenAtom)).toBe(true);
+  });
+
+  it("isShortcutsConfigOpenAtom can be closed after opening", () => {
+    const store = createStore();
+    store.set(isShortcutsConfigOpenAtom, true);
+    store.set(isShortcutsConfigOpenAtom, false);
+    expect(store.get(isShortcutsConfigOpenAtom)).toBe(false);
+  });
+
+  it("shortcutsAtom can be reset to defaults by setting DEFAULT_SHORTCUTS", () => {
+    const store = createStore();
+    const before = store.get(shortcutsAtom);
+    store.set(shortcutsAtom, {
+      ...before,
+      addZoom: { key: "x", shift: true },
+    });
+    // Now reset
+    store.set(shortcutsAtom, DEFAULT_SHORTCUTS);
+    expect(store.get(shortcutsAtom)).toEqual(DEFAULT_SHORTCUTS);
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    const customConfig: ShortcutsConfig = {
+      ...DEFAULT_SHORTCUTS,
+      addZoom: { key: "1", ctrl: true },
+    };
+    storeA.set(shortcutsAtom, customConfig);
+    storeA.set(isShortcutsConfigOpenAtom, true);
+
+    expect(storeB.get(shortcutsAtom)).toEqual(DEFAULT_SHORTCUTS);
+    expect(storeB.get(isShortcutsConfigOpenAtom)).toBe(false);
+  });
+});

--- a/apps/desktop/src/atoms/sourceSelector.test.ts
+++ b/apps/desktop/src/atoms/sourceSelector.test.ts
@@ -1,0 +1,121 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import type { DesktopSource } from "@/components/launch/sourceSelectorState";
+import {
+  selectedDesktopSourceAtom,
+  sourceSelectorTabAtom,
+  type SourceSelectorTab,
+  sourcesAtom,
+  sourcesLoadingAtom,
+  windowsLoadingAtom,
+} from "./sourceSelector";
+
+function makeSource(overrides: Partial<DesktopSource> = {}): DesktopSource {
+  return {
+    id: "screen:0",
+    name: "Main Display",
+    thumbnail: null,
+    display_id: "0",
+    appIcon: null,
+    originalName: "Main Display",
+    sourceType: "screen",
+    ...overrides,
+  };
+}
+
+describe("sourceSelector atoms – write / read", () => {
+  it("sourceSelectorTabAtom can be switched to windows", () => {
+    const store = createStore();
+    store.set(sourceSelectorTabAtom, "windows");
+    expect(store.get(sourceSelectorTabAtom)).toBe("windows");
+  });
+
+  it("sourceSelectorTabAtom can be switched back to screens", () => {
+    const store = createStore();
+    store.set(sourceSelectorTabAtom, "windows");
+    store.set(sourceSelectorTabAtom, "screens");
+    expect(store.get(sourceSelectorTabAtom)).toBe("screens");
+  });
+
+  it("sourceSelectorTabAtom accepts both SourceSelectorTab values", () => {
+    const tabs: SourceSelectorTab[] = ["screens", "windows"];
+    const store = createStore();
+    for (const tab of tabs) {
+      store.set(sourceSelectorTabAtom, tab);
+      expect(store.get(sourceSelectorTabAtom)).toBe(tab);
+    }
+  });
+
+  it("sourcesAtom can be populated with screen sources", () => {
+    const store = createStore();
+    const sources = [
+      makeSource({ id: "screen:0", name: "Main Display" }),
+      makeSource({ id: "screen:1", name: "External Monitor" }),
+    ];
+    store.set(sourcesAtom, sources);
+    expect(store.get(sourcesAtom)).toHaveLength(2);
+    expect(store.get(sourcesAtom)[0].name).toBe("Main Display");
+  });
+
+  it("sourcesAtom can be populated with window sources", () => {
+    const store = createStore();
+    const source = makeSource({
+      id: "window:100",
+      name: "Finder",
+      sourceType: "window",
+    });
+    store.set(sourcesAtom, [source]);
+    expect(store.get(sourcesAtom)[0].sourceType).toBe("window");
+  });
+
+  it("sourcesAtom can be cleared back to empty", () => {
+    const store = createStore();
+    store.set(sourcesAtom, [makeSource()]);
+    store.set(sourcesAtom, []);
+    expect(store.get(sourcesAtom)).toEqual([]);
+  });
+
+  it("selectedDesktopSourceAtom can be set to a source", () => {
+    const store = createStore();
+    const source = makeSource({ id: "screen:0", name: "Main Display" });
+    store.set(selectedDesktopSourceAtom, source);
+    expect(store.get(selectedDesktopSourceAtom)).toEqual(source);
+    expect(store.get(selectedDesktopSourceAtom)?.name).toBe("Main Display");
+  });
+
+  it("selectedDesktopSourceAtom can be cleared back to null", () => {
+    const store = createStore();
+    store.set(selectedDesktopSourceAtom, makeSource());
+    store.set(selectedDesktopSourceAtom, null);
+    expect(store.get(selectedDesktopSourceAtom)).toBeNull();
+  });
+
+  it("sourcesLoadingAtom can be set to false when loaded", () => {
+    const store = createStore();
+    store.set(sourcesLoadingAtom, false);
+    expect(store.get(sourcesLoadingAtom)).toBe(false);
+  });
+
+  it("windowsLoadingAtom can be set to false independently", () => {
+    const store = createStore();
+    store.set(windowsLoadingAtom, false);
+    expect(store.get(windowsLoadingAtom)).toBe(false);
+    // sourcesLoadingAtom should remain at its own value
+    expect(store.get(sourcesLoadingAtom)).toBe(true);
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(sourceSelectorTabAtom, "windows");
+    storeA.set(sourcesAtom, [makeSource()]);
+    storeA.set(selectedDesktopSourceAtom, makeSource());
+    storeA.set(sourcesLoadingAtom, false);
+
+    expect(storeB.get(sourceSelectorTabAtom)).toBe("screens");
+    expect(storeB.get(sourcesAtom)).toEqual([]);
+    expect(storeB.get(selectedDesktopSourceAtom)).toBeNull();
+    expect(storeB.get(sourcesLoadingAtom)).toBe(true);
+  });
+});

--- a/apps/desktop/src/atoms/timeline.test.ts
+++ b/apps/desktop/src/atoms/timeline.test.ts
@@ -1,0 +1,114 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  timelineCustomAspectHeightAtom,
+  timelineCustomAspectWidthAtom,
+  timelineKeyframesAtom,
+  timelineRangeAtom,
+  timelineScrollLabelsAtom,
+  timelineSelectedKeyframeIdAtom,
+} from "./timeline";
+
+describe("timeline atoms – write / read", () => {
+  it("timelineRangeAtom can be set to a non-zero range", () => {
+    const store = createStore();
+    store.set(timelineRangeAtom, { start: 1000, end: 5000 });
+    expect(store.get(timelineRangeAtom)).toEqual({ start: 1000, end: 5000 });
+  });
+
+  it("timelineRangeAtom can be reset to zero", () => {
+    const store = createStore();
+    store.set(timelineRangeAtom, { start: 1000, end: 5000 });
+    store.set(timelineRangeAtom, { start: 0, end: 0 });
+    expect(store.get(timelineRangeAtom)).toEqual({ start: 0, end: 0 });
+  });
+
+  it("timelineRangeAtom start and end are independent fields", () => {
+    const store = createStore();
+    store.set(timelineRangeAtom, { start: 500, end: 3000 });
+    const range = store.get(timelineRangeAtom);
+    expect(range.start).toBe(500);
+    expect(range.end).toBe(3000);
+  });
+
+  it("timelineKeyframesAtom can have keyframes added", () => {
+    const store = createStore();
+    store.set(timelineKeyframesAtom, [{ id: "kf1", time: 1000 }]);
+    expect(store.get(timelineKeyframesAtom)).toHaveLength(1);
+    expect(store.get(timelineKeyframesAtom)[0]).toEqual({ id: "kf1", time: 1000 });
+  });
+
+  it("timelineKeyframesAtom can hold multiple keyframes", () => {
+    const store = createStore();
+    const keyframes = [
+      { id: "kf1", time: 0 },
+      { id: "kf2", time: 500 },
+      { id: "kf3", time: 1000 },
+    ];
+    store.set(timelineKeyframesAtom, keyframes);
+    expect(store.get(timelineKeyframesAtom)).toHaveLength(3);
+  });
+
+  it("timelineKeyframesAtom can be cleared back to empty array", () => {
+    const store = createStore();
+    store.set(timelineKeyframesAtom, [{ id: "kf1", time: 500 }]);
+    store.set(timelineKeyframesAtom, []);
+    expect(store.get(timelineKeyframesAtom)).toEqual([]);
+  });
+
+  it("timelineKeyframesAtom allows multiple keyframes at the same time", () => {
+    const store = createStore();
+    store.set(timelineKeyframesAtom, [
+      { id: "kf1", time: 100 },
+      { id: "kf2", time: 100 },
+    ]);
+    expect(store.get(timelineKeyframesAtom)).toHaveLength(2);
+  });
+
+  it("timelineSelectedKeyframeIdAtom can be set to a keyframe ID", () => {
+    const store = createStore();
+    store.set(timelineSelectedKeyframeIdAtom, "kf-selected");
+    expect(store.get(timelineSelectedKeyframeIdAtom)).toBe("kf-selected");
+  });
+
+  it("timelineSelectedKeyframeIdAtom can be deselected (set to null)", () => {
+    const store = createStore();
+    store.set(timelineSelectedKeyframeIdAtom, "kf-1");
+    store.set(timelineSelectedKeyframeIdAtom, null);
+    expect(store.get(timelineSelectedKeyframeIdAtom)).toBeNull();
+  });
+
+  it("timelineCustomAspectWidthAtom can be updated", () => {
+    const store = createStore();
+    store.set(timelineCustomAspectWidthAtom, "4");
+    expect(store.get(timelineCustomAspectWidthAtom)).toBe("4");
+  });
+
+  it("timelineCustomAspectHeightAtom can be updated", () => {
+    const store = createStore();
+    store.set(timelineCustomAspectHeightAtom, "3");
+    expect(store.get(timelineCustomAspectHeightAtom)).toBe("3");
+  });
+
+  it("timelineScrollLabelsAtom can be customised", () => {
+    const store = createStore();
+    store.set(timelineScrollLabelsAtom, { pan: "Alt + Scroll", zoom: "Scroll" });
+    expect(store.get(timelineScrollLabelsAtom)).toEqual({
+      pan: "Alt + Scroll",
+      zoom: "Scroll",
+    });
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(timelineRangeAtom, { start: 0, end: 9999 });
+    storeA.set(timelineKeyframesAtom, [{ id: "kf1", time: 0 }]);
+    storeA.set(timelineSelectedKeyframeIdAtom, "kf1");
+
+    expect(storeB.get(timelineRangeAtom)).toEqual({ start: 0, end: 0 });
+    expect(storeB.get(timelineKeyframesAtom)).toEqual([]);
+    expect(storeB.get(timelineSelectedKeyframeIdAtom)).toBeNull();
+  });
+});

--- a/apps/desktop/src/atoms/updater.test.ts
+++ b/apps/desktop/src/atoms/updater.test.ts
@@ -1,0 +1,118 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+  type UpdateStatus,
+  updaterDialogOpenAtom,
+  updaterDownloadProgressAtom,
+  updaterErrorAtom,
+  updaterReleaseNotesAtom,
+  updaterStatusAtom,
+  updaterVersionAtom,
+} from "./updater";
+
+describe("updater atoms – write / read", () => {
+  it("updaterStatusAtom can be set to every UpdateStatus value", () => {
+    const statuses: UpdateStatus[] = [
+      "idle",
+      "checking",
+      "up-to-date",
+      "available",
+      "downloading",
+      "ready",
+      "error",
+    ];
+    const store = createStore();
+    for (const status of statuses) {
+      store.set(updaterStatusAtom, status);
+      expect(store.get(updaterStatusAtom)).toBe(status);
+    }
+  });
+
+  it("updaterStatusAtom transitions: idle → checking → available → downloading → ready", () => {
+    const store = createStore();
+    const flow: UpdateStatus[] = ["checking", "available", "downloading", "ready"];
+    for (const status of flow) {
+      store.set(updaterStatusAtom, status);
+      expect(store.get(updaterStatusAtom)).toBe(status);
+    }
+  });
+
+  it("updaterDialogOpenAtom can be opened and closed", () => {
+    const store = createStore();
+    store.set(updaterDialogOpenAtom, true);
+    expect(store.get(updaterDialogOpenAtom)).toBe(true);
+    store.set(updaterDialogOpenAtom, false);
+    expect(store.get(updaterDialogOpenAtom)).toBe(false);
+  });
+
+  it("updaterVersionAtom can be set to a semver string", () => {
+    const store = createStore();
+    store.set(updaterVersionAtom, "1.2.3");
+    expect(store.get(updaterVersionAtom)).toBe("1.2.3");
+  });
+
+  it("updaterVersionAtom can be cleared back to null", () => {
+    const store = createStore();
+    store.set(updaterVersionAtom, "2.0.0");
+    store.set(updaterVersionAtom, null);
+    expect(store.get(updaterVersionAtom)).toBeNull();
+  });
+
+  it("updaterReleaseNotesAtom can be set to a markdown string", () => {
+    const store = createStore();
+    const notes = "## v2.0.0\n- New feature\n- Bug fix";
+    store.set(updaterReleaseNotesAtom, notes);
+    expect(store.get(updaterReleaseNotesAtom)).toBe(notes);
+  });
+
+  it("updaterReleaseNotesAtom can be cleared to null", () => {
+    const store = createStore();
+    store.set(updaterReleaseNotesAtom, "some notes");
+    store.set(updaterReleaseNotesAtom, null);
+    expect(store.get(updaterReleaseNotesAtom)).toBeNull();
+  });
+
+  it("updaterDownloadProgressAtom can be set to boundary values 0 and 100", () => {
+    const store = createStore();
+    store.set(updaterDownloadProgressAtom, 0);
+    expect(store.get(updaterDownloadProgressAtom)).toBe(0);
+    store.set(updaterDownloadProgressAtom, 100);
+    expect(store.get(updaterDownloadProgressAtom)).toBe(100);
+  });
+
+  it("updaterDownloadProgressAtom tracks incremental progress", () => {
+    const store = createStore();
+    for (const pct of [0, 25, 50, 75, 100]) {
+      store.set(updaterDownloadProgressAtom, pct);
+      expect(store.get(updaterDownloadProgressAtom)).toBe(pct);
+    }
+  });
+
+  it("updaterErrorAtom can be set to an error message", () => {
+    const store = createStore();
+    store.set(updaterErrorAtom, "Network timeout");
+    expect(store.get(updaterErrorAtom)).toBe("Network timeout");
+  });
+
+  it("updaterErrorAtom can be cleared after an error is handled", () => {
+    const store = createStore();
+    store.set(updaterErrorAtom, "Something went wrong");
+    store.set(updaterErrorAtom, null);
+    expect(store.get(updaterErrorAtom)).toBeNull();
+  });
+
+  it("writes to one store do not affect another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(updaterStatusAtom, "available");
+    storeA.set(updaterVersionAtom, "3.0.0");
+    storeA.set(updaterDialogOpenAtom, true);
+    storeA.set(updaterDownloadProgressAtom, 42);
+
+    expect(storeB.get(updaterStatusAtom)).toBe("idle");
+    expect(storeB.get(updaterVersionAtom)).toBeNull();
+    expect(storeB.get(updaterDialogOpenAtom)).toBe(false);
+    expect(storeB.get(updaterDownloadProgressAtom)).toBe(0);
+  });
+});

--- a/apps/desktop/src/atoms/videoEditor.test.ts
+++ b/apps/desktop/src/atoms/videoEditor.test.ts
@@ -1,0 +1,451 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import type { AnnotationRegion, CropRegion, SpeedRegion, TrimRegion, ZoomRegion } from "@/components/video-editor/types";
+import type { ExportProgress } from "@/lib/exporter";
+import type { AspectRatio } from "@/utils/aspectRatioUtils";
+import {
+  annotationRegionsAtom,
+  aspectRatioAtom,
+  audioMutedAtom,
+  audioVolumeAtom,
+  backgroundBlurAtom,
+  borderRadiusAtom,
+  connectZoomsAtom,
+  cropRegionAtom,
+  currentProjectPathAtom,
+  cursorSettingsAtom,
+  type CursorSettings,
+  durationAtom,
+  exportErrorAtom,
+  exportFormatAtom,
+  exportProgressAtom,
+  exportQualityAtom,
+  exportedFilePathAtom,
+  facecamOffsetMsAtom,
+  facecamPlaybackPathAtom,
+  facecamVideoPathAtom,
+  gifFrameRateAtom,
+  gifLoopAtom,
+  gifSizePresetAtom,
+  hasPendingExportSaveAtom,
+  isExportingAtom,
+  isPlayingAtom,
+  lastSavedSnapshotAtom,
+  paddingAtom,
+  playbackReadyAtom,
+  selectedAnnotationIdAtom,
+  selectedSpeedIdAtom,
+  selectedTrimIdAtom,
+  selectedZoomIdAtom,
+  shadowIntensityAtom,
+  showExportDialogAtom,
+  showShortcutsDialogAtom,
+  sourceNameAtom,
+  speedRegionsAtom,
+  trimRegionsAtom,
+  videoErrorAtom,
+  videoLoadingAtom,
+  videoPathAtom,
+  videoSourcePathAtom,
+  zoomMotionBlurAtom,
+  zoomRegionsAtom,
+} from "./videoEditor";
+
+// ─── Video source atoms ────────────────────────────────────────────────────
+
+describe("videoEditor atoms – video source", () => {
+  it("videoPathAtom can be set to a file path", () => {
+    const store = createStore();
+    store.set(videoPathAtom, "/recordings/session.mp4");
+    expect(store.get(videoPathAtom)).toBe("/recordings/session.mp4");
+  });
+
+  it("videoPathAtom can be cleared to null", () => {
+    const store = createStore();
+    store.set(videoPathAtom, "/recordings/session.mp4");
+    store.set(videoPathAtom, null);
+    expect(store.get(videoPathAtom)).toBeNull();
+  });
+
+  it("videoSourcePathAtom can be set independently of videoPathAtom", () => {
+    const store = createStore();
+    store.set(videoPathAtom, "/recordings/session.mp4");
+    store.set(videoSourcePathAtom, "/recordings/original.mp4");
+    expect(store.get(videoPathAtom)).toBe("/recordings/session.mp4");
+    expect(store.get(videoSourcePathAtom)).toBe("/recordings/original.mp4");
+  });
+
+  it("sourceNameAtom can be set to a display name", () => {
+    const store = createStore();
+    store.set(sourceNameAtom, "Zoom Meeting");
+    expect(store.get(sourceNameAtom)).toBe("Zoom Meeting");
+  });
+
+  it("facecamVideoPathAtom can be set and cleared", () => {
+    const store = createStore();
+    store.set(facecamVideoPathAtom, "/facecam/face.mp4");
+    expect(store.get(facecamVideoPathAtom)).toBe("/facecam/face.mp4");
+    store.set(facecamVideoPathAtom, null);
+    expect(store.get(facecamVideoPathAtom)).toBeNull();
+  });
+
+  it("facecamPlaybackPathAtom can be set independently", () => {
+    const store = createStore();
+    store.set(facecamPlaybackPathAtom, "/facecam/playback.mp4");
+    expect(store.get(facecamPlaybackPathAtom)).toBe("/facecam/playback.mp4");
+  });
+
+  it("facecamOffsetMsAtom accepts positive and negative offsets", () => {
+    const store = createStore();
+    store.set(facecamOffsetMsAtom, 250);
+    expect(store.get(facecamOffsetMsAtom)).toBe(250);
+    store.set(facecamOffsetMsAtom, -500);
+    expect(store.get(facecamOffsetMsAtom)).toBe(-500);
+  });
+
+  it("currentProjectPathAtom can be set to a project directory", () => {
+    const store = createStore();
+    store.set(currentProjectPathAtom, "/projects/my-project");
+    expect(store.get(currentProjectPathAtom)).toBe("/projects/my-project");
+  });
+});
+
+// ─── Loading / error state atoms ──────────────────────────────────────────
+
+describe("videoEditor atoms – loading and error state", () => {
+  it("videoLoadingAtom can be set to false once loaded", () => {
+    const store = createStore();
+    store.set(videoLoadingAtom, false);
+    expect(store.get(videoLoadingAtom)).toBe(false);
+  });
+
+  it("playbackReadyAtom can be set to true when ready", () => {
+    const store = createStore();
+    store.set(playbackReadyAtom, true);
+    expect(store.get(playbackReadyAtom)).toBe(true);
+  });
+
+  it("videoErrorAtom can be set to an error message", () => {
+    const store = createStore();
+    store.set(videoErrorAtom, "Failed to decode video");
+    expect(store.get(videoErrorAtom)).toBe("Failed to decode video");
+  });
+
+  it("videoErrorAtom can be cleared after recovery", () => {
+    const store = createStore();
+    store.set(videoErrorAtom, "Decoding error");
+    store.set(videoErrorAtom, null);
+    expect(store.get(videoErrorAtom)).toBeNull();
+  });
+});
+
+// ─── Playback state atoms ─────────────────────────────────────────────────
+
+describe("videoEditor atoms – playback state", () => {
+  it("isPlayingAtom can be toggled to true and false", () => {
+    const store = createStore();
+    store.set(isPlayingAtom, true);
+    expect(store.get(isPlayingAtom)).toBe(true);
+    store.set(isPlayingAtom, false);
+    expect(store.get(isPlayingAtom)).toBe(false);
+  });
+
+  it("durationAtom can be set to a positive number of milliseconds", () => {
+    const store = createStore();
+    store.set(durationAtom, 120_000); // 2 minutes
+    expect(store.get(durationAtom)).toBe(120_000);
+  });
+});
+
+// ─── Appearance setting atoms ─────────────────────────────────────────────
+
+describe("videoEditor atoms – appearance settings", () => {
+  it("audioMutedAtom can be toggled", () => {
+    const store = createStore();
+    store.set(audioMutedAtom, true);
+    expect(store.get(audioMutedAtom)).toBe(true);
+  });
+
+  it("audioVolumeAtom accepts values from 0 to 1", () => {
+    const store = createStore();
+    for (const vol of [0, 0.25, 0.5, 0.75, 1]) {
+      store.set(audioVolumeAtom, vol);
+      expect(store.get(audioVolumeAtom)).toBe(vol);
+    }
+  });
+
+  it("shadowIntensityAtom can be set to boundary values 0 and 1", () => {
+    const store = createStore();
+    store.set(shadowIntensityAtom, 0);
+    expect(store.get(shadowIntensityAtom)).toBe(0);
+    store.set(shadowIntensityAtom, 1);
+    expect(store.get(shadowIntensityAtom)).toBe(1);
+  });
+
+  it("backgroundBlurAtom can be set to non-zero values", () => {
+    const store = createStore();
+    store.set(backgroundBlurAtom, 20);
+    expect(store.get(backgroundBlurAtom)).toBe(20);
+  });
+
+  it("zoomMotionBlurAtom can be adjusted", () => {
+    const store = createStore();
+    store.set(zoomMotionBlurAtom, 0);
+    expect(store.get(zoomMotionBlurAtom)).toBe(0);
+    store.set(zoomMotionBlurAtom, 1);
+    expect(store.get(zoomMotionBlurAtom)).toBe(1);
+  });
+
+  it("borderRadiusAtom can be set to 0 (sharp corners)", () => {
+    const store = createStore();
+    store.set(borderRadiusAtom, 0);
+    expect(store.get(borderRadiusAtom)).toBe(0);
+  });
+
+  it("paddingAtom can be set to 0 (no padding)", () => {
+    const store = createStore();
+    store.set(paddingAtom, 0);
+    expect(store.get(paddingAtom)).toBe(0);
+  });
+
+  it("connectZoomsAtom can be disabled", () => {
+    const store = createStore();
+    store.set(connectZoomsAtom, false);
+    expect(store.get(connectZoomsAtom)).toBe(false);
+  });
+});
+
+// ─── Cursor settings atom ─────────────────────────────────────────────────
+
+describe("videoEditor atoms – cursor settings", () => {
+  it("cursorSettingsAtom can be updated with partial values", () => {
+    const store = createStore();
+    const before = store.get(cursorSettingsAtom);
+    const updated: CursorSettings = { ...before, showCursor: false };
+    store.set(cursorSettingsAtom, updated);
+    expect(store.get(cursorSettingsAtom).showCursor).toBe(false);
+  });
+
+  it("cursorSettingsAtom can enable loopCursor", () => {
+    const store = createStore();
+    const before = store.get(cursorSettingsAtom);
+    store.set(cursorSettingsAtom, { ...before, loopCursor: true });
+    expect(store.get(cursorSettingsAtom).loopCursor).toBe(true);
+  });
+
+  it("cursorSettingsAtom preserves unmodified fields when one field changes", () => {
+    const store = createStore();
+    const before = store.get(cursorSettingsAtom);
+    store.set(cursorSettingsAtom, { ...before, cursorSize: 5 });
+    const after = store.get(cursorSettingsAtom);
+    expect(after.cursorSize).toBe(5);
+    expect(after.showCursor).toBe(before.showCursor);
+    expect(after.loopCursor).toBe(before.loopCursor);
+    expect(after.cursorSmoothing).toBe(before.cursorSmoothing);
+  });
+});
+
+// ─── Region / selection atoms ─────────────────────────────────────────────
+
+describe("videoEditor atoms – regions and selections", () => {
+  it("cropRegionAtom can be updated to a custom crop", () => {
+    const crop: CropRegion = { x: 0.1, y: 0.1, width: 0.8, height: 0.8 };
+    const store = createStore();
+    store.set(cropRegionAtom, crop);
+    expect(store.get(cropRegionAtom)).toEqual(crop);
+  });
+
+  it("zoomRegionsAtom can have a region added", () => {
+    const store = createStore();
+    const region: ZoomRegion = {
+      id: "z1",
+      startMs: 0,
+      endMs: 1000,
+      depth: 2,
+      focus: { cx: 0.5, cy: 0.5 },
+    };
+    store.set(zoomRegionsAtom, [region]);
+    expect(store.get(zoomRegionsAtom)).toHaveLength(1);
+    expect(store.get(zoomRegionsAtom)[0].id).toBe("z1");
+  });
+
+  it("selectedZoomIdAtom can be set and cleared", () => {
+    const store = createStore();
+    store.set(selectedZoomIdAtom, "z1");
+    expect(store.get(selectedZoomIdAtom)).toBe("z1");
+    store.set(selectedZoomIdAtom, null);
+    expect(store.get(selectedZoomIdAtom)).toBeNull();
+  });
+
+  it("trimRegionsAtom can have a trim region added", () => {
+    const store = createStore();
+    const trim: TrimRegion = { id: "t1", startMs: 500, endMs: 1500 };
+    store.set(trimRegionsAtom, [trim]);
+    expect(store.get(trimRegionsAtom)).toHaveLength(1);
+    expect(store.get(trimRegionsAtom)[0]).toEqual(trim);
+  });
+
+  it("selectedTrimIdAtom can be set and cleared", () => {
+    const store = createStore();
+    store.set(selectedTrimIdAtom, "t1");
+    expect(store.get(selectedTrimIdAtom)).toBe("t1");
+    store.set(selectedTrimIdAtom, null);
+    expect(store.get(selectedTrimIdAtom)).toBeNull();
+  });
+
+  it("speedRegionsAtom can have a speed region added", () => {
+    const store = createStore();
+    const speed: SpeedRegion = { id: "s1", startMs: 0, endMs: 2000, speed: 2 };
+    store.set(speedRegionsAtom, [speed]);
+    expect(store.get(speedRegionsAtom)).toHaveLength(1);
+  });
+
+  it("annotationRegionsAtom can have multiple annotations added", () => {
+    const store = createStore();
+    const a1 = { id: "a1" } as AnnotationRegion;
+    const a2 = { id: "a2" } as AnnotationRegion;
+    store.set(annotationRegionsAtom, [a1, a2]);
+    expect(store.get(annotationRegionsAtom)).toHaveLength(2);
+  });
+
+  it("selectedAnnotationIdAtom can be set and cleared", () => {
+    const store = createStore();
+    store.set(selectedAnnotationIdAtom, "a1");
+    expect(store.get(selectedAnnotationIdAtom)).toBe("a1");
+    store.set(selectedAnnotationIdAtom, null);
+    expect(store.get(selectedAnnotationIdAtom)).toBeNull();
+  });
+});
+
+// ─── Export state atoms ───────────────────────────────────────────────────
+
+describe("videoEditor atoms – export state", () => {
+  it("isExportingAtom can be set to true during export", () => {
+    const store = createStore();
+    store.set(isExportingAtom, true);
+    expect(store.get(isExportingAtom)).toBe(true);
+  });
+
+  it("exportProgressAtom can be set to a progress object", () => {
+    const store = createStore();
+    const progress: ExportProgress = { framesRendered: 10, totalFrames: 100 };
+    store.set(exportProgressAtom, progress);
+    expect(store.get(exportProgressAtom)).toEqual(progress);
+  });
+
+  it("exportProgressAtom can be cleared after export finishes", () => {
+    const store = createStore();
+    store.set(exportProgressAtom, { framesRendered: 100, totalFrames: 100 });
+    store.set(exportProgressAtom, null);
+    expect(store.get(exportProgressAtom)).toBeNull();
+  });
+
+  it("exportErrorAtom can be set and cleared", () => {
+    const store = createStore();
+    store.set(exportErrorAtom, "Write failed");
+    expect(store.get(exportErrorAtom)).toBe("Write failed");
+    store.set(exportErrorAtom, null);
+    expect(store.get(exportErrorAtom)).toBeNull();
+  });
+
+  it("showExportDialogAtom can be opened and closed", () => {
+    const store = createStore();
+    store.set(showExportDialogAtom, true);
+    expect(store.get(showExportDialogAtom)).toBe(true);
+    store.set(showExportDialogAtom, false);
+    expect(store.get(showExportDialogAtom)).toBe(false);
+  });
+
+  it("showShortcutsDialogAtom can be opened and closed", () => {
+    const store = createStore();
+    store.set(showShortcutsDialogAtom, true);
+    expect(store.get(showShortcutsDialogAtom)).toBe(true);
+    store.set(showShortcutsDialogAtom, false);
+    expect(store.get(showShortcutsDialogAtom)).toBe(false);
+  });
+
+  it("aspectRatioAtom accepts all common aspect ratios", () => {
+    const ratios: AspectRatio[] = ["16:9", "9:16", "1:1", "4:3", "custom"];
+    const store = createStore();
+    for (const ratio of ratios) {
+      store.set(aspectRatioAtom, ratio);
+      expect(store.get(aspectRatioAtom)).toBe(ratio);
+    }
+  });
+
+  it("exportQualityAtom can be changed to low or high", () => {
+    const store = createStore();
+    store.set(exportQualityAtom, "low");
+    expect(store.get(exportQualityAtom)).toBe("low");
+    store.set(exportQualityAtom, "high");
+    expect(store.get(exportQualityAtom)).toBe("high");
+  });
+
+  it("exportFormatAtom can be set to gif", () => {
+    const store = createStore();
+    store.set(exportFormatAtom, "gif");
+    expect(store.get(exportFormatAtom)).toBe("gif");
+  });
+
+  it("gifFrameRateAtom can be set to supported values", () => {
+    const store = createStore();
+    store.set(gifFrameRateAtom, 10);
+    expect(store.get(gifFrameRateAtom)).toBe(10);
+    store.set(gifFrameRateAtom, 30);
+    expect(store.get(gifFrameRateAtom)).toBe(30);
+  });
+
+  it("gifLoopAtom can be disabled", () => {
+    const store = createStore();
+    store.set(gifLoopAtom, false);
+    expect(store.get(gifLoopAtom)).toBe(false);
+  });
+
+  it("gifSizePresetAtom can be changed", () => {
+    const store = createStore();
+    store.set(gifSizePresetAtom, "large");
+    expect(store.get(gifSizePresetAtom)).toBe("large");
+    store.set(gifSizePresetAtom, "small");
+    expect(store.get(gifSizePresetAtom)).toBe("small");
+  });
+
+  it("exportedFilePathAtom can be set after a successful export", () => {
+    const store = createStore();
+    store.set(exportedFilePathAtom, "/exports/output.mp4");
+    expect(store.get(exportedFilePathAtom)).toBe("/exports/output.mp4");
+  });
+
+  it("hasPendingExportSaveAtom can be toggled", () => {
+    const store = createStore();
+    store.set(hasPendingExportSaveAtom, true);
+    expect(store.get(hasPendingExportSaveAtom)).toBe(true);
+  });
+
+  it("lastSavedSnapshotAtom can store a JSON snapshot string", () => {
+    const store = createStore();
+    const snapshot = JSON.stringify({ version: 1, data: "abc" });
+    store.set(lastSavedSnapshotAtom, snapshot);
+    expect(store.get(lastSavedSnapshotAtom)).toBe(snapshot);
+  });
+});
+
+// ─── Store isolation ──────────────────────────────────────────────────────
+
+describe("videoEditor atoms – store isolation", () => {
+  it("writes to one store do not bleed into another store", () => {
+    const storeA = createStore();
+    const storeB = createStore();
+
+    storeA.set(videoPathAtom, "/recordings/a.mp4");
+    storeA.set(isPlayingAtom, true);
+    storeA.set(durationAtom, 60_000);
+    storeA.set(isExportingAtom, true);
+    storeA.set(aspectRatioAtom, "1:1");
+
+    expect(storeB.get(videoPathAtom)).toBeNull();
+    expect(storeB.get(isPlayingAtom)).toBe(false);
+    expect(storeB.get(durationAtom)).toBe(0);
+    expect(storeB.get(isExportingAtom)).toBe(false);
+    expect(storeB.get(aspectRatioAtom)).toBe("16:9");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 11 new test files (one per atom source file in `apps/desktop/src/atoms/`)
- **173 new test cases** covering write/read behaviour, state transitions, edge cases, and store isolation
- All tests use `createStore()` from `jotai/vanilla` for hermatic, dependency-free isolation
- Pre-existing `gifExporter.test.ts` failure (pixi.js `navigator` issue at module-load time) is unchanged

## Test files added

| File | Tests | Coverage focus |
|---|---|---|
| `app.test.ts` | 8 | `windowTypeAtom`, `appNameAtom`, `isMacOSAtom` |
| `recording.test.ts` | 12 | recording/microphone/camera atom write-read cycles |
| `permissions.test.ts` | 14 | all six `PermissionStatus` values, key-level updates, transitions |
| `updater.test.ts` | 12 | all `UpdateStatus` cycle, progress 0→100, error lifecycle |
| `timeline.test.ts` | 13 | range, keyframes CRUD, aspect-ratio strings, scroll labels |
| `settingsPanel.test.ts` | 12 | all sidebar/background tabs, custom images, color/gradient updates |
| `shortcuts.test.ts` | 11 | `ShortcutsConfig` per-binding updates, open/close, reset to defaults |
| `imageEditor.test.ts` | 19 | src path, dimensions, all `ImageBackgroundType` values, effects |
| `videoEditor.test.ts` | 49 | source paths, loading/error, playback, appearance, regions, export flow |
| `launch.test.ts` | 12 | every `LaunchView`/`ScreenshotMode`, timer atoms, source selection |
| `sourceSelector.test.ts` | 11 | tab toggle, sources array CRUD, loading flag independence |

## Test plan

- [x] `pnpm test` run from `apps/desktop` — all 11 new files pass (173/173 tests green)
- [x] Pre-existing `gifExporter.test.ts` failure confirmed unchanged (pixi.js issue, not related to atoms)
- [x] Store isolation verified across all atom groups (writes in store A do not affect store B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)