### PR TITLE
test: 114 Jotai edge-case tests (race conditions, stale closures, errors, memory, storage, boundary values)

### DIFF
--- a/apps/desktop/src/__tests__/edge-cases/jotai-boundary-values.test.ts
+++ b/apps/desktop/src/__tests__/edge-cases/jotai-boundary-values.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Boundary Value Tests for Jotai State Management
+ *
+ * Covers: extremely large/small numbers, NaN/Infinity, empty and huge
+ * strings, null/undefined transitions, empty/large arrays, deeply
+ * nested objects, rapid value toggling, and special JS edge cases.
+ */
+
+import { atom } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import {
+	audioVolumeAtom,
+	borderRadiusAtom,
+	durationAtom,
+	shadowIntensityAtom,
+	trimRegionsAtom,
+	zoomRegionsAtom,
+} from "@/atoms/videoEditor";
+import { recordingElapsedAtom } from "@/atoms/launch";
+import { imagePaddingAtom } from "@/atoms/imageEditor";
+
+describe("boundary values", () => {
+	it("stores Number.MAX_SAFE_INTEGER without precision loss", () => {
+		const store = createStore();
+		const bigAtom = atom(0);
+
+		store.set(bigAtom, Number.MAX_SAFE_INTEGER);
+
+		expect(store.get(bigAtom)).toBe(Number.MAX_SAFE_INTEGER);
+	});
+
+	it("stores Number.MIN_SAFE_INTEGER without precision loss", () => {
+		const store = createStore();
+		const negAtom = atom(0);
+
+		store.set(negAtom, Number.MIN_SAFE_INTEGER);
+
+		expect(store.get(negAtom)).toBe(Number.MIN_SAFE_INTEGER);
+	});
+
+	it("stores NaN and retrieves it correctly", () => {
+		const store = createStore();
+		const nanAtom = atom<number>(0);
+
+		store.set(nanAtom, Number.NaN);
+
+		expect(Number.isNaN(store.get(nanAtom))).toBe(true);
+	});
+
+	it("stores Infinity correctly", () => {
+		const store = createStore();
+		const infAtom = atom(0);
+
+		store.set(infAtom, Number.POSITIVE_INFINITY);
+
+		expect(store.get(infAtom)).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("stores negative Infinity correctly", () => {
+		const store = createStore();
+		const negInfAtom = atom(0);
+
+		store.set(negInfAtom, Number.NEGATIVE_INFINITY);
+
+		expect(store.get(negInfAtom)).toBe(Number.NEGATIVE_INFINITY);
+	});
+
+	it("stores negative zero and distinguishes it from positive zero via Object.is", () => {
+		const store = createStore();
+		const zeroAtom = atom(0);
+
+		store.set(zeroAtom, -0);
+
+		expect(Object.is(store.get(zeroAtom), -0)).toBe(true);
+		expect(Object.is(store.get(zeroAtom), 0)).toBe(false);
+	});
+
+	it("stores an empty string without coercion", () => {
+		const store = createStore();
+		const strAtom = atom("non-empty");
+
+		store.set(strAtom, "");
+
+		expect(store.get(strAtom)).toBe("");
+	});
+
+	it("stores a 100 000-character string without truncation", () => {
+		const store = createStore();
+		const longStrAtom = atom("");
+		const longString = "a".repeat(100_000);
+
+		store.set(longStrAtom, longString);
+
+		const stored = store.get(longStrAtom);
+		expect(stored.length).toBe(100_000);
+		expect(stored[0]).toBe("a");
+		expect(stored[99_999]).toBe("a");
+	});
+
+	it("stores a string containing only whitespace", () => {
+		const store = createStore();
+		const wsAtom = atom("default");
+
+		store.set(wsAtom, "   \t\n   ");
+
+		expect(store.get(wsAtom)).toBe("   \t\n   ");
+	});
+
+	it("stores emoji and multi-byte unicode characters correctly", () => {
+		const store = createStore();
+		const emojiAtom = atom("");
+
+		const emoji = "🎬🎤🎥📽️🎞️";
+		store.set(emojiAtom, emoji);
+
+		expect(store.get(emojiAtom)).toBe(emoji);
+	});
+
+	it("transitions from null to a value and back to null", () => {
+		const store = createStore();
+		const nullableAtom = atom<string | null>(null);
+
+		expect(store.get(nullableAtom)).toBeNull();
+
+		store.set(nullableAtom, "some value");
+		expect(store.get(nullableAtom)).toBe("some value");
+
+		store.set(nullableAtom, null);
+		expect(store.get(nullableAtom)).toBeNull();
+	});
+
+	it("transitions from undefined to a defined value and back to undefined", () => {
+		const store = createStore();
+		const undefinedAtom = atom<string | undefined>(undefined);
+
+		expect(store.get(undefinedAtom)).toBeUndefined();
+
+		store.set(undefinedAtom, "defined");
+		expect(store.get(undefinedAtom)).toBe("defined");
+
+		store.set(undefinedAtom, undefined);
+		expect(store.get(undefinedAtom)).toBeUndefined();
+	});
+
+	it("stores an empty array without modification", () => {
+		const store = createStore();
+		const arrAtom = atom<number[]>([1, 2, 3]);
+
+		store.set(arrAtom, []);
+
+		expect(store.get(arrAtom)).toEqual([]);
+	});
+
+	it("stores a 10 000-element array correctly", () => {
+		const store = createStore();
+		const bigArrAtom = atom<number[]>([]);
+		const bigArray = Array.from({ length: 10_000 }, (_, i) => i);
+
+		store.set(bigArrAtom, bigArray);
+
+		const stored = store.get(bigArrAtom);
+		expect(stored.length).toBe(10_000);
+		expect(stored[0]).toBe(0);
+		expect(stored[9_999]).toBe(9_999);
+	});
+
+	it("stores an empty object without adding extra keys", () => {
+		const store = createStore();
+		const objAtom = atom<Record<string, unknown>>({ initial: true });
+
+		store.set(objAtom, {});
+
+		expect(store.get(objAtom)).toEqual({});
+	});
+
+	it("stores a deeply-nested object (10 levels) correctly", () => {
+		const store = createStore();
+		type Nested = { child?: Nested; value: number };
+		const deepAtom = atom<Nested>({ value: 0 });
+
+		let deep: Nested = { value: 10 };
+		for (let i = 0; i < 9; i++) {
+			deep = { child: deep, value: i };
+		}
+
+		store.set(deepAtom, deep);
+		let current: Nested | undefined = store.get(deepAtom);
+		let depth = 0;
+		while (current?.child) {
+			current = current.child;
+			depth++;
+		}
+
+		expect(depth).toBe(9);
+		expect(current?.value).toBe(10);
+	});
+
+	it("rapid null/value toggling settles to the final state", () => {
+		const store = createStore();
+		const nullableAtom = atom<string | null>(null);
+
+		for (let i = 0; i < 500; i++) {
+			store.set(nullableAtom, i % 2 === 0 ? null : "active");
+		}
+
+		// Last i=499: 499%2=1 → "active"
+		expect(store.get(nullableAtom)).toBe("active");
+	});
+
+	it("real atom: durationAtom handles a zero-length video (0ms)", () => {
+		const store = createStore();
+
+		store.set(durationAtom, 0);
+
+		expect(store.get(durationAtom)).toBe(0);
+	});
+
+	it("real atom: durationAtom handles an extremely long video (24-hour duration in ms)", () => {
+		const store = createStore();
+		const twentyFourHoursMs = 24 * 60 * 60 * 1000;
+
+		store.set(durationAtom, twentyFourHoursMs);
+
+		expect(store.get(durationAtom)).toBe(twentyFourHoursMs);
+	});
+
+	it("real atom: audioVolumeAtom handles boundary values 0 and 1 cleanly", () => {
+		const store = createStore();
+
+		store.set(audioVolumeAtom, 0);
+		expect(store.get(audioVolumeAtom)).toBe(0);
+
+		store.set(audioVolumeAtom, 1);
+		expect(store.get(audioVolumeAtom)).toBe(1);
+	});
+
+	it("real atom: borderRadiusAtom handles 0 (no rounding) and 9999 (extreme)", () => {
+		const store = createStore();
+
+		store.set(borderRadiusAtom, 0);
+		expect(store.get(borderRadiusAtom)).toBe(0);
+
+		store.set(borderRadiusAtom, 9999);
+		expect(store.get(borderRadiusAtom)).toBe(9999);
+	});
+
+	it("real atom: shadowIntensityAtom handles the full 0.0–1.0 boundary", () => {
+		const store = createStore();
+
+		store.set(shadowIntensityAtom, 0.0);
+		expect(store.get(shadowIntensityAtom)).toBe(0.0);
+
+		store.set(shadowIntensityAtom, 1.0);
+		expect(store.get(shadowIntensityAtom)).toBe(1.0);
+	});
+
+	it("real atom: zoomRegionsAtom handles an empty array and then a large array", () => {
+		const store = createStore();
+
+		store.set(zoomRegionsAtom, []);
+		expect(store.get(zoomRegionsAtom)).toHaveLength(0);
+
+		const manyRegions = Array.from({ length: 500 }, (_, i) => ({
+			id: `z-${i}`,
+			startTime: i * 10,
+			endTime: i * 10 + 5,
+			x: 0,
+			y: 0,
+			width: 1,
+			height: 1,
+			scale: 2,
+		}));
+		store.set(zoomRegionsAtom, manyRegions);
+		expect(store.get(zoomRegionsAtom)).toHaveLength(500);
+	});
+
+	it("real atom: trimRegionsAtom is empty by default and handles boundary region count", () => {
+		const store = createStore();
+
+		expect(store.get(trimRegionsAtom)).toHaveLength(0);
+
+		const oneRegion = [{ id: "t-0", startTime: 0, endTime: 1000 }];
+		store.set(trimRegionsAtom, oneRegion);
+		expect(store.get(trimRegionsAtom)).toHaveLength(1);
+	});
+
+	it("real atom: recordingElapsedAtom handles a very large elapsed time", () => {
+		const store = createStore();
+		const tenHoursSeconds = 10 * 60 * 60;
+
+		store.set(recordingElapsedAtom, tenHoursSeconds);
+
+		expect(store.get(recordingElapsedAtom)).toBe(tenHoursSeconds);
+	});
+
+	it("real atom: imagePaddingAtom at minimum 0 and very large 9999", () => {
+		const store = createStore();
+
+		store.set(imagePaddingAtom, 0);
+		expect(store.get(imagePaddingAtom)).toBe(0);
+
+		store.set(imagePaddingAtom, 9999);
+		expect(store.get(imagePaddingAtom)).toBe(9999);
+	});
+});

--- a/apps/desktop/src/__tests__/edge-cases/jotai-error-handling.test.ts
+++ b/apps/desktop/src/__tests__/edge-cases/jotai-error-handling.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Error Handling Tests for Jotai State Management
+ *
+ * Covers: derived atoms that throw on read, async atoms that reject,
+ * write atoms with throwing setters, store recovery after errors,
+ * and error isolation between stores.
+ */
+
+import { atom } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import { videoErrorAtom, exportErrorAtom, isExportingAtom } from "@/atoms/videoEditor";
+import { updaterErrorAtom, updaterStatusAtom } from "@/atoms/updater";
+
+describe("error handling", () => {
+	it("derived atom that throws propagates the error to the caller", () => {
+		const store = createStore();
+		const throwingAtom = atom<string>(() => {
+			throw new Error("read error");
+		});
+
+		expect(() => store.get(throwingAtom)).toThrow("read error");
+	});
+
+	it("store continues to function normally after a derived atom throws", () => {
+		const store = createStore();
+		const throwingAtom = atom<number>(() => {
+			throw new Error("boom");
+		});
+		const healthyAtom = atom(42);
+
+		try {
+			store.get(throwingAtom);
+		} catch {
+			// expected
+		}
+
+		expect(store.get(healthyAtom)).toBe(42);
+	});
+
+	it("async atom that rejects exposes a rejected promise", async () => {
+		const store = createStore();
+		const rejectingAtom = atom(async () => {
+			await Promise.resolve();
+			throw new Error("async rejection");
+		});
+
+		await expect(store.get(rejectingAtom)).rejects.toThrow("async rejection");
+	});
+
+	it("async atom rejection does not corrupt sibling atoms", async () => {
+		const store = createStore();
+		const rejectingAtom = atom(async () => {
+			throw new Error("rejected");
+		});
+		const safeAtom = atom("safe-value");
+
+		try {
+			await store.get(rejectingAtom);
+		} catch {
+			// expected
+		}
+
+		expect(store.get(safeAtom)).toBe("safe-value");
+	});
+
+	it("write atom with throwing setter propagates the error", () => {
+		const store = createStore();
+		const dataAtom = atom(0);
+		const badWriteAtom = atom(null, (_get, _set) => {
+			throw new Error("write failed");
+		});
+
+		store.set(dataAtom, 5);
+		expect(() => store.set(badWriteAtom)).toThrow("write failed");
+
+		// Underlying atom is unchanged after failed write
+		expect(store.get(dataAtom)).toBe(5);
+	});
+
+	it("write atom that conditionally throws leaves atom unchanged when it throws", () => {
+		const store = createStore();
+		const safeAtom = atom(10);
+		const conditionalWriteAtom = atom(null, (get, set, shouldThrow: boolean) => {
+			if (shouldThrow) throw new Error("conditional failure");
+			set(safeAtom, get(safeAtom) + 1);
+		});
+
+		expect(() => store.set(conditionalWriteAtom, true)).toThrow("conditional failure");
+		// Value should be unchanged because the write threw before the set
+		expect(store.get(safeAtom)).toBe(10);
+
+		store.set(conditionalWriteAtom, false); // succeeds — value becomes 11
+		expect(store.get(safeAtom)).toBe(11);
+	});
+
+	it("error in one store does not affect an independent store", () => {
+		const throwingDef = atom<string>(() => {
+			throw new Error("store A error");
+		});
+		const storeA = createStore();
+		const storeB = createStore();
+		const healthyAtom = atom("healthy");
+
+		try {
+			storeA.get(throwingDef);
+		} catch {
+			// expected
+		}
+
+		// storeB is completely unaffected
+		expect(storeB.get(healthyAtom)).toBe("healthy");
+	});
+
+	it("derived atom with internal try/catch provides fallback on error", () => {
+		const store = createStore();
+		const riskyAtom = atom<number>(() => {
+			throw new Error("risky computation");
+		});
+		const safeWrapperAtom = atom((get) => {
+			try {
+				return get(riskyAtom);
+			} catch {
+				return -1; // fallback
+			}
+		});
+
+		expect(store.get(safeWrapperAtom)).toBe(-1);
+	});
+
+	it("multiple sequential async rejections are each independent", async () => {
+		const store = createStore();
+		const errors: string[] = [];
+
+		for (let i = 0; i < 3; i++) {
+			const attempt = i;
+			const failingAtom = atom(async () => {
+				throw new Error(`failure-${attempt}`);
+			});
+			try {
+				await store.get(failingAtom);
+			} catch (e) {
+				errors.push((e as Error).message);
+			}
+		}
+
+		expect(errors).toEqual(["failure-0", "failure-1", "failure-2"]);
+	});
+
+	it("async atom with recovery: second call after rejection resolves correctly", async () => {
+		const store = createStore();
+		let shouldFail = true;
+
+		const conditionalAsyncAtom = atom(async () => {
+			if (shouldFail) throw new Error("temporary failure");
+			return "success";
+		});
+
+		await expect(store.get(conditionalAsyncAtom)).rejects.toThrow("temporary failure");
+
+		shouldFail = false;
+		// New atom call (new atom instance) should succeed
+		const recoveredAtom = atom(async () => {
+			if (shouldFail) throw new Error("temporary failure");
+			return "success";
+		});
+		await expect(store.get(recoveredAtom)).resolves.toBe("success");
+	});
+
+	it("subscription survives a write-atom error and continues notifying on subsequent valid writes", () => {
+		const store = createStore();
+		const trackAtom = atom(0);
+		const badWriteAtom = atom(null, (_get, _set) => {
+			throw new Error("set error");
+		});
+		const notifications: number[] = [];
+
+		store.sub(trackAtom, () => {
+			notifications.push(store.get(trackAtom));
+		});
+
+		store.set(trackAtom, 1);
+
+		try {
+			store.set(badWriteAtom);
+		} catch {
+			// expected
+		}
+
+		store.set(trackAtom, 2);
+
+		expect(notifications).toEqual([1, 2]);
+	});
+
+	it("real atom: videoErrorAtom can be set to an error string and then cleared", () => {
+		const store = createStore();
+
+		expect(store.get(videoErrorAtom)).toBeNull();
+
+		store.set(videoErrorAtom, "Failed to load video");
+		expect(store.get(videoErrorAtom)).toBe("Failed to load video");
+
+		store.set(videoErrorAtom, null);
+		expect(store.get(videoErrorAtom)).toBeNull();
+	});
+
+	it("real atom: exportErrorAtom and isExportingAtom can model export failure recovery", () => {
+		const store = createStore();
+
+		store.set(isExportingAtom, true);
+		store.set(exportErrorAtom, "Disk full");
+
+		expect(store.get(isExportingAtom)).toBe(true);
+		expect(store.get(exportErrorAtom)).toBe("Disk full");
+
+		// Recovery: reset both
+		store.set(isExportingAtom, false);
+		store.set(exportErrorAtom, null);
+
+		expect(store.get(isExportingAtom)).toBe(false);
+		expect(store.get(exportErrorAtom)).toBeNull();
+	});
+
+	it("real atom: updater error cycle models a complete update failure and reset", () => {
+		const store = createStore();
+
+		store.set(updaterStatusAtom, "error");
+		store.set(updaterErrorAtom, "Network timeout");
+
+		expect(store.get(updaterStatusAtom)).toBe("error");
+		expect(store.get(updaterErrorAtom)).toBe("Network timeout");
+
+		// Reset to idle
+		store.set(updaterStatusAtom, "idle");
+		store.set(updaterErrorAtom, null);
+
+		expect(store.get(updaterStatusAtom)).toBe("idle");
+		expect(store.get(updaterErrorAtom)).toBeNull();
+	});
+
+	it("derived atom that conditionally throws based on dependency value", () => {
+		const store = createStore();
+		const inputAtom = atom<number | null>(null);
+		const safeDivideAtom = atom((get) => {
+			const val = get(inputAtom);
+			if (val === null) throw new Error("value is null");
+			if (val === 0) throw new Error("division by zero");
+			return 100 / val;
+		});
+
+		expect(() => store.get(safeDivideAtom)).toThrow("value is null");
+
+		store.set(inputAtom, 0);
+		expect(() => store.get(safeDivideAtom)).toThrow("division by zero");
+
+		store.set(inputAtom, 4);
+		expect(store.get(safeDivideAtom)).toBe(25);
+	});
+
+	it("multiple derived atoms all throwing independently do not prevent each other from recovering", () => {
+		const store = createStore();
+		const flagA = atom(false);
+		const flagB = atom(false);
+
+		const throwingA = atom((get) => {
+			if (!get(flagA)) throw new Error("A not ready");
+			return "A ok";
+		});
+		const throwingB = atom((get) => {
+			if (!get(flagB)) throw new Error("B not ready");
+			return "B ok";
+		});
+
+		expect(() => store.get(throwingA)).toThrow("A not ready");
+		expect(() => store.get(throwingB)).toThrow("B not ready");
+
+		store.set(flagA, true);
+		expect(store.get(throwingA)).toBe("A ok");
+		expect(() => store.get(throwingB)).toThrow("B not ready");
+
+		store.set(flagB, true);
+		expect(store.get(throwingA)).toBe("A ok");
+		expect(store.get(throwingB)).toBe("B ok");
+	});
+});

--- a/apps/desktop/src/__tests__/edge-cases/jotai-memory-cleanup.test.ts
+++ b/apps/desktop/src/__tests__/edge-cases/jotai-memory-cleanup.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Memory & Cleanup Tests for Jotai State Management
+ *
+ * Covers: subscription cleanup via unsubscribe, no lingering callbacks
+ * after cleanup, interval/timeout simulation with proper teardown,
+ * and double-unsubscribe safety.
+ */
+
+import { atom } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { recordingActiveAtom } from "@/atoms/recording";
+import { isPlayingAtom, audioVolumeAtom } from "@/atoms/videoEditor";
+import { isCapturingAtom } from "@/atoms/launch";
+
+describe("memory and cleanup", () => {
+	it("unsubscribe prevents future notifications from reaching the callback", () => {
+		const store = createStore();
+		const myAtom = atom(0);
+		let callCount = 0;
+
+		const unsub = store.sub(myAtom, () => {
+			callCount++;
+		});
+
+		store.set(myAtom, 1);
+		expect(callCount).toBe(1);
+
+		unsub();
+		store.set(myAtom, 2);
+		store.set(myAtom, 3);
+
+		expect(callCount).toBe(1); // no additional calls after unsubscribe
+	});
+
+	it("double-calling the unsubscribe function does not throw", () => {
+		const store = createStore();
+		const myAtom = atom(0);
+		const unsub = store.sub(myAtom, () => {});
+
+		unsub(); // first cleanup
+		expect(() => unsub()).not.toThrow(); // second cleanup — must be safe
+	});
+
+	it("multiple subscribe/unsubscribe cycles do not accumulate leftover callbacks", () => {
+		const store = createStore();
+		const myAtom = atom(0);
+		let totalCalls = 0;
+
+		for (let i = 0; i < 20; i++) {
+			const unsub = store.sub(myAtom, () => {
+				totalCalls++;
+			});
+			unsub(); // immediately unsubscribe each time
+		}
+
+		store.set(myAtom, 99);
+		expect(totalCalls).toBe(0);
+	});
+
+	it("store.sub returns a function (the cleanup/unsubscribe fn)", () => {
+		const store = createStore();
+		const myAtom = atom(false);
+
+		const cleanup = store.sub(myAtom, () => {});
+
+		expect(typeof cleanup).toBe("function");
+		cleanup();
+	});
+
+	it("partial unsubscribe: remaining subscribers still receive notifications", () => {
+		const store = createStore();
+		const myAtom = atom("start");
+		const receivedA: string[] = [];
+		const receivedB: string[] = [];
+
+		const unsubA = store.sub(myAtom, () => receivedA.push(store.get(myAtom)));
+		store.sub(myAtom, () => receivedB.push(store.get(myAtom)));
+
+		store.set(myAtom, "first");
+		unsubA(); // remove A only
+		store.set(myAtom, "second");
+
+		expect(receivedA).toEqual(["first"]); // stopped after unsubA
+		expect(receivedB).toEqual(["first", "second"]); // still active
+	});
+
+	it("atom value persists in store even after all subscribers are removed", () => {
+		const store = createStore();
+		const dataAtom = atom("initial");
+
+		const unsub = store.sub(dataAtom, () => {});
+		store.set(dataAtom, "updated");
+		unsub();
+
+		// Atom still holds the value even with no subscribers
+		expect(store.get(dataAtom)).toBe("updated");
+	});
+
+	it("simulated setInterval cleanup: timer fn is a no-op after clearInterval", () => {
+		const store = createStore();
+		const counterAtom = atom(0);
+		let active = true;
+		const ticks: number[] = [];
+
+		// Simulate an interval that reads the atom and stops when cleaned up
+		const tick = () => {
+			if (!active) return;
+			ticks.push(store.get(counterAtom));
+		};
+
+		store.set(counterAtom, 1);
+		tick();
+		store.set(counterAtom, 2);
+		tick();
+
+		active = false; // simulate clearInterval
+
+		store.set(counterAtom, 3);
+		tick(); // should be no-op
+
+		expect(ticks).toEqual([1, 2]);
+	});
+
+	it("simulated setTimeout: timeout callback does nothing if cancelled before it runs", () => {
+		const store = createStore();
+		const resultAtom = atom<string | null>(null);
+		let cancelled = false;
+
+		// Simulate a deferred update that can be cancelled
+		const deferredUpdate = () => {
+			if (cancelled) return;
+			store.set(resultAtom, "timeout fired");
+		};
+
+		cancelled = true;
+		deferredUpdate(); // should be skipped
+
+		expect(store.get(resultAtom)).toBeNull();
+	});
+
+	it("re-subscribing after cleanup works correctly", () => {
+		const store = createStore();
+		const stateAtom = atom(0);
+		const received: number[] = [];
+
+		// First subscription cycle
+		const unsub1 = store.sub(stateAtom, () => received.push(store.get(stateAtom)));
+		store.set(stateAtom, 1);
+		unsub1();
+
+		// Second subscription cycle
+		const unsub2 = store.sub(stateAtom, () => received.push(store.get(stateAtom)));
+		store.set(stateAtom, 2);
+		unsub2();
+
+		expect(received).toEqual([1, 2]);
+	});
+
+	it("subscriber added after a prior subscriber is removed is isolated", () => {
+		const store = createStore();
+		const myAtom = atom("a");
+		const firstSeen: string[] = [];
+		const secondSeen: string[] = [];
+
+		const unsub1 = store.sub(myAtom, () => firstSeen.push(store.get(myAtom)));
+		store.set(myAtom, "b");
+		unsub1();
+
+		store.sub(myAtom, () => secondSeen.push(store.get(myAtom)));
+		store.set(myAtom, "c");
+
+		expect(firstSeen).toEqual(["b"]);
+		expect(secondSeen).toEqual(["c"]);
+	});
+
+	it("cleanup of derived atom subscriber stops propagation notifications", () => {
+		const store = createStore();
+		const baseAtom = atom(0);
+		const derivedAtom = atom((get) => get(baseAtom) * 10);
+		const seen: number[] = [];
+
+		const unsub = store.sub(derivedAtom, () => seen.push(store.get(derivedAtom)));
+
+		store.set(baseAtom, 1); // triggers derived → 10
+		unsub();
+		store.set(baseAtom, 2); // no more subscription
+
+		expect(seen).toEqual([10]);
+	});
+
+	it("large number of simultaneous subscriptions all clean up without memory errors", () => {
+		const store = createStore();
+		const myAtom = atom(false);
+		let callCount = 0;
+		const unsubs: Array<() => void> = [];
+
+		for (let i = 0; i < 1000; i++) {
+			unsubs.push(
+				store.sub(myAtom, () => {
+					callCount++;
+				}),
+			);
+		}
+
+		store.set(myAtom, true); // all 1000 fire
+		expect(callCount).toBe(1000);
+
+		// Clean up all
+		unsubs.forEach((u) => u());
+		store.set(myAtom, false); // nobody should fire now
+		expect(callCount).toBe(1000); // unchanged
+	});
+
+	it("real atom: recordingActiveAtom subscription cleans up correctly", () => {
+		const store = createStore();
+		const log: boolean[] = [];
+
+		const unsub = store.sub(recordingActiveAtom, () => {
+			log.push(store.get(recordingActiveAtom));
+		});
+
+		store.set(recordingActiveAtom, true);
+		store.set(recordingActiveAtom, false);
+		unsub();
+		store.set(recordingActiveAtom, true); // should not be logged
+
+		expect(log).toEqual([true, false]);
+	});
+
+	it("real atom: isCapturingAtom and isPlayingAtom subscriptions are independent", () => {
+		const store = createStore();
+		const captureLogs: boolean[] = [];
+		const playingLogs: boolean[] = [];
+
+		const unsubCapture = store.sub(isCapturingAtom, () =>
+			captureLogs.push(store.get(isCapturingAtom)),
+		);
+		const unsubPlaying = store.sub(isPlayingAtom, () =>
+			playingLogs.push(store.get(isPlayingAtom)),
+		);
+
+		store.set(isCapturingAtom, true);
+		store.set(isPlayingAtom, true);
+		unsubCapture(); // stop capture subscription
+		store.set(isCapturingAtom, false); // not logged
+		store.set(isPlayingAtom, false); // still logged
+		unsubPlaying();
+
+		expect(captureLogs).toEqual([true]);
+		expect(playingLogs).toEqual([true, false]);
+	});
+
+	it("atom subscription does not fire when written value is the same reference", () => {
+		const store = createStore();
+		// Write-atoms in jotai notify subscribers only when the value actually changes
+		const numAtom = atom(5);
+		let notifyCount = 0;
+
+		store.sub(numAtom, () => {
+			notifyCount++;
+		});
+
+		store.set(numAtom, 5); // same value — Jotai may skip notification
+		store.set(numAtom, 5);
+		store.set(numAtom, 6); // actually changed → notification fires
+
+		// Jotai v2 skips notifications when Object.is(prev, next) is true
+		expect(notifyCount).toBeLessThanOrEqual(1);
+		expect(store.get(numAtom)).toBe(6);
+	});
+});

--- a/apps/desktop/src/__tests__/edge-cases/jotai-race-conditions.test.ts
+++ b/apps/desktop/src/__tests__/edge-cases/jotai-race-conditions.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Race Condition Tests for Jotai State Management
+ *
+ * Covers: rapid sequential writes, concurrent async atom resolution,
+ * subscriber notification ordering, and re-entrant writes.
+ */
+
+import { atom } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+import { microphoneEnabledAtom, recordingActiveAtom } from "@/atoms/recording";
+import { audioVolumeAtom, durationAtom, zoomRegionsAtom } from "@/atoms/videoEditor";
+
+describe("race conditions", () => {
+	it("rapid sequential writes maintain the correct final value", () => {
+		const store = createStore();
+		const countAtom = atom(0);
+
+		for (let i = 0; i < 1000; i++) {
+			store.set(countAtom, i);
+		}
+
+		expect(store.get(countAtom)).toBe(999);
+	});
+
+	it("subscriber receives notifications in write order", () => {
+		const store = createStore();
+		const countAtom = atom(0);
+		const received: number[] = [];
+
+		store.sub(countAtom, () => {
+			received.push(store.get(countAtom));
+		});
+
+		store.set(countAtom, 1);
+		store.set(countAtom, 2);
+		store.set(countAtom, 3);
+
+		expect(received).toEqual([1, 2, 3]);
+	});
+
+	it("all subscribers are notified on rapid writes", () => {
+		const store = createStore();
+		const valueAtom = atom("initial");
+		const notifyCount = [0, 0, 0];
+
+		const unsubs = notifyCount.map((_, i) =>
+			store.sub(valueAtom, () => {
+				notifyCount[i]++;
+			}),
+		);
+
+		for (let w = 0; w < 50; w++) {
+			store.set(valueAtom, `value-${w}`);
+		}
+
+		unsubs.forEach((u) => u());
+		expect(notifyCount).toEqual([50, 50, 50]);
+	});
+
+	it("derived atom reflects the latest dependency value after rapid changes", () => {
+		const store = createStore();
+		const baseAtom = atom(0);
+		const derivedAtom = atom((get) => get(baseAtom) * 2);
+
+		for (let i = 0; i < 500; i++) {
+			store.set(baseAtom, i);
+		}
+
+		expect(store.get(derivedAtom)).toBe(998); // 499 * 2
+	});
+
+	it("derived atom subscriber always reads the current value, not a stale one", () => {
+		const store = createStore();
+		const srcAtom = atom(0);
+		const doubleAtom = atom((get) => get(srcAtom) * 2);
+		const seen: number[] = [];
+
+		store.sub(doubleAtom, () => {
+			seen.push(store.get(doubleAtom));
+		});
+
+		store.set(srcAtom, 1);
+		store.set(srcAtom, 2);
+		store.set(srcAtom, 3);
+
+		expect(seen).toEqual([2, 4, 6]);
+	});
+
+	it("async atom resolves to its computed value", async () => {
+		const store = createStore();
+		const asyncAtom = atom(async () => {
+			await Promise.resolve();
+			return 42;
+		});
+
+		const result = await store.get(asyncAtom);
+		expect(result).toBe(42);
+	});
+
+	it("multiple independent async atoms resolve correctly in any order", async () => {
+		const store = createStore();
+
+		const slowAtom = atom(async () => {
+			await new Promise<void>((r) => setTimeout(r, 10));
+			return "slow";
+		});
+		const fastAtom = atom(async () => {
+			await Promise.resolve();
+			return "fast";
+		});
+
+		const [slow, fast] = await Promise.all([store.get(slowAtom), store.get(fastAtom)]);
+
+		expect(fast).toBe("fast");
+		expect(slow).toBe("slow");
+	});
+
+	it("async atom with dependency reads the correct value at execution time", async () => {
+		const store = createStore();
+		const baseAtom = atom(1);
+		const asyncDerived = atom(async (get) => {
+			const val = get(baseAtom);
+			await Promise.resolve();
+			return val * 10;
+		});
+
+		expect(await store.get(asyncDerived)).toBe(10);
+
+		store.set(baseAtom, 5);
+		expect(await store.get(asyncDerived)).toBe(50);
+	});
+
+	it("write atom with updater handles 100 rapid increments correctly", () => {
+		const store = createStore();
+		const counterAtom = atom(0);
+		const incrementAtom = atom(null, (get, set) => {
+			set(counterAtom, get(counterAtom) + 1);
+		});
+
+		for (let i = 0; i < 100; i++) {
+			store.set(incrementAtom);
+		}
+
+		expect(store.get(counterAtom)).toBe(100);
+	});
+
+	it("atom write inside a subscription callback takes effect immediately", () => {
+		const store = createStore();
+		const triggerAtom = atom(false);
+		const sideEffectAtom = atom(0);
+		let fired = false;
+
+		store.sub(triggerAtom, () => {
+			if (!fired) {
+				fired = true;
+				store.set(sideEffectAtom, 99);
+			}
+		});
+
+		store.set(triggerAtom, true);
+
+		expect(store.get(sideEffectAtom)).toBe(99);
+	});
+
+	it("two independent stores do not interfere under concurrent writes", () => {
+		const sharedDef = atom(0);
+		const storeA = createStore();
+		const storeB = createStore();
+
+		for (let i = 0; i < 100; i++) {
+			storeA.set(sharedDef, i);
+			storeB.set(sharedDef, i * 2);
+		}
+
+		expect(storeA.get(sharedDef)).toBe(99);
+		expect(storeB.get(sharedDef)).toBe(198);
+	});
+
+	it("unsubscribed listener stops receiving notifications during rapid writes", () => {
+		const store = createStore();
+		const valueAtom = atom(0);
+		const received: number[] = [];
+
+		const unsub = store.sub(valueAtom, () => {
+			received.push(store.get(valueAtom));
+		});
+
+		store.set(valueAtom, 1);
+		store.set(valueAtom, 2);
+		unsub();
+		store.set(valueAtom, 3);
+		store.set(valueAtom, 4);
+
+		expect(received).toEqual([1, 2]);
+		expect(store.get(valueAtom)).toBe(4); // store still updated correctly
+	});
+
+	it("three-level derived chain propagates rapid changes end-to-end", () => {
+		const store = createStore();
+		const aAtom = atom(0);
+		const bAtom = atom((get) => get(aAtom) + 1);
+		const cAtom = atom((get) => get(bAtom) * 2);
+
+		store.set(aAtom, 10);
+
+		expect(store.get(bAtom)).toBe(11);
+		expect(store.get(cAtom)).toBe(22);
+	});
+
+	it("rapid boolean toggling settles to the final written state", () => {
+		const store = createStore();
+		const toggleAtom = atom(false);
+
+		// i=0..1000, last i=1000: 1000%2===0 → write false
+		for (let i = 0; i <= 1000; i++) {
+			store.set(toggleAtom, i % 2 !== 0);
+		}
+
+		expect(store.get(toggleAtom)).toBe(false);
+	});
+
+	it("rapid subscribe/unsubscribe cycles do not accumulate phantom callbacks", () => {
+		const store = createStore();
+		const trackAtom = atom(0);
+		let callCount = 0;
+
+		for (let i = 0; i < 50; i++) {
+			const unsub = store.sub(trackAtom, () => {
+				callCount++;
+			});
+			unsub();
+		}
+
+		store.set(trackAtom, 999);
+		expect(callCount).toBe(0);
+	});
+
+	it("interleaved reads and writes always return the latest written value", () => {
+		const store = createStore();
+		const dataAtom = atom<string>("start");
+		const readValues: string[] = [];
+
+		for (let i = 0; i < 10; i++) {
+			store.set(dataAtom, `value-${i}`);
+			readValues.push(store.get(dataAtom));
+		}
+
+		expect(readValues).toEqual(Array.from({ length: 10 }, (_, i) => `value-${i}`));
+	});
+
+	it("real recording atoms maintain correct final value under rapid writes", () => {
+		const store = createStore();
+
+		for (let i = 0; i < 200; i++) {
+			store.set(recordingActiveAtom, i % 2 === 0);
+			store.set(microphoneEnabledAtom, i % 3 === 0);
+		}
+
+		// i=199: 199%2=1 → false; 199%3≠0 → false
+		expect(store.get(recordingActiveAtom)).toBe(false);
+		expect(store.get(microphoneEnabledAtom)).toBe(false);
+	});
+
+	it("video editor atoms survive a rapid write storm", () => {
+		const store = createStore();
+
+		for (let i = 0; i < 500; i++) {
+			store.set(audioVolumeAtom, i / 500);
+			store.set(durationAtom, i * 1000);
+		}
+
+		expect(store.get(audioVolumeAtom)).toBeCloseTo(499 / 500);
+		expect(store.get(durationAtom)).toBe(499000);
+	});
+
+	it("two async atoms with controlled out-of-order promises both resolve correctly", async () => {
+		const store = createStore();
+		let resolveA!: (v: string) => void;
+		let resolveB!: (v: string) => void;
+
+		const promiseA = new Promise<string>((r) => {
+			resolveA = r;
+		});
+		const promiseB = new Promise<string>((r) => {
+			resolveB = r;
+		});
+
+		const atomA = atom(() => promiseA);
+		const atomB = atom(() => promiseB);
+
+		const pendingA = store.get(atomA);
+		const pendingB = store.get(atomB);
+
+		// Resolve B before A (deliberate out-of-order)
+		resolveB("result-B");
+		resolveA("result-A");
+
+		expect(await pendingA).toBe("result-A");
+		expect(await pendingB).toBe("result-B");
+	});
+
+	it("notification count exactly matches write count", () => {
+		const store = createStore();
+		const atom1 = atom(0);
+		let notificationCount = 0;
+
+		store.sub(atom1, () => {
+			notificationCount++;
+		});
+
+		const writesCount = 47;
+		for (let i = 0; i < writesCount; i++) {
+			store.set(atom1, i + 1);
+		}
+
+		expect(notificationCount).toBe(writesCount);
+	});
+
+	it("zoom regions atom handles rapid array replacements without corruption", () => {
+		const store = createStore();
+		const iterations = 200;
+
+		for (let i = 0; i < iterations; i++) {
+			store.set(
+				zoomRegionsAtom,
+				Array.from({ length: i % 5 }, (_, j) => ({
+					id: `z-${j}`,
+					startTime: j * 100,
+					endTime: j * 100 + 50,
+					x: 0,
+					y: 0,
+					width: 1,
+					height: 1,
+					scale: 1.5,
+				})),
+			);
+		}
+
+		// Last iteration: 199 % 5 = 4 regions
+		expect(store.get(zoomRegionsAtom)).toHaveLength(4);
+	});
+
+	it("concurrent async atoms sharing a dependency do not corrupt each other", async () => {
+		const store = createStore();
+		const sharedAtom = atom(10);
+
+		const asyncA = atom(async (get) => get(sharedAtom) + 1);
+		const asyncB = atom(async (get) => get(sharedAtom) * 2);
+
+		const [a, b] = await Promise.all([store.get(asyncA), store.get(asyncB)]);
+
+		expect(a).toBe(11);
+		expect(b).toBe(20);
+	});
+});

--- a/apps/desktop/src/__tests__/edge-cases/jotai-stale-closures.test.ts
+++ b/apps/desktop/src/__tests__/edge-cases/jotai-stale-closures.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Stale Closure Detection Tests for Jotai State Management
+ *
+ * Verifies that atoms used inside useEffect/useCallback/setInterval-like
+ * patterns capture fresh values (via atom references + store.get) rather
+ * than stale captured values.
+ *
+ * Pattern being tested:
+ *   BAD  → capture the VALUE at setup time (goes stale)
+ *   GOOD → capture the ATOM REFERENCE and call store.get() at read time (always fresh)
+ */
+
+import { atom } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { audioVolumeAtom, isPlayingAtom } from "@/atoms/videoEditor";
+import { recordingActiveAtom, microphoneEnabledAtom } from "@/atoms/recording";
+import { isCapturingAtom, recordingElapsedAtom } from "@/atoms/launch";
+
+describe("stale closure detection", () => {
+	it("captured value is stale after an atom write; atom reference is always fresh", () => {
+		const store = createStore();
+		const countAtom = atom(0);
+
+		// Simulate capturing the VALUE (stale closure anti-pattern)
+		const capturedValue = store.get(countAtom);
+
+		store.set(countAtom, 42);
+
+		// Stale capture: still sees the old value
+		expect(capturedValue).toBe(0);
+
+		// Fresh via atom reference: reads current value
+		expect(store.get(countAtom)).toBe(42);
+	});
+
+	it("simulated setInterval using atom reference always reads current value", () => {
+		const store = createStore();
+		const counterAtom = atom(0);
+		const ticks: number[] = [];
+
+		// Simulate setInterval callback: captures atom ref, not value
+		const intervalCallback = () => {
+			ticks.push(store.get(counterAtom)); // always fresh
+		};
+
+		store.set(counterAtom, 1);
+		intervalCallback();
+		store.set(counterAtom, 2);
+		intervalCallback();
+		store.set(counterAtom, 3);
+		intervalCallback();
+
+		expect(ticks).toEqual([1, 2, 3]);
+	});
+
+	it("simulated setInterval with stale captured value misses updates", () => {
+		const store = createStore();
+		const counterAtom = atom(0);
+		const ticks: number[] = [];
+
+		// Capture the VALUE once (stale anti-pattern)
+		const staleValue = store.get(counterAtom);
+		const staleCallback = () => {
+			ticks.push(staleValue); // always 0, never updates
+		};
+
+		store.set(counterAtom, 10);
+		staleCallback();
+		store.set(counterAtom, 20);
+		staleCallback();
+
+		// All ticks see the stale initial value
+		expect(ticks).toEqual([0, 0]);
+	});
+
+	it("simulated useEffect cleanup captures atom ref and sees updates after re-run", () => {
+		const store = createStore();
+		const statusAtom = atom("idle");
+		const observedStatuses: string[] = [];
+
+		// Simulate useEffect body that reads atom on each execution
+		const runEffect = () => {
+			observedStatuses.push(store.get(statusAtom));
+		};
+
+		runEffect(); // first "render"
+		store.set(statusAtom, "recording");
+		runEffect(); // second "render"
+		store.set(statusAtom, "done");
+		runEffect(); // third "render"
+
+		expect(observedStatuses).toEqual(["idle", "recording", "done"]);
+	});
+
+	it("write atom updater pattern (prev => next) never reads stale value", () => {
+		const store = createStore();
+		const countAtom = atom(0);
+		const incrementAtom = atom(null, (get, set) => {
+			// Uses get() inside the write fn — always reads current state
+			set(countAtom, get(countAtom) + 1);
+		});
+
+		store.set(countAtom, 100);
+		store.set(incrementAtom);
+		store.set(incrementAtom);
+
+		// Each increment sees the result of the previous one
+		expect(store.get(countAtom)).toBe(102);
+	});
+
+	it("subscription callback always receives the current value, not the value at subscribe time", () => {
+		const store = createStore();
+		const valueAtom = atom("initial");
+		const seenInCallback: string[] = [];
+
+		store.sub(valueAtom, () => {
+			seenInCallback.push(store.get(valueAtom));
+		});
+
+		store.set(valueAtom, "updated");
+		store.set(valueAtom, "final");
+
+		expect(seenInCallback).toEqual(["updated", "final"]);
+	});
+
+	it("derived atom always computes from fresh dependency, never from stale snapshot", () => {
+		const store = createStore();
+		const sourceAtom = atom(10);
+		const derivedAtom = atom((get) => get(sourceAtom) * 3);
+
+		// Read derived before update
+		const beforeUpdate = store.get(derivedAtom);
+
+		store.set(sourceAtom, 20);
+
+		// Read derived after update
+		const afterUpdate = store.get(derivedAtom);
+
+		expect(beforeUpdate).toBe(30); // was fresh at time of read
+		expect(afterUpdate).toBe(60); // fresh after update
+	});
+
+	it("multiple closures with atom references all see the same current state", () => {
+		const store = createStore();
+		const sharedAtom = atom(0);
+
+		// Simulate three components/hooks each capturing the atom reference
+		const readerA = () => store.get(sharedAtom);
+		const readerB = () => store.get(sharedAtom);
+		const readerC = () => store.get(sharedAtom);
+
+		store.set(sharedAtom, 7);
+
+		expect(readerA()).toBe(7);
+		expect(readerB()).toBe(7);
+		expect(readerC()).toBe(7);
+	});
+
+	it("simulated useCallback: fresh read via store.get in callback sees latest value", () => {
+		const store = createStore();
+		const thresholdAtom = atom(100);
+		const dataAtom = atom(50);
+
+		// Simulate useCallback that captures atom refs (fresh pattern)
+		const handleProcess = () => {
+			const threshold = store.get(thresholdAtom);
+			const data = store.get(dataAtom);
+			return data >= threshold;
+		};
+
+		expect(handleProcess()).toBe(false); // 50 < 100
+
+		store.set(thresholdAtom, 40);
+		expect(handleProcess()).toBe(true); // 50 >= 40
+
+		store.set(dataAtom, 200);
+		expect(handleProcess()).toBe(true); // 200 >= 40
+	});
+
+	it("real atom: isCapturingAtom read inside a simulated interval stays fresh", () => {
+		const store = createStore();
+		const snapshots: boolean[] = [];
+
+		const checkCapture = () => {
+			snapshots.push(store.get(isCapturingAtom));
+		};
+
+		checkCapture(); // false
+		store.set(isCapturingAtom, true);
+		checkCapture(); // true
+		store.set(isCapturingAtom, false);
+		checkCapture(); // false
+
+		expect(snapshots).toEqual([false, true, false]);
+	});
+
+	it("real atom: recordingElapsedAtom incremented via updater never skips a count", () => {
+		const store = createStore();
+		const tickAtom = atom(null, (get, set) => {
+			set(recordingElapsedAtom, get(recordingElapsedAtom) + 1);
+		});
+
+		for (let i = 0; i < 10; i++) {
+			store.set(tickAtom);
+		}
+
+		expect(store.get(recordingElapsedAtom)).toBe(10);
+	});
+
+	it("subscription callback closure over external var sees its own scope correctly", () => {
+		const store = createStore();
+		const flagAtom = atom(false);
+		let externalCounter = 0;
+
+		store.sub(flagAtom, () => {
+			// Closure captures externalCounter by reference — demonstrates standard JS closure
+			externalCounter += store.get(flagAtom) ? 1 : -1;
+		});
+
+		store.set(flagAtom, true); // +1
+		store.set(flagAtom, false); // -1
+		store.set(flagAtom, true); // +1
+
+		expect(externalCounter).toBe(1); // net: +1 -1 +1 = 1
+	});
+
+	it("chained derived atoms each read fresh from their direct dependency", () => {
+		const store = createStore();
+		const base = atom(1);
+		const step1 = atom((get) => get(base) + 10);
+		const step2 = atom((get) => get(step1) * 2);
+		const step3 = atom((get) => get(step2) - 3);
+
+		store.set(base, 5);
+
+		// step1: 5+10=15, step2: 15*2=30, step3: 30-3=27
+		expect(store.get(step3)).toBe(27);
+
+		store.set(base, 0);
+
+		// step1: 0+10=10, step2: 10*2=20, step3: 20-3=17
+		expect(store.get(step3)).toBe(17);
+	});
+
+	it("atom value captured before multiple writes is stale; re-reading is always current", () => {
+		const store = createStore();
+		const configAtom = atom({ timeout: 1000, retries: 3 });
+
+		// Captured snapshot — stale after updates
+		const snapshot = store.get(configAtom);
+
+		store.set(configAtom, { timeout: 5000, retries: 5 });
+		store.set(configAtom, { timeout: 500, retries: 1 });
+
+		// Snapshot is stuck at initial value
+		expect(snapshot).toEqual({ timeout: 1000, retries: 3 });
+
+		// Live read reflects the latest value
+		expect(store.get(configAtom)).toEqual({ timeout: 500, retries: 1 });
+	});
+
+	it("real atom: audioVolumeAtom read freshly inside simulated playback loop", () => {
+		const store = createStore();
+		const volumeReadings: number[] = [];
+
+		// Simulate a playback render loop that reads volume each frame
+		const renderFrame = () => {
+			volumeReadings.push(store.get(audioVolumeAtom));
+		};
+
+		renderFrame(); // default 1
+		store.set(audioVolumeAtom, 0.5);
+		renderFrame(); // 0.5
+		store.set(audioVolumeAtom, 0);
+		renderFrame(); // 0
+
+		expect(volumeReadings).toEqual([1, 0.5, 0]);
+	});
+});

--- a/apps/desktop/src/__tests__/edge-cases/jotai-storage-edge-cases.test.ts
+++ b/apps/desktop/src/__tests__/edge-cases/jotai-storage-edge-cases.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+/**
+ * Storage Edge Case Tests for Jotai State Management
+ *
+ * Covers: localStorage full (QuotaExceededError), localStorage unavailable,
+ * corrupt JSON in storage, storage events from other tabs, and
+ * atomWithStorage read/write behaviour under adverse conditions.
+ *
+ * Note: atomWithStorage in Jotai v2 requires `getOnInit: true` for the
+ * vanilla store's `get()` to read from localStorage on first access.
+ */
+
+import { atomWithStorage } from "jotai/utils";
+import { createStore } from "jotai/vanilla";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getInitialLocale, normalizeLocale } from "@/atoms/i18n";
+import { getInitialLaunchView } from "@/atoms/launch";
+import { getInitialTab } from "@/atoms/sourceSelector";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function clearStorage() {
+	window.localStorage.clear();
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("storage edge cases", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks(); // restore before clearing so clear() works
+		clearStorage();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks(); // restore before clearing so clear() works
+		clearStorage();
+	});
+
+	// ── atomWithStorage baseline ──────────────────────────────────────────────
+
+	it("atomWithStorage returns the initial value when localStorage is empty", () => {
+		const store = createStore();
+		const persistedAtom = atomWithStorage("edge-test-key", "default-value");
+
+		expect(store.get(persistedAtom)).toBe("default-value");
+	});
+
+	it("atomWithStorage with getOnInit reads a previously stored string value", () => {
+		window.localStorage.setItem("edge-str-key", JSON.stringify("stored"));
+		const store = createStore();
+		const persistedAtom = atomWithStorage("edge-str-key", "default", undefined, {
+			getOnInit: true,
+		});
+
+		expect(store.get(persistedAtom)).toBe("stored");
+	});
+
+	it("atomWithStorage persists a new value to localStorage on set", () => {
+		const store = createStore();
+		const persistedAtom = atomWithStorage("edge-write-key", "original");
+
+		store.set(persistedAtom, "changed");
+
+		expect(JSON.parse(window.localStorage.getItem("edge-write-key") ?? "null")).toBe("changed");
+	});
+
+	it("atomWithStorage with getOnInit reads a stored object value correctly", () => {
+		const stored = { name: "Open Recorder", version: 2 };
+		window.localStorage.setItem("edge-obj-key", JSON.stringify(stored));
+		const store = createStore();
+		const persistedAtom = atomWithStorage<typeof stored>(
+			"edge-obj-key",
+			{ name: "default", version: 0 },
+			undefined,
+			{ getOnInit: true },
+		);
+
+		expect(store.get(persistedAtom)).toEqual(stored);
+	});
+
+	it("atomWithStorage falls back to default when stored JSON is corrupt", () => {
+		window.localStorage.setItem("edge-corrupt-key", "{{{not valid json}}}");
+		const store = createStore();
+		const persistedAtom = atomWithStorage("edge-corrupt-key", "fallback", undefined, {
+			getOnInit: true,
+		});
+
+		// Jotai v2 atomWithStorage catches JSON parse errors and uses initialValue
+		expect(store.get(persistedAtom)).toBe("fallback");
+	});
+
+	it("atomWithStorage with boolean value round-trips correctly via getOnInit", () => {
+		window.localStorage.setItem("edge-bool-key", JSON.stringify(true));
+		const store = createStore();
+		const boolAtom = atomWithStorage("edge-bool-key", false, undefined, { getOnInit: true });
+
+		expect(store.get(boolAtom)).toBe(true);
+	});
+
+	it("atomWithStorage persists boolean correctly to localStorage", () => {
+		const store = createStore();
+		const boolAtom = atomWithStorage("edge-bool-write-key", false);
+
+		store.set(boolAtom, true);
+
+		const raw = window.localStorage.getItem("edge-bool-write-key");
+		expect(JSON.parse(raw ?? "false")).toBe(true);
+	});
+
+	it("atomWithStorage with array value round-trips correctly via getOnInit", () => {
+		window.localStorage.setItem("edge-list-key", JSON.stringify(["a", "b", "c"]));
+		const store = createStore();
+		const listAtom = atomWithStorage<string[]>("edge-list-key", [], undefined, {
+			getOnInit: true,
+		});
+
+		expect(store.get(listAtom)).toEqual(["a", "b", "c"]);
+	});
+
+	it("two atomWithStorage atoms with different keys do not share values", () => {
+		window.localStorage.setItem("edge-key-a", JSON.stringify("overriddenA"));
+
+		const storeA = createStore();
+		const atomA = atomWithStorage("edge-key-a", "valueA", undefined, { getOnInit: true });
+		const atomB = atomWithStorage("edge-key-b", "valueB", undefined, { getOnInit: true });
+
+		expect(storeA.get(atomA)).toBe("overriddenA");
+		expect(storeA.get(atomB)).toBe("valueB"); // unaffected key
+	});
+
+	// ── localStorage unavailable ──────────────────────────────────────────────
+
+	it("atomWithStorage set survives a QuotaExceededError without crashing the store", () => {
+		const store = createStore();
+		const persistedAtom = atomWithStorage("edge-quota-key", "original");
+
+		// Prime the atom value
+		store.get(persistedAtom);
+
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new DOMException("QuotaExceededError", "QuotaExceededError");
+		});
+
+		// The set should propagate the storage error or swallow it — either way
+		// the test verifies the store itself doesn't crash irreversibly.
+		try {
+			store.set(persistedAtom, "new-value");
+		} catch {
+			// Storage error may propagate — document this behavior
+		}
+
+		vi.restoreAllMocks();
+		// The atom's in-memory value should not be left in an indeterminate state
+		const val = store.get(persistedAtom);
+		expect(typeof val === "string").toBe(true);
+	});
+
+	// ── getInitialLocale helper ───────────────────────────────────────────────
+
+	it("getInitialLocale returns the stored locale when it is a supported value", () => {
+		window.localStorage.setItem("open-recorder.locale", "es");
+		expect(getInitialLocale()).toBe("es");
+	});
+
+	it("getInitialLocale falls back to navigator language when storage has no entry", () => {
+		// localStorage is clear; navigator.language is en-US by default in jsdom
+		const locale = getInitialLocale();
+		expect(typeof locale).toBe("string");
+		expect(locale.length).toBeGreaterThan(0);
+	});
+
+	it("normalizeLocale returns a supported locale for region-suffixed tags", () => {
+		expect(normalizeLocale("en-US")).toBe("en");
+		expect(normalizeLocale("es-MX")).toBe("es");
+	});
+
+	it("normalizeLocale returns the default locale for unsupported language tags", () => {
+		const result = normalizeLocale("fr-CA");
+		expect(typeof result).toBe("string");
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	it("normalizeLocale returns the default locale for null/empty input", () => {
+		expect(typeof normalizeLocale(null)).toBe("string");
+		expect(typeof normalizeLocale("")).toBe("string");
+	});
+
+	// ── getInitialLaunchView helper ───────────────────────────────────────────
+
+	it("getInitialLaunchView returns onboarding when the completion flag is absent", () => {
+		// localStorage is empty (cleared in beforeEach)
+		expect(getInitialLaunchView()).toBe("onboarding");
+	});
+
+	it("getInitialLaunchView returns choice after the completion flag is set", () => {
+		window.localStorage.setItem("open-recorder-onboarding-v1", "true");
+		expect(getInitialLaunchView()).toBe("choice");
+	});
+
+	it("getInitialLaunchView returns choice when localStorage throws on access", () => {
+		vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+			throw new Error("storage unavailable");
+		});
+
+		expect(getInitialLaunchView()).toBe("choice");
+	});
+
+	// ── getInitialTab helper ──────────────────────────────────────────────────
+
+	it("getInitialTab falls back to screens when the URL has no tab param", () => {
+		window.history.replaceState({}, "", "/");
+		expect(getInitialTab()).toBe("screens");
+	});
+
+	it("getInitialTab returns windows when the URL tab param is windows", () => {
+		window.history.replaceState({}, "", "/?tab=windows");
+		expect(getInitialTab()).toBe("windows");
+		window.history.replaceState({}, "", "/");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds **114 new Vitest test cases** in `apps/desktop/src/__tests__/edge-cases/` covering six adversarial categories of Jotai state management behaviour
- All 114 tests pass; no changes to production code

## Test files

| File | Tests | Category |
|------|------:|---------|
| `jotai-race-conditions.test.ts` | 22 | Rapid sequential writes, concurrent async atoms, out-of-order resolution, re-entrant writes |
| `jotai-stale-closures.test.ts` | 15 | Verify atom references (not captured values) stay fresh inside setInterval/useEffect/useCallback patterns |
| `jotai-error-handling.test.ts` | 16 | Throwing derived atoms, async rejections, throwing write atoms, store recovery after errors |
| `jotai-memory-cleanup.test.ts` | 15 | `store.sub()` cleanup, double-unsubscribe safety, no lingering callbacks, simulated interval/timeout teardown |
| `jotai-storage-edge-cases.test.ts` | 20 | `atomWithStorage` with `getOnInit`, corrupt JSON fallback, QuotaExceededError, localStorage unavailable, helper functions |
| `jotai-boundary-values.test.ts` | 26 | MAX_SAFE_INTEGER, NaN, ±Infinity, −0, empty/100k-char strings, emoji, null↔value transitions, 10k-element arrays, 10-deep nesting |

## Implementation notes

- Uses `createStore()` from `jotai/vanilla` for fully isolated store instances per test (same pattern as existing `stateDefaults.test.ts`)
- Storage tests use `// @vitest-environment jsdom` and `atomWithStorage(..., undefined, { getOnInit: true })` so the vanilla store reads localStorage on first `get()`
- No new runtime dependencies; `jsdom` and `vitest` were already installed

## Test plan

- [x] `pnpm test --run src/__tests__/edge-cases/` — all 114 tests pass
- [x] Full test suite — all pre-existing tests continue to pass (one pre-existing `gifExporter` pixi.js failure in node env is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)