### PR TITLE
test: add 122 new tests for Jotai-backed hooks and contexts

### DIFF
--- a/apps/desktop/src/contexts/I18nContext.additional.test.tsx
+++ b/apps/desktop/src/contexts/I18nContext.additional.test.tsx
@@ -1,0 +1,338 @@
+// @vitest-environment jsdom
+
+import { Provider } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeLocale } from "@/atoms/i18n";
+import type { I18nNamespace } from "@/i18n/config";
+import { I18nProvider, useI18n, useScopedT } from "./I18nContext";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+type HarnessResult = {
+	getCurrent: () => ReturnType<typeof useI18n>;
+	unmount: () => Promise<void>;
+};
+
+async function flushEffects() {
+	await act(async () => {
+		await Promise.resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+async function mountI18nHarness(): Promise<HarnessResult> {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const root: Root = createRoot(container);
+	const store = createStore();
+	let currentValue!: ReturnType<typeof useI18n>;
+
+	function Harness() {
+		currentValue = useI18n();
+		return null;
+	}
+
+	await act(async () => {
+		root.render(
+			<Provider store={store}>
+				<I18nProvider>
+					<Harness />
+				</I18nProvider>
+			</Provider>,
+		);
+	});
+	await flushEffects();
+
+	return {
+		getCurrent: () => currentValue,
+		unmount: async () => {
+			await act(async () => {
+				root.unmount();
+			});
+			container.remove();
+		},
+	};
+}
+
+async function mountScopedTHarness(namespace: I18nNamespace) {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const root: Root = createRoot(container);
+	const store = createStore();
+	let scopedT!: ReturnType<typeof useScopedT>;
+
+	function Harness() {
+		scopedT = useScopedT(namespace);
+		return null;
+	}
+
+	await act(async () => {
+		root.render(
+			<Provider store={store}>
+				<I18nProvider>
+					<Harness />
+				</I18nProvider>
+			</Provider>,
+		);
+	});
+	await flushEffects();
+
+	return {
+		t: () => scopedT,
+		unmount: async () => {
+			await act(async () => {
+				root.unmount();
+			});
+			container.remove();
+		},
+	};
+}
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	window.localStorage.clear();
+	document.documentElement.lang = "en";
+});
+
+// ─── I18nContext behavior ─────────────────────────────────────────────────────
+
+describe("I18nContext – additional coverage", () => {
+	describe("default locale", () => {
+		it("starts with locale 'en'", async () => {
+			const harness = await mountI18nHarness();
+			expect(harness.getCurrent().locale).toBe("en");
+			await harness.unmount();
+		});
+
+		it("sets document.documentElement.lang to 'en' on initial mount", async () => {
+			const harness = await mountI18nHarness();
+			expect(document.documentElement.lang).toBe("en");
+			await harness.unmount();
+		});
+	});
+
+	describe("translation function t()", () => {
+		it("resolves a known top-level English key", async () => {
+			const harness = await mountI18nHarness();
+			expect(harness.getCurrent().t("common.app.name")).toBe("Open Recorder");
+			await harness.unmount();
+		});
+
+		it("resolves a deeply nested key", async () => {
+			const harness = await mountI18nHarness();
+			expect(harness.getCurrent().t("common.app.editorTitle")).toBe("Open Recorder Editor");
+			await harness.unmount();
+		});
+
+		it("returns the explicit fallback string for a missing key", async () => {
+			const harness = await mountI18nHarness();
+			expect(harness.getCurrent().t("totally.missing.key", "Fallback Value")).toBe(
+				"Fallback Value",
+			);
+			await harness.unmount();
+		});
+
+		it("returns the key itself when no fallback is provided and key is missing", async () => {
+			const harness = await mountI18nHarness();
+			expect(harness.getCurrent().t("no.such.key")).toBe("no.such.key");
+			await harness.unmount();
+		});
+
+		it("interpolates {{ variable }} placeholders in the fallback string", async () => {
+			const harness = await mountI18nHarness();
+			const result = harness.getCurrent().t("missing.key", "Hello {{ name }}!", { name: "World" });
+			expect(result).toBe("Hello World!");
+			await harness.unmount();
+		});
+
+		it("interpolates numeric variables", async () => {
+			const harness = await mountI18nHarness();
+			const result = harness.getCurrent().t("missing.key", "Count: {{ count }}", { count: 42 });
+			expect(result).toBe("Count: 42");
+			await harness.unmount();
+		});
+
+		it("replaces a missing variable with an empty string", async () => {
+			const harness = await mountI18nHarness();
+			const result = harness
+				.getCurrent()
+				.t("missing.key", "Hello {{ name }}!", {} as Record<string, string>);
+			expect(result).toBe("Hello !");
+			await harness.unmount();
+		});
+
+		it("falls back to English when a key is absent in the active locale", async () => {
+			const harness = await mountI18nHarness();
+
+			await act(async () => {
+				harness.getCurrent().setLocale("es");
+			});
+			await flushEffects();
+
+			// common.app.name exists in both locales as "Open Recorder"
+			expect(harness.getCurrent().t("common.app.name")).toBe("Open Recorder");
+			await harness.unmount();
+		});
+	});
+
+	describe("locale switching", () => {
+		it("switches locale from en to es and updates the atom", async () => {
+			const harness = await mountI18nHarness();
+			expect(harness.getCurrent().locale).toBe("en");
+
+			await act(async () => {
+				harness.getCurrent().setLocale("es");
+			});
+			await flushEffects();
+
+			expect(harness.getCurrent().locale).toBe("es");
+			await harness.unmount();
+		});
+
+		it("updates document.documentElement.lang when locale changes", async () => {
+			const harness = await mountI18nHarness();
+
+			await act(async () => {
+				harness.getCurrent().setLocale("es");
+			});
+			await flushEffects();
+
+			expect(document.documentElement.lang).toBe("es");
+			await harness.unmount();
+		});
+
+		it("t() returns the Spanish translation after switching to es", async () => {
+			const harness = await mountI18nHarness();
+
+			await act(async () => {
+				harness.getCurrent().setLocale("es");
+			});
+			await flushEffects();
+
+			expect(harness.getCurrent().t("common.app.subtitle")).toBe(
+				"Grabacion de pantalla y edicion",
+			);
+			await harness.unmount();
+		});
+
+		it("can switch back from es to en and restores English translations", async () => {
+			const harness = await mountI18nHarness();
+
+			await act(async () => {
+				harness.getCurrent().setLocale("es");
+			});
+			await flushEffects();
+
+			await act(async () => {
+				harness.getCurrent().setLocale("en");
+			});
+			await flushEffects();
+
+			expect(harness.getCurrent().locale).toBe("en");
+			expect(harness.getCurrent().t("common.app.subtitle")).toBe("Screen recording and editing");
+			await harness.unmount();
+		});
+	});
+});
+
+// ── useScopedT ───────────────────────────────────────────────────────────────
+
+describe("useScopedT", () => {
+	it("prepends the namespace to the key so scoped lookups resolve correctly", async () => {
+		const h = await mountScopedTHarness("common");
+		// "app.name" under the "common" namespace → "Open Recorder"
+		expect(h.t()("app.name")).toBe("Open Recorder");
+		await h.unmount();
+	});
+
+	it("passes through the fallback parameter", async () => {
+		const h = await mountScopedTHarness("common");
+		expect(h.t()("nonexistent.key", "My Fallback")).toBe("My Fallback");
+		await h.unmount();
+	});
+
+	it("passes through the vars parameter for interpolation", async () => {
+		const h = await mountScopedTHarness("common");
+		expect(h.t()("missing", "Hello {{ who }}", { who: "Test" })).toBe("Hello Test");
+		await h.unmount();
+	});
+
+	it("throws when used outside <I18nProvider>", async () => {
+		function BrokenConsumer() {
+			useScopedT("common");
+			return null;
+		}
+
+		const container = document.createElement("div");
+		const root = createRoot(container);
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		let caughtError: unknown;
+
+		try {
+			await act(async () => {
+				root.render(<BrokenConsumer />);
+			});
+		} catch (error) {
+			caughtError = error;
+		} finally {
+			consoleError.mockRestore();
+			await act(async () => {
+				root.unmount();
+			});
+		}
+
+		expect(caughtError).toBeDefined();
+		expect(String(caughtError)).toContain("useI18n must be used within <I18nProvider>");
+	});
+});
+
+// ── normalizeLocale ──────────────────────────────────────────────────────────
+
+describe("normalizeLocale", () => {
+	it("returns 'en' for null input", () => {
+		expect(normalizeLocale(null)).toBe("en");
+	});
+
+	it("returns 'en' for undefined input", () => {
+		expect(normalizeLocale(undefined)).toBe("en");
+	});
+
+	it("returns 'en' for empty string", () => {
+		expect(normalizeLocale("")).toBe("en");
+	});
+
+	it("normalizes 'en' to 'en'", () => {
+		expect(normalizeLocale("en")).toBe("en");
+	});
+
+	it("normalizes 'es' to 'es'", () => {
+		expect(normalizeLocale("es")).toBe("es");
+	});
+
+	it("strips the subtag from 'en-US' to produce 'en'", () => {
+		expect(normalizeLocale("en-US")).toBe("en");
+	});
+
+	it("strips the subtag from 'es-MX' to produce 'es'", () => {
+		expect(normalizeLocale("es-MX")).toBe("es");
+	});
+
+	it("falls back to 'en' for an unsupported locale ('fr')", () => {
+		expect(normalizeLocale("fr")).toBe("en");
+	});
+
+	it("is case-insensitive ('EN' normalizes to 'en')", () => {
+		expect(normalizeLocale("EN")).toBe("en");
+	});
+
+	it("is case-insensitive ('ES' normalizes to 'es')", () => {
+		expect(normalizeLocale("ES")).toBe("es");
+	});
+});

--- a/apps/desktop/src/contexts/ShortcutsContext.additional.test.tsx
+++ b/apps/desktop/src/contexts/ShortcutsContext.additional.test.tsx
@@ -1,0 +1,469 @@
+// @vitest-environment jsdom
+
+import { Provider } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	bindingsEqual,
+	DEFAULT_SHORTCUTS,
+	findConflict,
+	formatBinding,
+	matchesShortcut,
+	mergeWithDefaults,
+	type ShortcutBinding,
+	type ShortcutsConfig,
+} from "@/lib/shortcuts";
+import { ShortcutsProvider, useShortcuts } from "./ShortcutsContext";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/backend", () => ({
+	getShortcuts: vi.fn(),
+	saveShortcuts: vi.fn(),
+}));
+
+vi.mock("@/utils/platformUtils", () => ({
+	isMac: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const backend = vi.mocked(await import("@/lib/backend"));
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const platformUtils = vi.mocked(await import("@/utils/platformUtils"));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+type HarnessResult = {
+	getCurrent: () => ReturnType<typeof useShortcuts>;
+	unmount: () => Promise<void>;
+};
+
+async function flushEffects() {
+	await act(async () => {
+		await Promise.resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+async function mountShortcutsHarness(): Promise<HarnessResult> {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const root: Root = createRoot(container);
+	const store = createStore();
+	let currentValue!: ReturnType<typeof useShortcuts>;
+
+	function Harness() {
+		currentValue = useShortcuts();
+		return null;
+	}
+
+	await act(async () => {
+		root.render(
+			<Provider store={store}>
+				<ShortcutsProvider>
+					<Harness />
+				</ShortcutsProvider>
+			</Provider>,
+		);
+	});
+	await flushEffects();
+
+	return {
+		getCurrent: () => currentValue,
+		unmount: async () => {
+			await act(async () => {
+				root.unmount();
+			});
+			container.remove();
+		},
+	};
+}
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	platformUtils.isMac.mockResolvedValue(false);
+	backend.getShortcuts.mockResolvedValue(null);
+});
+
+afterEach(() => {
+	document.body.innerHTML = "";
+});
+
+// ─── ShortcutsContext behavior ────────────────────────────────────────────────
+
+describe("ShortcutsContext – additional coverage", () => {
+	describe("initial state", () => {
+		it("starts with DEFAULT_SHORTCUTS when backend returns null", async () => {
+			const harness = await mountShortcutsHarness();
+			expect(harness.getCurrent().shortcuts).toEqual(DEFAULT_SHORTCUTS);
+			await harness.unmount();
+		});
+
+		it("starts with isMac=false when platform detection returns false", async () => {
+			const harness = await mountShortcutsHarness();
+			expect(harness.getCurrent().isMac).toBe(false);
+			await harness.unmount();
+		});
+
+		it("reflects isMac=true when platform is macOS", async () => {
+			platformUtils.isMac.mockResolvedValue(true);
+
+			const harness = await mountShortcutsHarness();
+			expect(harness.getCurrent().isMac).toBe(true);
+			await harness.unmount();
+		});
+	});
+
+	describe("error handling", () => {
+		it("keeps DEFAULT_SHORTCUTS when backend getShortcuts rejects", async () => {
+			backend.getShortcuts.mockRejectedValue(new Error("Storage error"));
+
+			const harness = await mountShortcutsHarness();
+			expect(harness.getCurrent().shortcuts).toEqual(DEFAULT_SHORTCUTS);
+			await harness.unmount();
+		});
+
+		it("keeps isMac=false when platform detection rejects", async () => {
+			platformUtils.isMac.mockRejectedValue(new Error("Platform error"));
+
+			const harness = await mountShortcutsHarness();
+			expect(harness.getCurrent().isMac).toBe(false);
+			await harness.unmount();
+		});
+
+		it("does not throw when persistShortcuts fails", async () => {
+			backend.saveShortcuts.mockRejectedValue(new Error("Save failed"));
+
+			const harness = await mountShortcutsHarness();
+
+			await act(async () => {
+				try {
+					await harness.getCurrent().persistShortcuts();
+				} catch {
+					// expected to fail – just verify no unhandled crash
+				}
+			});
+
+			expect(backend.saveShortcuts).toHaveBeenCalled();
+			await harness.unmount();
+		});
+	});
+
+	describe("setShortcuts", () => {
+		it("immediately updates the shortcuts state in the atom", async () => {
+			const harness = await mountShortcutsHarness();
+
+			const newShortcuts: ShortcutsConfig = {
+				...DEFAULT_SHORTCUTS,
+				addZoom: { key: "q" },
+			};
+
+			await act(async () => {
+				harness.getCurrent().setShortcuts(newShortcuts);
+			});
+
+			expect(harness.getCurrent().shortcuts.addZoom).toEqual({ key: "q" });
+			await harness.unmount();
+		});
+
+		it("does not persist to backend until persistShortcuts is explicitly called", async () => {
+			const harness = await mountShortcutsHarness();
+
+			await act(async () => {
+				harness.getCurrent().setShortcuts({ ...DEFAULT_SHORTCUTS, addTrim: { key: "x" } });
+			});
+
+			expect(backend.saveShortcuts).not.toHaveBeenCalled();
+			await harness.unmount();
+		});
+	});
+
+	describe("persistShortcuts", () => {
+		it("saves current shortcuts when called without arguments", async () => {
+			const harness = await mountShortcutsHarness();
+
+			await act(async () => {
+				await harness.getCurrent().persistShortcuts();
+			});
+
+			expect(backend.saveShortcuts).toHaveBeenCalledWith(harness.getCurrent().shortcuts);
+			await harness.unmount();
+		});
+
+		it("saves the explicitly provided shortcuts config", async () => {
+			const harness = await mountShortcutsHarness();
+
+			const customShortcuts: ShortcutsConfig = {
+				...DEFAULT_SHORTCUTS,
+				playPause: { key: "k" },
+			};
+
+			await act(async () => {
+				await harness.getCurrent().persistShortcuts(customShortcuts);
+			});
+
+			expect(backend.saveShortcuts).toHaveBeenCalledWith(customShortcuts);
+			await harness.unmount();
+		});
+
+		it("calls saveShortcuts once per persistShortcuts call", async () => {
+			const harness = await mountShortcutsHarness();
+
+			await act(async () => {
+				await harness.getCurrent().persistShortcuts();
+				await harness.getCurrent().persistShortcuts();
+			});
+
+			expect(backend.saveShortcuts).toHaveBeenCalledTimes(2);
+			await harness.unmount();
+		});
+	});
+
+	describe("config dialog state", () => {
+		it("isConfigOpen starts as false", async () => {
+			const harness = await mountShortcutsHarness();
+			expect(harness.getCurrent().isConfigOpen).toBe(false);
+			await harness.unmount();
+		});
+
+		it("openConfig sets isConfigOpen=true, closeConfig sets it back to false", async () => {
+			const harness = await mountShortcutsHarness();
+
+			await act(async () => {
+				harness.getCurrent().openConfig();
+			});
+			expect(harness.getCurrent().isConfigOpen).toBe(true);
+
+			await act(async () => {
+				harness.getCurrent().closeConfig();
+			});
+			expect(harness.getCurrent().isConfigOpen).toBe(false);
+
+			await harness.unmount();
+		});
+	});
+
+	describe("shortcuts merging from backend", () => {
+		it("overrides only the provided keys and keeps defaults for the rest", async () => {
+			backend.getShortcuts.mockResolvedValue({ addZoom: { key: "q" } });
+
+			const harness = await mountShortcutsHarness();
+
+			expect(harness.getCurrent().shortcuts.addZoom).toEqual({ key: "q" });
+			expect(harness.getCurrent().shortcuts.playPause).toEqual(DEFAULT_SHORTCUTS.playPause);
+
+			await harness.unmount();
+		});
+
+		it("merges multiple overrides correctly", async () => {
+			backend.getShortcuts.mockResolvedValue({
+				addZoom: { key: "1" },
+				addTrim: { key: "2" },
+				playPause: { key: "p", ctrl: true },
+			});
+
+			const harness = await mountShortcutsHarness();
+
+			expect(harness.getCurrent().shortcuts.addZoom).toEqual({ key: "1" });
+			expect(harness.getCurrent().shortcuts.addTrim).toEqual({ key: "2" });
+			expect(harness.getCurrent().shortcuts.playPause).toEqual({ key: "p", ctrl: true });
+
+			await harness.unmount();
+		});
+	});
+
+	describe("useShortcuts outside provider", () => {
+		it("throws when used outside <ShortcutsProvider>", async () => {
+			function BrokenConsumer() {
+				useShortcuts();
+				return null;
+			}
+
+			const container = document.createElement("div");
+			const root = createRoot(container);
+			const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+			let caughtError: unknown;
+
+			try {
+				await act(async () => {
+					root.render(<BrokenConsumer />);
+				});
+			} catch (error) {
+				caughtError = error;
+			} finally {
+				consoleError.mockRestore();
+				await act(async () => {
+					root.unmount();
+				});
+			}
+
+			expect(caughtError).toBeDefined();
+			expect(String(caughtError)).toContain(
+				"useShortcuts must be used within <ShortcutsProvider>",
+			);
+		});
+	});
+});
+
+// ─── shortcuts lib utility functions ─────────────────────────────────────────
+
+describe("bindingsEqual", () => {
+	it("returns true for identical bindings", () => {
+		const a: ShortcutBinding = { key: "z", ctrl: true, shift: false };
+		const b: ShortcutBinding = { key: "z", ctrl: true, shift: false };
+		expect(bindingsEqual(a, b)).toBe(true);
+	});
+
+	it("returns false when keys differ", () => {
+		expect(bindingsEqual({ key: "z" }, { key: "x" })).toBe(false);
+	});
+
+	it("returns false when ctrl modifier differs", () => {
+		expect(bindingsEqual({ key: "z", ctrl: true }, { key: "z" })).toBe(false);
+	});
+
+	it("returns false when shift modifier differs", () => {
+		expect(bindingsEqual({ key: "z", shift: true }, { key: "z" })).toBe(false);
+	});
+
+	it("returns false when alt modifier differs", () => {
+		expect(bindingsEqual({ key: "z", alt: true }, { key: "z" })).toBe(false);
+	});
+
+	it("is case-insensitive for key comparison", () => {
+		expect(bindingsEqual({ key: "Z" }, { key: "z" })).toBe(true);
+	});
+
+	it("treats undefined and false as equivalent for modifier flags", () => {
+		expect(bindingsEqual({ key: "a", ctrl: false }, { key: "a" })).toBe(true);
+	});
+});
+
+describe("findConflict", () => {
+	it("returns null when there is no conflict", () => {
+		const result = findConflict({ key: "q" }, "addZoom", DEFAULT_SHORTCUTS);
+		expect(result).toBeNull();
+	});
+
+	it("detects a conflict with a fixed shortcut (tab key)", () => {
+		const result = findConflict({ key: "tab" }, "addZoom", DEFAULT_SHORTCUTS);
+		expect(result).not.toBeNull();
+		expect(result?.type).toBe("fixed");
+	});
+
+	it("detects a conflict with another configurable action", () => {
+		// addTrim default is 't' — assigning 't' to addZoom should conflict with addTrim
+		const result = findConflict({ key: "t" }, "addZoom", DEFAULT_SHORTCUTS);
+		expect(result).not.toBeNull();
+		expect(result?.type).toBe("configurable");
+		expect((result as { type: "configurable"; action: string }).action).toBe("addTrim");
+	});
+
+	it("does not flag a self-conflict when the action keeps its own binding", () => {
+		const result = findConflict(DEFAULT_SHORTCUTS.addZoom, "addZoom", DEFAULT_SHORTCUTS);
+		expect(result).toBeNull();
+	});
+});
+
+describe("formatBinding", () => {
+	it("formats a simple key on non-macOS", () => {
+		expect(formatBinding({ key: "z" }, false)).toBe("Z");
+	});
+
+	it("formats Ctrl modifier on non-macOS", () => {
+		expect(formatBinding({ key: "z", ctrl: true }, false)).toBe("Ctrl + Z");
+	});
+
+	it("formats ⌘ (Cmd) modifier on macOS", () => {
+		expect(formatBinding({ key: "z", ctrl: true }, true)).toBe("⌘ + Z");
+	});
+
+	it("formats Shift+Alt combination on non-macOS", () => {
+		expect(formatBinding({ key: "a", shift: true, alt: true }, false)).toBe("Shift + Alt + A");
+	});
+
+	it("uses the human-readable label for space key", () => {
+		expect(formatBinding({ key: " " }, false)).toBe("Space");
+	});
+});
+
+describe("matchesShortcut", () => {
+	function makeKeyboardEvent(
+		key: string,
+		{
+			ctrlKey = false,
+			metaKey = false,
+			shiftKey = false,
+			altKey = false,
+		}: Partial<{
+			ctrlKey: boolean;
+			metaKey: boolean;
+			shiftKey: boolean;
+			altKey: boolean;
+		}> = {},
+	): KeyboardEvent {
+		return { key, ctrlKey, metaKey, shiftKey, altKey } as KeyboardEvent;
+	}
+
+	it("matches a simple key press", () => {
+		expect(matchesShortcut(makeKeyboardEvent("z"), { key: "z" }, false)).toBe(true);
+	});
+
+	it("returns false for wrong key", () => {
+		expect(matchesShortcut(makeKeyboardEvent("x"), { key: "z" }, false)).toBe(false);
+	});
+
+	it("matches Ctrl+key on non-macOS using ctrlKey", () => {
+		expect(
+			matchesShortcut(makeKeyboardEvent("z", { ctrlKey: true }), { key: "z", ctrl: true }, false),
+		).toBe(true);
+	});
+
+	it("matches Cmd+key on macOS using metaKey", () => {
+		expect(
+			matchesShortcut(makeKeyboardEvent("z", { metaKey: true }), { key: "z", ctrl: true }, true),
+		).toBe(true);
+	});
+
+	it("returns false when modifier is required but not pressed", () => {
+		expect(matchesShortcut(makeKeyboardEvent("z"), { key: "z", ctrl: true }, false)).toBe(false);
+	});
+
+	it("is case-insensitive for the key comparison", () => {
+		expect(matchesShortcut(makeKeyboardEvent("Z"), { key: "z" }, false)).toBe(true);
+	});
+});
+
+describe("mergeWithDefaults", () => {
+	it("returns all DEFAULT_SHORTCUTS when partial is empty", () => {
+		expect(mergeWithDefaults({})).toEqual(DEFAULT_SHORTCUTS);
+	});
+
+	it("overrides a specific action while keeping the rest as defaults", () => {
+		const result = mergeWithDefaults({ addZoom: { key: "q" } });
+		expect(result.addZoom).toEqual({ key: "q" });
+		expect(result.addTrim).toEqual(DEFAULT_SHORTCUTS.addTrim);
+	});
+
+	it("does not mutate the DEFAULT_SHORTCUTS object", () => {
+		const before = { ...DEFAULT_SHORTCUTS };
+		mergeWithDefaults({ addZoom: { key: "q" } });
+		expect(DEFAULT_SHORTCUTS).toEqual(before);
+	});
+
+	it("merges multiple partial overrides in one call", () => {
+		const result = mergeWithDefaults({
+			addZoom: { key: "1" },
+			addTrim: { key: "2" },
+		});
+		expect(result.addZoom).toEqual({ key: "1" });
+		expect(result.addTrim).toEqual({ key: "2" });
+		expect(result.playPause).toEqual(DEFAULT_SHORTCUTS.playPause);
+	});
+});

--- a/apps/desktop/src/hooks/usePermissionAwareMediaDevices.additional.test.tsx
+++ b/apps/desktop/src/hooks/usePermissionAwareMediaDevices.additional.test.tsx
@@ -1,0 +1,571 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	enumeratePermissionAwareDevices,
+	filterDevicesByKind,
+	mapSelectableDevice,
+	resolveSelectedDeviceId,
+	shouldRequestDeviceAccess,
+	usePermissionAwareMediaDevices,
+} from "./usePermissionAwareMediaDevices";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type DeviceKind = "audioinput" | "videoinput";
+
+type HookHarnessResult<T> = {
+	getCurrent: () => T;
+	unmount: () => Promise<void>;
+};
+
+function createDevice(
+	kind: DeviceKind,
+	deviceId: string,
+	label: string,
+	groupId: string = `${deviceId}-group`,
+): MediaDeviceInfo {
+	return {
+		deviceId,
+		groupId,
+		kind,
+		label,
+		toJSON: () => ({ deviceId, groupId, kind, label }),
+	} as MediaDeviceInfo;
+}
+
+function createMediaDevicesMock(
+	enumerateResponses: MediaDeviceInfo[][],
+	getUserMediaImpl: MediaDevices["getUserMedia"] = vi.fn(async () => ({
+		getTracks: () => [{ stop: vi.fn() }],
+	})) as MediaDevices["getUserMedia"],
+) {
+	let enumerateCall = 0;
+	const deviceChangeListeners = new Set<() => void>();
+
+	const mediaDevices = {
+		enumerateDevices: vi.fn(async () => {
+			const responseIndex = Math.min(enumerateCall, enumerateResponses.length - 1);
+			enumerateCall += 1;
+			return enumerateResponses[responseIndex];
+		}),
+		getUserMedia: vi.fn(getUserMediaImpl),
+		addEventListener: vi.fn((event: string, listener: EventListenerOrEventListenerObject) => {
+			if (event === "devicechange" && typeof listener === "function") {
+				deviceChangeListeners.add(listener as () => void);
+			}
+		}),
+		removeEventListener: vi.fn(
+			(event: string, listener: EventListenerOrEventListenerObject) => {
+				if (event === "devicechange" && typeof listener === "function") {
+					deviceChangeListeners.delete(listener as () => void);
+				}
+			},
+		),
+		emitDeviceChange: async () => {
+			await act(async () => {
+				deviceChangeListeners.forEach((listener) => listener());
+			});
+			await flushEffects();
+		},
+	};
+
+	Object.defineProperty(navigator, "mediaDevices", {
+		configurable: true,
+		value: mediaDevices,
+	});
+
+	return mediaDevices;
+}
+
+async function flushEffects() {
+	await act(async () => {
+		await Promise.resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+async function mountHook<T>(renderHook: () => T): Promise<HookHarnessResult<T>> {
+	const container = document.createElement("div");
+	const root: Root = createRoot(container);
+	let currentValue!: T;
+
+	function Harness() {
+		currentValue = renderHook();
+		return null;
+	}
+
+	await act(async () => {
+		root.render(<Harness />);
+	});
+	await flushEffects();
+
+	return {
+		getCurrent: () => currentValue,
+		unmount: async () => {
+			await act(async () => {
+				root.unmount();
+			});
+		},
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ── filterDevicesByKind ───────────────────────────────────────────────────────
+
+describe("filterDevicesByKind", () => {
+	it("returns only audioinput devices from a mixed list", () => {
+		const devices = [
+			createDevice("audioinput", "mic-1", "Microphone"),
+			createDevice("videoinput", "cam-1", "Camera"),
+			createDevice("audioinput", "mic-2", "Headset"),
+		];
+		const result = filterDevicesByKind(devices, "audioinput");
+		expect(result).toHaveLength(2);
+		expect(result.every((d) => d.kind === "audioinput")).toBe(true);
+	});
+
+	it("returns only videoinput devices from a mixed list", () => {
+		const devices = [
+			createDevice("audioinput", "mic-1", "Microphone"),
+			createDevice("videoinput", "cam-1", "Camera"),
+			createDevice("videoinput", "cam-2", "Webcam"),
+		];
+		const result = filterDevicesByKind(devices, "videoinput");
+		expect(result).toHaveLength(2);
+		expect(result.every((d) => d.kind === "videoinput")).toBe(true);
+	});
+
+	it("returns empty array when no devices match the requested kind", () => {
+		const devices = [createDevice("audioinput", "mic-1", "Microphone")];
+		expect(filterDevicesByKind(devices, "videoinput")).toHaveLength(0);
+	});
+
+	it("returns empty array when the input list is empty", () => {
+		expect(filterDevicesByKind([], "audioinput")).toHaveLength(0);
+	});
+});
+
+// ── shouldRequestDeviceAccess ────────────────────────────────────────────────
+
+describe("shouldRequestDeviceAccess", () => {
+	it("returns true for an empty device list", () => {
+		expect(shouldRequestDeviceAccess([])).toBe(true);
+	});
+
+	it("returns true when there is exactly one device", () => {
+		const devices = [createDevice("audioinput", "default", "Default Microphone")];
+		expect(shouldRequestDeviceAccess(devices)).toBe(true);
+	});
+
+	it("returns true when any device has an empty label", () => {
+		const devices = [
+			createDevice("audioinput", "mic-1", "Microphone"),
+			createDevice("audioinput", "mic-2", ""),
+		];
+		expect(shouldRequestDeviceAccess(devices)).toBe(true);
+	});
+
+	it("returns true when all device IDs are placeholder values", () => {
+		const devices = [
+			createDevice("audioinput", "default", "Default"),
+			createDevice("audioinput", "communications", "Communications"),
+		];
+		expect(shouldRequestDeviceAccess(devices)).toBe(true);
+	});
+
+	it("returns false when 2+ devices all have real IDs and labels", () => {
+		const devices = [
+			createDevice("audioinput", "mic-1", "USB Microphone"),
+			createDevice("audioinput", "mic-2", "Built-in Microphone"),
+		];
+		expect(shouldRequestDeviceAccess(devices)).toBe(false);
+	});
+
+	it("returns true when a label contains only whitespace", () => {
+		const devices = [
+			createDevice("audioinput", "mic-1", "Microphone"),
+			createDevice("audioinput", "mic-2", "   "),
+		];
+		expect(shouldRequestDeviceAccess(devices)).toBe(true);
+	});
+});
+
+// ── mapSelectableDevice ───────────────────────────────────────────────────────
+
+describe("mapSelectableDevice", () => {
+	it("preserves the device label when it is non-empty", () => {
+		const device = createDevice("audioinput", "abc123", "USB Microphone");
+		const result = mapSelectableDevice(device, "Microphone");
+		expect(result.label).toBe("USB Microphone");
+		expect(result.deviceId).toBe("abc123");
+		expect(result.groupId).toBe("abc123-group");
+	});
+
+	it("uses fallback prefix + first 8 chars of deviceId when label is empty", () => {
+		const device = createDevice("audioinput", "abc123def456", "");
+		const result = mapSelectableDevice(device, "Microphone");
+		expect(result.label).toBe("Microphone abc123de");
+	});
+
+	it("preserves all three selectable-device fields", () => {
+		const device = createDevice("videoinput", "cam-999", "My Camera", "group-abc");
+		const result = mapSelectableDevice(device, "Camera");
+		expect(result).toEqual({ deviceId: "cam-999", label: "My Camera", groupId: "group-abc" });
+	});
+});
+
+// ── resolveSelectedDeviceId ───────────────────────────────────────────────────
+
+describe("resolveSelectedDeviceId", () => {
+	const devices = [
+		{ deviceId: "cam-1", label: "Camera One", groupId: "g1" },
+		{ deviceId: "cam-2", label: "Camera Two", groupId: "g2" },
+	];
+
+	it("keeps the current selection when it exists in the device list", () => {
+		expect(resolveSelectedDeviceId("cam-2", devices, false)).toBe("cam-2");
+	});
+
+	it("returns 'default' when current selection is not in list and autoSelect is off", () => {
+		expect(resolveSelectedDeviceId("cam-99", devices, false)).toBe("default");
+	});
+
+	it("auto-selects first device when current is 'default' and autoSelectFirstDevice=true", () => {
+		expect(resolveSelectedDeviceId("default", devices, true)).toBe("cam-1");
+	});
+
+	it("auto-selects first device when current is missing and autoSelectFirstDevice=true", () => {
+		expect(resolveSelectedDeviceId("cam-99", devices, true)).toBe("cam-1");
+	});
+
+	it("returns 'default' when devices are empty even with autoSelectFirstDevice=true", () => {
+		expect(resolveSelectedDeviceId("default", [], true)).toBe("default");
+	});
+
+	it("returns 'default' for 'default' currentId without auto-select enabled", () => {
+		expect(resolveSelectedDeviceId("default", devices, false)).toBe("default");
+	});
+});
+
+// ── enumeratePermissionAwareDevices ──────────────────────────────────────────
+
+describe("enumeratePermissionAwareDevices", () => {
+	it("returns filtered and mapped devices by kind", async () => {
+		const mockMediaDevices = {
+			enumerateDevices: vi.fn(async () => [
+				createDevice("audioinput", "mic-1", "USB Mic"),
+				createDevice("videoinput", "cam-1", "Webcam"),
+				createDevice("audioinput", "mic-2", "Headset"),
+			]),
+		} as unknown as MediaDevices;
+
+		const result = await enumeratePermissionAwareDevices(mockMediaDevices, "audioinput", "Mic");
+		expect(result).toHaveLength(2);
+		expect(result.every((d) => d.deviceId !== "")).toBe(true);
+	});
+
+	it("excludes devices with an empty deviceId", async () => {
+		const mockMediaDevices = {
+			enumerateDevices: vi.fn(async () => [
+				createDevice("audioinput", "", "Empty ID device"),
+				createDevice("audioinput", "mic-1", "Real Device"),
+			]),
+		} as unknown as MediaDevices;
+
+		const result = await enumeratePermissionAwareDevices(mockMediaDevices, "audioinput", "Mic");
+		expect(result).toHaveLength(1);
+		expect(result[0].deviceId).toBe("mic-1");
+	});
+});
+
+// ── hook: disabled state ──────────────────────────────────────────────────────
+
+describe("usePermissionAwareMediaDevices – disabled state", () => {
+	it("does not load devices when enabled=false", async () => {
+		const mediaDevices = createMediaDevicesMock([
+			[createDevice("audioinput", "mic-1", "USB Microphone")],
+		]);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				enabled: false,
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().devices).toEqual([]);
+		expect(hook.getCurrent().isLoading).toBe(false);
+		expect(mediaDevices.enumerateDevices).not.toHaveBeenCalled();
+
+		await hook.unmount();
+	});
+
+	it("does not register a devicechange listener when disabled", async () => {
+		const mediaDevices = createMediaDevicesMock([
+			[createDevice("audioinput", "mic-1", "USB Microphone")],
+		]);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				enabled: false,
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(mediaDevices.addEventListener).not.toHaveBeenCalled();
+
+		await hook.unmount();
+	});
+});
+
+// ── hook: error handling ──────────────────────────────────────────────────────
+
+describe("usePermissionAwareMediaDevices – error handling", () => {
+	afterEach(() => {
+		// Restore a valid mediaDevices object after each test in this block
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: {
+				enumerateDevices: vi.fn(async () => []),
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				getUserMedia: vi.fn(async () => ({ getTracks: () => [] })),
+			},
+		});
+	});
+
+	it("sets the unavailableMessage error when mediaDevices is undefined", async () => {
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: undefined,
+		});
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Microphone not available",
+			}),
+		);
+
+		expect(hook.getCurrent().error).toBe("Microphone not available");
+		expect(hook.getCurrent().devices).toEqual([]);
+		expect(hook.getCurrent().isLoading).toBe(false);
+
+		await hook.unmount();
+	});
+
+	it("sets error and empty devices when enumerateDevices throws", async () => {
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: {
+				enumerateDevices: vi.fn(async () => {
+					throw new Error("Enumeration failed");
+				}),
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+			},
+		});
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().error).toBe("Enumeration failed");
+		expect(hook.getCurrent().devices).toEqual([]);
+		expect(hook.getCurrent().isLoading).toBe(false);
+
+		await hook.unmount();
+	});
+
+	it("sets permissionDenied=true and specific error for PermissionDeniedError", async () => {
+		createMediaDevicesMock(
+			[[createDevice("audioinput", "default", "")]],
+			vi.fn(async () => {
+				throw new DOMException("Permission denied", "PermissionDeniedError");
+			}) as MediaDevices["getUserMedia"],
+		);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().permissionDenied).toBe(true);
+		expect(hook.getCurrent().error).toContain("Microphone access was denied");
+
+		await hook.unmount();
+	});
+
+	it("sets permissionDenied=true for SecurityError", async () => {
+		createMediaDevicesMock(
+			[[createDevice("audioinput", "default", "")]],
+			vi.fn(async () => {
+				throw new DOMException("Security error", "SecurityError");
+			}) as MediaDevices["getUserMedia"],
+		);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().permissionDenied).toBe(true);
+
+		await hook.unmount();
+	});
+
+	it("sets error but not permissionDenied for generic getUserMedia errors", async () => {
+		createMediaDevicesMock(
+			[[createDevice("audioinput", "default", "")]],
+			vi.fn(async () => {
+				throw new Error("Generic device error");
+			}) as MediaDevices["getUserMedia"],
+		);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().permissionDenied).toBe(false);
+		expect(hook.getCurrent().error).toBe("Generic device error");
+
+		await hook.unmount();
+	});
+});
+
+// ── hook: camera devices ──────────────────────────────────────────────────────
+
+describe("usePermissionAwareMediaDevices – videoinput (camera)", () => {
+	it("loads camera devices and auto-selects the first when configured", async () => {
+		createMediaDevicesMock([
+			[
+				createDevice("videoinput", "cam-1", "Built-in Camera"),
+				createDevice("videoinput", "cam-2", "USB Camera"),
+			],
+		]);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "videoinput",
+				fallbackLabelPrefix: "Camera",
+				unavailableMessage: "Camera unavailable",
+				autoSelectFirstDevice: true,
+			}),
+		);
+
+		expect(hook.getCurrent().devices).toHaveLength(2);
+		expect(hook.getCurrent().selectedDeviceId).toBe("cam-1");
+		expect(hook.getCurrent().permissionDenied).toBe(false);
+
+		await hook.unmount();
+	});
+
+	it("shows the correct camera-specific denial message on NotAllowedError", async () => {
+		createMediaDevicesMock(
+			[[createDevice("videoinput", "default", "")]],
+			vi.fn(async () => {
+				throw new DOMException("denied", "NotAllowedError");
+			}) as MediaDevices["getUserMedia"],
+		);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "videoinput",
+				fallbackLabelPrefix: "Camera",
+				unavailableMessage: "Camera unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().permissionDenied).toBe(true);
+		expect(hook.getCurrent().error).toContain("Camera access was denied");
+
+		await hook.unmount();
+	});
+});
+
+// ── hook: devicechange listener lifecycle ─────────────────────────────────────
+
+describe("usePermissionAwareMediaDevices – listener lifecycle", () => {
+	it("registers a devicechange listener on mount and removes it on unmount", async () => {
+		const mediaDevices = createMediaDevicesMock([
+			[createDevice("audioinput", "mic-1", "Microphone")],
+		]);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(mediaDevices.addEventListener).toHaveBeenCalledWith(
+			"devicechange",
+			expect.any(Function),
+		);
+
+		await hook.unmount();
+
+		expect(mediaDevices.removeEventListener).toHaveBeenCalledWith(
+			"devicechange",
+			expect.any(Function),
+		);
+	});
+
+	it("does not re-request getUserMedia on device change after a previous denial", async () => {
+		const getUserMedia = vi.fn(async () => {
+			throw new DOMException("denied", "NotAllowedError");
+		}) as MediaDevices["getUserMedia"];
+
+		const mediaDevices = createMediaDevicesMock(
+			[
+				[createDevice("audioinput", "default", "")],
+				[createDevice("audioinput", "default", "")],
+			],
+			getUserMedia,
+		);
+
+		const hook = await mountHook(() =>
+			usePermissionAwareMediaDevices({
+				kind: "audioinput",
+				fallbackLabelPrefix: "Microphone",
+				unavailableMessage: "Unavailable",
+			}),
+		);
+
+		expect(hook.getCurrent().permissionDenied).toBe(true);
+		expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+
+		await mediaDevices.emitDeviceChange();
+
+		// After denial the device-change handler passes allowPermissionPrompt=false
+		expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+
+		await hook.unmount();
+	});
+});

--- a/apps/desktop/src/hooks/usePermissions.additional.test.tsx
+++ b/apps/desktop/src/hooks/usePermissions.additional.test.tsx
@@ -1,0 +1,534 @@
+// @vitest-environment jsdom
+
+import { Provider } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PermissionState, UsePermissionsResult } from "./usePermissions";
+import { usePermissions } from "./usePermissions";
+
+// ─── Mock the backend module ──────────────────────────────────────────────────
+
+vi.mock("@/lib/backend", () => ({
+	getPlatform: vi.fn(),
+	getScreenRecordingPermissionStatus: vi.fn(),
+	getMicrophonePermissionStatus: vi.fn(),
+	getCameraPermissionStatus: vi.fn(),
+	getAccessibilityPermissionStatus: vi.fn(),
+	requestScreenRecordingPermission: vi.fn(),
+	requestMicrophonePermission: vi.fn(),
+	requestCameraPermission: vi.fn(),
+	openScreenRecordingPreferences: vi.fn(),
+	openMicrophonePreferences: vi.fn(),
+	openCameraPreferences: vi.fn(),
+	openAccessibilityPreferences: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const backend = vi.mocked(await import("@/lib/backend"));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type HookHarnessResult = {
+	getCurrent: () => UsePermissionsResult;
+	unmount: () => Promise<void>;
+};
+
+async function flushEffects() {
+	await act(async () => {
+		await Promise.resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+async function mountHook(): Promise<HookHarnessResult> {
+	const container = document.createElement("div");
+	const root: Root = createRoot(container);
+	const store = createStore();
+	let currentValue!: UsePermissionsResult;
+
+	function Harness() {
+		currentValue = usePermissions();
+		return null;
+	}
+
+	await act(async () => {
+		root.render(
+			<Provider store={store}>
+				<Harness />
+			</Provider>,
+		);
+	});
+	await flushEffects();
+
+	return {
+		getCurrent: () => currentValue,
+		unmount: async () => {
+			await act(async () => {
+				root.unmount();
+			});
+		},
+	};
+}
+
+function setupMediaDevicesMock(getUserMediaImpl?: () => Promise<MediaStream>) {
+	const stop = vi.fn();
+	const defaultImpl = async () => ({ getTracks: () => [{ stop }] }) as unknown as MediaStream;
+
+	Object.defineProperty(navigator, "mediaDevices", {
+		configurable: true,
+		value: {
+			getUserMedia: vi.fn(getUserMediaImpl ?? defaultImpl),
+			enumerateDevices: vi.fn(async () => []),
+		},
+	});
+
+	return { stop };
+}
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	setupMediaDevicesMock();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ─── Additional Tests ─────────────────────────────────────────────────────────
+
+describe("usePermissions – additional coverage", () => {
+	// ── allPermissionsGranted and allRequiredPermissionsGranted ──────────────
+
+	describe("allPermissionsGranted computed flags", () => {
+		it("allRequiredPermissionsGranted is false when accessibility is denied", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("denied");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().allRequiredPermissionsGranted).toBe(false);
+			expect(hook.getCurrent().allPermissionsGranted).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("allPermissionsGranted is false when only microphone is denied", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("denied");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().allRequiredPermissionsGranted).toBe(true);
+			expect(hook.getCurrent().allPermissionsGranted).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("allPermissionsGranted is false when only camera is denied", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("denied");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().allRequiredPermissionsGranted).toBe(true);
+			expect(hook.getCurrent().allPermissionsGranted).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("allRequiredPermissionsGranted is false when screenRecording is 'not_determined'", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("not_determined");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().allRequiredPermissionsGranted).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("treats 'restricted' status as not granted for all computed flags", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("restricted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("restricted");
+			backend.getCameraPermissionStatus.mockResolvedValue("restricted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("restricted");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().allRequiredPermissionsGranted).toBe(false);
+			expect(hook.getCurrent().allPermissionsGranted).toBe(false);
+
+			await hook.unmount();
+		});
+	});
+
+	// ── refreshPermissions ────────────────────────────────────────────────────
+
+	describe("refreshPermissions – return value and side effects", () => {
+		it("returns the resolved PermissionState as its value", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("denied");
+			backend.getCameraPermissionStatus.mockResolvedValue("denied");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("denied");
+
+			const hook = await mountHook();
+
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			let result!: PermissionState;
+			await act(async () => {
+				result = await hook.getCurrent().refreshPermissions();
+			});
+
+			expect(result).toEqual({
+				screenRecording: "granted",
+				microphone: "granted",
+				camera: "granted",
+				accessibility: "granted",
+			});
+
+			await hook.unmount();
+		});
+
+		it("calls getPlatform on each refresh invocation", async () => {
+			backend.getPlatform.mockResolvedValue("win32");
+
+			const hook = await mountHook();
+			expect(backend.getPlatform).toHaveBeenCalledTimes(1);
+
+			await act(async () => {
+				await hook.getCurrent().refreshPermissions();
+			});
+
+			expect(backend.getPlatform).toHaveBeenCalledTimes(2);
+
+			await hook.unmount();
+		});
+
+		it("sets isChecking to false after completing", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().isChecking).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("handles partial backend errors – succeeding checks retain their values, failing checks become 'unknown'", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockRejectedValue(new Error("IPC error"));
+			backend.getCameraPermissionStatus.mockResolvedValue("denied");
+			backend.getAccessibilityPermissionStatus.mockRejectedValue(new Error("IPC error"));
+
+			const hook = await mountHook();
+			const { permissions } = hook.getCurrent();
+
+			expect(permissions.screenRecording).toBe("granted");
+			expect(permissions.microphone).toBe("unknown");
+			expect(permissions.camera).toBe("denied");
+			expect(permissions.accessibility).toBe("unknown");
+
+			await hook.unmount();
+		});
+	});
+
+	// ── requestMicrophoneAccess ───────────────────────────────────────────────
+
+	describe("requestMicrophoneAccess – fallback and edge cases", () => {
+		it("falls back to getUserMedia when native macOS request throws", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus
+				.mockResolvedValueOnce("not_determined")
+				.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+			backend.requestMicrophonePermission.mockRejectedValue(new Error("IPC error"));
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestMicrophoneAccess();
+			});
+			await flushEffects();
+
+			expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+				audio: true,
+				video: false,
+			});
+			expect(granted).toBe(true);
+
+			await hook.unmount();
+		});
+
+		it("uses getUserMedia directly on non-macOS (skips native request)", async () => {
+			backend.getPlatform.mockResolvedValue("linux");
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestMicrophoneAccess();
+			});
+			await flushEffects();
+
+			expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+				audio: true,
+				video: false,
+			});
+			expect(backend.requestMicrophonePermission).not.toHaveBeenCalled();
+			expect(granted).toBe(true);
+
+			await hook.unmount();
+		});
+
+		it("returns false when getUserMedia fails on non-macOS", async () => {
+			backend.getPlatform.mockResolvedValue("win32");
+			setupMediaDevicesMock(async () => {
+				throw new DOMException("denied", "NotAllowedError");
+			});
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestMicrophoneAccess();
+			});
+			await flushEffects();
+
+			expect(granted).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("stops all tracks returned by getUserMedia stream", async () => {
+			backend.getPlatform.mockResolvedValue("win32");
+			const stop1 = vi.fn();
+			const stop2 = vi.fn();
+			setupMediaDevicesMock(
+				async () =>
+					({
+						getTracks: () => [{ stop: stop1 }, { stop: stop2 }],
+					}) as unknown as MediaStream,
+			);
+
+			const hook = await mountHook();
+
+			await act(async () => {
+				await hook.getCurrent().requestMicrophoneAccess();
+			});
+			await flushEffects();
+
+			expect(stop1).toHaveBeenCalledTimes(1);
+			expect(stop2).toHaveBeenCalledTimes(1);
+
+			await hook.unmount();
+		});
+	});
+
+	// ── requestCameraAccess ───────────────────────────────────────────────────
+
+	describe("requestCameraAccess – fallback and edge cases", () => {
+		it("falls back to getUserMedia when native macOS camera request throws", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus
+				.mockResolvedValueOnce("not_determined")
+				.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+			backend.requestCameraPermission.mockRejectedValue(new Error("IPC error"));
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestCameraAccess();
+			});
+			await flushEffects();
+
+			expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+				audio: false,
+				video: true,
+			});
+			expect(granted).toBe(true);
+
+			await hook.unmount();
+		});
+
+		it("uses getUserMedia with video constraints on non-macOS", async () => {
+			backend.getPlatform.mockResolvedValue("win32");
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestCameraAccess();
+			});
+			await flushEffects();
+
+			expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+				audio: false,
+				video: true,
+			});
+			expect(backend.requestCameraPermission).not.toHaveBeenCalled();
+			expect(granted).toBe(true);
+
+			await hook.unmount();
+		});
+	});
+
+	// ── requestScreenRecordingAccess ──────────────────────────────────────────
+
+	describe("requestScreenRecordingAccess – edge cases", () => {
+		it("returns false when backend throws and status remains denied", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+			backend.requestScreenRecordingPermission.mockRejectedValue(new Error("IPC error"));
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestScreenRecordingAccess();
+			});
+			await flushEffects();
+
+			expect(granted).toBe(false);
+
+			await hook.unmount();
+		});
+
+		it("returns true when backend returns false but re-check shows granted", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus
+				.mockResolvedValueOnce("not_determined")
+				.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+			backend.requestScreenRecordingPermission.mockResolvedValue(false);
+
+			const hook = await mountHook();
+
+			let granted!: boolean;
+			await act(async () => {
+				granted = await hook.getCurrent().requestScreenRecordingAccess();
+			});
+			await flushEffects();
+
+			expect(granted).toBe(true);
+
+			await hook.unmount();
+		});
+	});
+
+	// ── mountedRef guard ──────────────────────────────────────────────────────
+
+	describe("mountedRef guard", () => {
+		it("does not update state after component unmounts during an in-flight refresh", async () => {
+			let resolvePlatform!: (v: string) => void;
+			backend.getPlatform.mockReturnValueOnce(
+				new Promise<string>((resolve) => {
+					resolvePlatform = resolve;
+				}),
+			);
+
+			const container = document.createElement("div");
+			const root = createRoot(container);
+			let currentValue!: UsePermissionsResult;
+
+			function Harness() {
+				currentValue = usePermissions();
+				return null;
+			}
+
+			await act(async () => {
+				root.render(<Harness />);
+			});
+
+			// Capture state before platform resolves – should still be in initial "checking" state
+			expect(currentValue.permissions.screenRecording).toBe("checking");
+
+			// Unmount before the platform promise resolves
+			await act(async () => {
+				root.unmount();
+			});
+
+			// Resolve after unmount – the mountedRef guard should prevent state updates
+			await act(async () => {
+				resolvePlatform("win32");
+				await new Promise((r) => setTimeout(r, 0));
+			});
+
+			// We get here without errors – the guard worked
+			expect(currentValue.permissions.screenRecording).toBe("checking");
+		});
+	});
+
+	// ── isMacOS state ─────────────────────────────────────────────────────────
+
+	describe("isMacOS state transitions", () => {
+		it("sets isMacOS=true when darwin is detected on mount", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().isMacOS).toBe(true);
+
+			await hook.unmount();
+		});
+
+		it("updates isMacOS when platform changes between refreshPermissions calls", async () => {
+			backend.getPlatform.mockResolvedValue("win32");
+
+			const hook = await mountHook();
+			expect(hook.getCurrent().isMacOS).toBe(false);
+
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			await act(async () => {
+				await hook.getCurrent().refreshPermissions();
+			});
+			await flushEffects();
+
+			expect(hook.getCurrent().isMacOS).toBe(true);
+
+			await hook.unmount();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds 4 new `*.additional.test.tsx` files with **122 new test cases** covering Jotai-backed hooks and contexts in `apps/desktop/src/`
- All 122 tests pass alongside the existing 231 tests (353 total), with no regressions

## Files added

| File | Tests |
|------|-------|
| `hooks/usePermissions.additional.test.tsx` | 20 |
| `hooks/usePermissionAwareMediaDevices.additional.test.tsx` | 32 |
| `contexts/ShortcutsContext.additional.test.tsx` | 42 |
| `contexts/I18nContext.additional.test.tsx` | 28 |

## Coverage highlights

**`usePermissions`** (20 tests)
- `allRequiredPermissionsGranted` / `allPermissionsGranted` computed flags for denied, `not_determined`, and `restricted` statuses
- `refreshPermissions` return value, `getPlatform` call count, partial backend errors
- `requestMicrophoneAccess` / `requestCameraAccess` fallback to `getUserMedia` when native macOS path throws
- Stream track cleanup, non-macOS direct `getUserMedia` path
- `requestScreenRecordingAccess` when backend throws or returns false-but-status-granted
- `mountedRef` guard: no state updates after component unmounts during in-flight refresh
- `isMacOS` atom transitions between `refreshPermissions` calls

**`usePermissionAwareMediaDevices`** (32 tests)
- Pure utility functions: `filterDevicesByKind`, `shouldRequestDeviceAccess` (empty/whitespace/placeholder), `mapSelectableDevice` fallback label, `resolveSelectedDeviceId` all branches, `enumeratePermissionAwareDevices` empty-deviceId filtering
- Hook: disabled state, unavailable `mediaDevices`, `enumerateDevices` throws, `PermissionDeniedError` / `SecurityError` / generic errors, camera-specific denial message
- Listener lifecycle: `addEventListener` on mount, `removeEventListener` on unmount
- Post-denial device-change: `getUserMedia` not re-called after permission denied

**`ShortcutsContext`** (42 tests)
- Context: defaults, error resilience (backend throws, platform throws), `setShortcuts` atom sync, `persistShortcuts` argument/no-argument forms, config dialog open/close, partial backend merge, `useShortcuts` outside provider
- Shortcuts library utilities: `bindingsEqual` (all modifier combos, case-insensitivity), `findConflict` (fixed, configurable, self-assignment), `formatBinding` (macOS/non-macOS, special keys), `matchesShortcut` (ctrlKey vs metaKey, case-insensitive), `mergeWithDefaults` (immutability, partial overrides)

**`I18nContext`** (28 tests)
- Context: default locale, key resolution, fallback strings, key-as-fallback, `{{ }}` interpolation (string/number/missing), Spanish locale switching, `document.lang` sync, round-trip en→es→en
- `useScopedT`: namespace prepending, fallback passthrough, vars passthrough, throws outside provider
- `normalizeLocale`: null/undefined/empty, supported locales, subtag stripping, unsupported fallback, case-insensitivity

## Test plan

- [x] `pnpm test` passes with 353 tests (231 pre-existing + 122 new)
- [x] Pre-existing `gifExporter.test.ts` failure is unrelated (pixi.js navigator issue in node env)
- [x] No new test infrastructure added — follows the existing `renderHook`/`act`/`flushEffects` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)