### PR TITLE
test: add ~167 Jotai atom and component tests

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -97,6 +97,9 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.3.13",
 		"@tauri-apps/cli": "^2",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "^25.0.3",
 		"@types/react": "^18.2.64",
 		"@types/react-dom": "^18.2.21",

--- a/apps/desktop/src/atoms/jotaiProvider.test.tsx
+++ b/apps/desktop/src/atoms/jotaiProvider.test.tsx
@@ -1,0 +1,603 @@
+// @vitest-environment jsdom
+
+/**
+ * Jotai Provider + React component integration tests.
+ *
+ * Tests cover:
+ * 1. Atoms are read correctly on mount
+ * 2. State updates propagate to the UI
+ * 3. useAtomValue vs useSetAtom vs useAtom behaviour
+ * 4. Component re-render tracking (writer doesn't re-render when reader atom changes)
+ * 5. Unmount-cleanup patterns (atoms reset when component unmounts)
+ * 6. Multiple components sharing the same atom stay in sync
+ * 7. Conditional rendering based on atom state
+ * 8. Provider-store isolation (separate Providers are fully independent)
+ */
+
+import { cleanup, fireEvent, render, screen, act } from "@testing-library/react";
+import { Provider, createStore, useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	hasSelectedSourceAtom,
+	isCapturingAtom,
+	launchViewAtom,
+	recordingElapsedAtom,
+	recordingStartAtom,
+	screenshotModeAtom,
+	selectedSourceAtom,
+} from "./launch";
+import {
+	cameraEnabledAtom,
+	microphoneEnabledAtom,
+	recordingActiveAtom,
+} from "./recording";
+import {
+	settingsActiveTabAtom,
+	settingsShowCropModalAtom,
+} from "./settingsPanel";
+import {
+	isExportingAtom,
+	isPlayingAtom,
+	showExportDialogAtom,
+	videoErrorAtom,
+	videoPathAtom,
+} from "./videoEditor";
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Render `ui` inside a fresh Jotai Provider backed by `store`.
+ * Returns the store so tests can set atom values imperatively.
+ */
+function renderWithStore(
+	ui: React.ReactElement,
+	store = createStore(),
+) {
+	const result = render(<Provider store={store}>{ui}</Provider>);
+	return { store, ...result };
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+// ─── 1. Atoms are read correctly on mount ────────────────────────────────────
+
+describe("atoms are read correctly on mount", () => {
+	it("reads launchViewAtom default ('choice') on mount", () => {
+		function Display() {
+			const view = useAtomValue(launchViewAtom);
+			return <span data-testid="view">{view}</span>;
+		}
+		renderWithStore(<Display />);
+		expect(screen.getByTestId("view").textContent).toBe("choice");
+	});
+
+	it("reads isCapturingAtom default (false) on mount", () => {
+		function Display() {
+			const capturing = useAtomValue(isCapturingAtom);
+			return <span data-testid="cap">{String(capturing)}</span>;
+		}
+		renderWithStore(<Display />);
+		expect(screen.getByTestId("cap").textContent).toBe("false");
+	});
+
+	it("reads selectedSourceAtom default ('Main Display') on mount", () => {
+		function Display() {
+			const src = useAtomValue(selectedSourceAtom);
+			return <span data-testid="src">{src}</span>;
+		}
+		renderWithStore(<Display />);
+		expect(screen.getByTestId("src").textContent).toBe("Main Display");
+	});
+
+	it("reads videoPathAtom default (null → empty string) on mount", () => {
+		function Display() {
+			const path = useAtomValue(videoPathAtom);
+			return <span data-testid="path">{path ?? "null"}</span>;
+		}
+		renderWithStore(<Display />);
+		expect(screen.getByTestId("path").textContent).toBe("null");
+	});
+
+	it("reads settingsActiveTabAtom default ('appearance') on mount", () => {
+		function Display() {
+			const tab = useAtomValue(settingsActiveTabAtom);
+			return <span data-testid="tab">{tab}</span>;
+		}
+		renderWithStore(<Display />);
+		expect(screen.getByTestId("tab").textContent).toBe("appearance");
+	});
+
+	it("reads recordingActiveAtom default (false) on mount", () => {
+		function Display() {
+			const active = useAtomValue(recordingActiveAtom);
+			return <span data-testid="rec">{String(active)}</span>;
+		}
+		renderWithStore(<Display />);
+		expect(screen.getByTestId("rec").textContent).toBe("false");
+	});
+});
+
+// ─── 2. State updates propagate to the UI ────────────────────────────────────
+
+describe("state updates propagate to the UI", () => {
+	it("launchViewAtom update is reflected in the component", () => {
+		function Display() {
+			const view = useAtomValue(launchViewAtom);
+			return <span data-testid="view">{view}</span>;
+		}
+		const { store } = renderWithStore(<Display />);
+		act(() => { store.set(launchViewAtom, "recording"); });
+		expect(screen.getByTestId("view").textContent).toBe("recording");
+	});
+
+	it("isCapturingAtom update is reflected in the component", () => {
+		function Display() {
+			const capturing = useAtomValue(isCapturingAtom);
+			return <span data-testid="cap">{String(capturing)}</span>;
+		}
+		const { store } = renderWithStore(<Display />);
+		act(() => { store.set(isCapturingAtom, true); });
+		expect(screen.getByTestId("cap").textContent).toBe("true");
+	});
+
+	it("videoPathAtom update is reflected in the component", () => {
+		function Display() {
+			const path = useAtomValue(videoPathAtom);
+			return <span data-testid="path">{path ?? "null"}</span>;
+		}
+		const { store } = renderWithStore(<Display />);
+		act(() => { store.set(videoPathAtom, "/my/video.mp4"); });
+		expect(screen.getByTestId("path").textContent).toBe("/my/video.mp4");
+	});
+
+	it("recordingElapsedAtom increments are reflected", () => {
+		function Elapsed() {
+			const elapsed = useAtomValue(recordingElapsedAtom);
+			return <span data-testid="elapsed">{elapsed}</span>;
+		}
+		const { store } = renderWithStore(<Elapsed />);
+		act(() => { store.set(recordingElapsedAtom, 5); });
+		expect(screen.getByTestId("elapsed").textContent).toBe("5");
+		act(() => { store.set(recordingElapsedAtom, 10); });
+		expect(screen.getByTestId("elapsed").textContent).toBe("10");
+	});
+});
+
+// ─── 3. useAtomValue / useSetAtom / useAtom behaviour ────────────────────────
+
+describe("useAtomValue, useSetAtom, useAtom behaviour", () => {
+	it("useSetAtom triggers update seen by a useAtomValue consumer", () => {
+		function Reader() {
+			const val = useAtomValue(isPlayingAtom);
+			return <span data-testid="playing">{String(val)}</span>;
+		}
+		function Toggler() {
+			const setPlaying = useSetAtom(isPlayingAtom);
+			return <button onClick={() => setPlaying(true)}>Play</button>;
+		}
+		renderWithStore(
+			<>
+				<Reader />
+				<Toggler />
+			</>,
+		);
+		expect(screen.getByTestId("playing").textContent).toBe("false");
+		fireEvent.click(screen.getByText("Play"));
+		expect(screen.getByTestId("playing").textContent).toBe("true");
+	});
+
+	it("useAtom provides both read and write in one hook", () => {
+		function Toggle() {
+			const [capturing, setCapturing] = useAtom(isCapturingAtom);
+			return (
+				<>
+					<span data-testid="val">{String(capturing)}</span>
+					<button onClick={() => setCapturing((prev) => !prev)}>Toggle</button>
+				</>
+			);
+		}
+		renderWithStore(<Toggle />);
+		expect(screen.getByTestId("val").textContent).toBe("false");
+		fireEvent.click(screen.getByText("Toggle"));
+		expect(screen.getByTestId("val").textContent).toBe("true");
+		fireEvent.click(screen.getByText("Toggle"));
+		expect(screen.getByTestId("val").textContent).toBe("false");
+	});
+
+	it("useAtom setter can replace the full value", () => {
+		function TabSwitcher() {
+			const [tab, setTab] = useAtom(settingsActiveTabAtom);
+			return (
+				<>
+					<span data-testid="tab">{tab}</span>
+					<button onClick={() => setTab("audio")}>Audio</button>
+					<button onClick={() => setTab("appearance")}>Appearance</button>
+				</>
+			);
+		}
+		renderWithStore(<TabSwitcher />);
+		fireEvent.click(screen.getByText("Audio"));
+		expect(screen.getByTestId("tab").textContent).toBe("audio");
+		fireEvent.click(screen.getByText("Appearance"));
+		expect(screen.getByTestId("tab").textContent).toBe("appearance");
+	});
+});
+
+// ─── 4. Re-render tracking ───────────────────────────────────────────────────
+
+describe("component re-render behaviour", () => {
+	it("useSetAtom component does NOT re-render when the atom's value changes", () => {
+		let writerRenders = 0;
+
+		function Writer() {
+			writerRenders++;
+			const setPlaying = useSetAtom(isPlayingAtom);
+			return <button onClick={() => setPlaying(true)}>Play</button>;
+		}
+		function Reader() {
+			const val = useAtomValue(isPlayingAtom);
+			return <span data-testid="v">{String(val)}</span>;
+		}
+
+		renderWithStore(
+			<>
+				<Writer />
+				<Reader />
+			</>,
+		);
+
+		const rendersBeforeClick = writerRenders;
+		fireEvent.click(screen.getByText("Play"));
+
+		// Writer should not re-render; Reader should
+		expect(writerRenders).toBe(rendersBeforeClick);
+		expect(screen.getByTestId("v").textContent).toBe("true");
+	});
+
+	it("useAtomValue component re-renders only for its own atom, not unrelated atoms", () => {
+		let readerRenders = 0;
+
+		function Reader() {
+			readerRenders++;
+			useAtomValue(isPlayingAtom);
+			return null;
+		}
+
+		const { store } = renderWithStore(<Reader />);
+		const before = readerRenders;
+
+		// Change an unrelated atom (videoError)
+		act(() => { store.set(videoErrorAtom, "an error"); });
+		const afterUnrelated = readerRenders;
+		expect(afterUnrelated).toBe(before); // no extra render
+
+		// Change the watched atom
+		act(() => { store.set(isPlayingAtom, true); });
+		expect(readerRenders).toBeGreaterThan(afterUnrelated); // re-rendered
+	});
+});
+
+// ─── 5. Unmount-cleanup patterns ─────────────────────────────────────────────
+
+describe("unmount cleanup patterns", () => {
+	it("atom reset on unmount is reflected in the store", () => {
+		const store = createStore();
+		store.set(recordingStartAtom, Date.now());
+		store.set(recordingElapsedAtom, 30);
+
+		function ComponentWithCleanup() {
+			const setStart = useSetAtom(recordingStartAtom);
+			const setElapsed = useSetAtom(recordingElapsedAtom);
+			useEffect(() => {
+				return () => {
+					setStart(null);
+					setElapsed(0);
+				};
+			}, [setStart, setElapsed]);
+			return null;
+		}
+
+		const { unmount } = render(
+			<Provider store={store}>
+				<ComponentWithCleanup />
+			</Provider>,
+		);
+
+		expect(store.get(recordingStartAtom)).not.toBeNull();
+		unmount();
+		expect(store.get(recordingStartAtom)).toBeNull();
+		expect(store.get(recordingElapsedAtom)).toBe(0);
+	});
+
+	it("atom values remain after unmount when no cleanup is set up", () => {
+		const store = createStore();
+
+		function Component() {
+			const setPath = useSetAtom(videoPathAtom);
+			useEffect(() => {
+				setPath("/persisted.mp4");
+			}, [setPath]);
+			return null;
+		}
+
+		const { unmount } = render(
+			<Provider store={store}>
+				<Component />
+			</Provider>,
+		);
+
+		act(() => {}); // flush effects
+		unmount();
+
+		// No cleanup → atom retains its value
+		expect(store.get(videoPathAtom)).toBe("/persisted.mp4");
+	});
+});
+
+// ─── 6. Multiple components sharing the same atom ────────────────────────────
+
+describe("multiple components sharing the same atom stay in sync", () => {
+	it("two Reader components stay in sync when the atom changes", () => {
+		function Reader({ id }: { id: string }) {
+			const view = useAtomValue(launchViewAtom);
+			return <span data-testid={id}>{view}</span>;
+		}
+		function Writer() {
+			const setView = useSetAtom(launchViewAtom);
+			return <button onClick={() => setView("recording")}>Record</button>;
+		}
+
+		renderWithStore(
+			<>
+				<Reader id="a" />
+				<Reader id="b" />
+				<Writer />
+			</>,
+		);
+
+		expect(screen.getByTestId("a").textContent).toBe("choice");
+		expect(screen.getByTestId("b").textContent).toBe("choice");
+
+		fireEvent.click(screen.getByText("Record"));
+
+		expect(screen.getByTestId("a").textContent).toBe("recording");
+		expect(screen.getByTestId("b").textContent).toBe("recording");
+	});
+
+	it("three components sharing microphoneEnabledAtom all update together", () => {
+		function Display({ id }: { id: string }) {
+			const enabled = useAtomValue(microphoneEnabledAtom);
+			return <span data-testid={id}>{String(enabled)}</span>;
+		}
+		function Toggle() {
+			const setEnabled = useSetAtom(microphoneEnabledAtom);
+			return <button onClick={() => setEnabled(true)}>Enable Mic</button>;
+		}
+
+		renderWithStore(
+			<>
+				<Display id="c1" />
+				<Display id="c2" />
+				<Display id="c3" />
+				<Toggle />
+			</>,
+		);
+
+		fireEvent.click(screen.getByText("Enable Mic"));
+
+		expect(screen.getByTestId("c1").textContent).toBe("true");
+		expect(screen.getByTestId("c2").textContent).toBe("true");
+		expect(screen.getByTestId("c3").textContent).toBe("true");
+	});
+});
+
+// ─── 7. Conditional rendering based on atom state ────────────────────────────
+
+describe("conditional rendering based on atom state", () => {
+	it("shows recording UI only when launchViewAtom is 'recording'", () => {
+		function ConditionalView() {
+			const view = useAtomValue(launchViewAtom);
+			return (
+				<div>
+					{view === "recording" && <div data-testid="rec-ui">Recording…</div>}
+					{view !== "recording" && <div data-testid="idle-ui">Idle</div>}
+				</div>
+			);
+		}
+		const { store } = renderWithStore(<ConditionalView />);
+
+		expect(screen.getByTestId("idle-ui")).toBeTruthy();
+		expect(screen.queryByTestId("rec-ui")).toBeNull();
+
+		act(() => { store.set(launchViewAtom, "recording"); });
+
+		expect(screen.getByTestId("rec-ui")).toBeTruthy();
+		expect(screen.queryByTestId("idle-ui")).toBeNull();
+	});
+
+	it("shows export dialog only when showExportDialogAtom is true", () => {
+		function ExportDialog() {
+			const show = useAtomValue(showExportDialogAtom);
+			return show ? <div data-testid="export-dialog">Export</div> : null;
+		}
+		const { store } = renderWithStore(<ExportDialog />);
+
+		expect(screen.queryByTestId("export-dialog")).toBeNull();
+		act(() => { store.set(showExportDialogAtom, true); });
+		expect(screen.getByTestId("export-dialog")).toBeTruthy();
+		act(() => { store.set(showExportDialogAtom, false); });
+		expect(screen.queryByTestId("export-dialog")).toBeNull();
+	});
+
+	it("shows error banner only when videoErrorAtom is non-null", () => {
+		function ErrorBanner() {
+			const error = useAtomValue(videoErrorAtom);
+			return error ? <div data-testid="error">{error}</div> : null;
+		}
+		const { store } = renderWithStore(<ErrorBanner />);
+
+		expect(screen.queryByTestId("error")).toBeNull();
+		act(() => { store.set(videoErrorAtom, "Decode failed"); });
+		expect(screen.getByTestId("error").textContent).toBe("Decode failed");
+		act(() => { store.set(videoErrorAtom, null); });
+		expect(screen.queryByTestId("error")).toBeNull();
+	});
+
+	it("shows crop modal only when settingsShowCropModalAtom is true", () => {
+		function CropModal() {
+			const show = useAtomValue(settingsShowCropModalAtom);
+			return show ? <div data-testid="crop-modal">Crop</div> : null;
+		}
+		function OpenButton() {
+			const setShow = useSetAtom(settingsShowCropModalAtom);
+			return <button onClick={() => setShow(true)}>Open Crop</button>;
+		}
+		renderWithStore(
+			<>
+				<CropModal />
+				<OpenButton />
+			</>,
+		);
+
+		expect(screen.queryByTestId("crop-modal")).toBeNull();
+		fireEvent.click(screen.getByText("Open Crop"));
+		expect(screen.getByTestId("crop-modal")).toBeTruthy();
+	});
+
+	it("hides camera panel when cameraEnabledAtom is false", () => {
+		function CameraPanel() {
+			const enabled = useAtomValue(cameraEnabledAtom);
+			return enabled ? <div data-testid="cam-panel">Camera active</div> : null;
+		}
+		const { store } = renderWithStore(<CameraPanel />);
+
+		expect(screen.queryByTestId("cam-panel")).toBeNull();
+		act(() => { store.set(cameraEnabledAtom, true); });
+		expect(screen.getByTestId("cam-panel")).toBeTruthy();
+	});
+
+	it("shows exporting indicator when isExportingAtom is true", () => {
+		function ExportIndicator() {
+			const exporting = useAtomValue(isExportingAtom);
+			return exporting ? <div data-testid="exporting">Exporting…</div> : null;
+		}
+		const { store } = renderWithStore(<ExportIndicator />);
+
+		expect(screen.queryByTestId("exporting")).toBeNull();
+		act(() => { store.set(isExportingAtom, true); });
+		expect(screen.getByTestId("exporting")).toBeTruthy();
+	});
+});
+
+// ─── 8. Provider-store isolation ─────────────────────────────────────────────
+
+describe("Provider-store isolation", () => {
+	it("two separate Providers do not share atom state", () => {
+		function Display({ id }: { id: string }) {
+			const view = useAtomValue(launchViewAtom);
+			return <span data-testid={id}>{view}</span>;
+		}
+
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(launchViewAtom, "recording");
+
+		render(
+			<>
+				<Provider store={storeA}>
+					<Display id="storeA" />
+				</Provider>
+				<Provider store={storeB}>
+					<Display id="storeB" />
+				</Provider>
+			</>,
+		);
+
+		expect(screen.getByTestId("storeA").textContent).toBe("recording");
+		expect(screen.getByTestId("storeB").textContent).toBe("choice");
+	});
+
+	it("writing to storeA does not cause storeB component to re-render", () => {
+		let storeBRenders = 0;
+
+		function StoreBDisplay() {
+			storeBRenders++;
+			const view = useAtomValue(launchViewAtom);
+			return <span>{view}</span>;
+		}
+
+		const storeA = createStore();
+		const storeB = createStore();
+
+		render(
+			<>
+				<Provider store={storeA}>
+					{/* intentionally empty – just to hold storeA */}
+					<span />
+				</Provider>
+				<Provider store={storeB}>
+					<StoreBDisplay />
+				</Provider>
+			</>,
+		);
+
+		const before = storeBRenders;
+		act(() => { storeA.set(launchViewAtom, "screenshot"); });
+		expect(storeBRenders).toBe(before); // storeB component did NOT re-render
+	});
+
+	it("screenshotModeAtom changes in storeA are invisible to storeB component", () => {
+		function ModeDisplay() {
+			const mode = useAtomValue(screenshotModeAtom);
+			return <span data-testid="mode">{mode ?? "none"}</span>;
+		}
+
+		const storeA = createStore();
+		const storeB = createStore();
+
+		render(
+			<Provider store={storeB}>
+				<ModeDisplay />
+			</Provider>,
+		);
+
+		act(() => { storeA.set(screenshotModeAtom, "area"); });
+
+		// storeB's component still shows the default
+		expect(screen.getByTestId("mode").textContent).toBe("none");
+	});
+
+	it("initialising a store with preset values is visible to its Provider's children", () => {
+		const store = createStore();
+		store.set(launchViewAtom, "onboarding");
+		store.set(selectedSourceAtom, "External Monitor");
+		store.set(hasSelectedSourceAtom, false);
+
+		function Summary() {
+			const view = useAtomValue(launchViewAtom);
+			const source = useAtomValue(selectedSourceAtom);
+			const selected = useAtomValue(hasSelectedSourceAtom);
+			return (
+				<div>
+					<span data-testid="view">{view}</span>
+					<span data-testid="source">{source}</span>
+					<span data-testid="selected">{String(selected)}</span>
+				</div>
+			);
+		}
+
+		render(
+			<Provider store={store}>
+				<Summary />
+			</Provider>,
+		);
+
+		expect(screen.getByTestId("view").textContent).toBe("onboarding");
+		expect(screen.getByTestId("source").textContent).toBe("External Monitor");
+		expect(screen.getByTestId("selected").textContent).toBe("false");
+	});
+});

--- a/apps/desktop/src/atoms/launch.jotai.test.ts
+++ b/apps/desktop/src/atoms/launch.jotai.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Jotai atom tests for launch.ts
+ *
+ * Tests cover:
+ * - Default atom values
+ * - Atom mutations (set / update)
+ * - Store isolation between independent stores
+ * - Subscription notifications
+ */
+
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	hasSelectedSourceAtom,
+	isCapturingAtom,
+	launchViewAtom,
+	recordingElapsedAtom,
+	recordingStartAtom,
+	screenshotModeAtom,
+	selectedSourceAtom,
+} from "./launch";
+
+// ─── Default values ─────────────────────────────────────────────────────────
+
+describe("launch atoms – defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("launchViewAtom defaults to 'choice'", () => {
+		expect(store.get(launchViewAtom)).toBe("choice");
+	});
+
+	it("screenshotModeAtom defaults to null", () => {
+		expect(store.get(screenshotModeAtom)).toBeNull();
+	});
+
+	it("isCapturingAtom defaults to false", () => {
+		expect(store.get(isCapturingAtom)).toBe(false);
+	});
+
+	it("recordingStartAtom defaults to null", () => {
+		expect(store.get(recordingStartAtom)).toBeNull();
+	});
+
+	it("recordingElapsedAtom defaults to 0", () => {
+		expect(store.get(recordingElapsedAtom)).toBe(0);
+	});
+
+	it("selectedSourceAtom defaults to 'Main Display'", () => {
+		expect(store.get(selectedSourceAtom)).toBe("Main Display");
+	});
+
+	it("hasSelectedSourceAtom defaults to true", () => {
+		expect(store.get(hasSelectedSourceAtom)).toBe(true);
+	});
+});
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+describe("launch atoms – mutations", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can transition launchViewAtom to 'recording'", () => {
+		store.set(launchViewAtom, "recording");
+		expect(store.get(launchViewAtom)).toBe("recording");
+	});
+
+	it("can transition launchViewAtom to 'onboarding'", () => {
+		store.set(launchViewAtom, "onboarding");
+		expect(store.get(launchViewAtom)).toBe("onboarding");
+	});
+
+	it("can transition launchViewAtom to 'screenshot'", () => {
+		store.set(launchViewAtom, "screenshot");
+		expect(store.get(launchViewAtom)).toBe("screenshot");
+	});
+
+	it("can set screenshotModeAtom to 'screen'", () => {
+		store.set(screenshotModeAtom, "screen");
+		expect(store.get(screenshotModeAtom)).toBe("screen");
+	});
+
+	it("can set screenshotModeAtom to 'window'", () => {
+		store.set(screenshotModeAtom, "window");
+		expect(store.get(screenshotModeAtom)).toBe("window");
+	});
+
+	it("can set screenshotModeAtom to 'area'", () => {
+		store.set(screenshotModeAtom, "area");
+		expect(store.get(screenshotModeAtom)).toBe("area");
+	});
+
+	it("can reset screenshotModeAtom back to null", () => {
+		store.set(screenshotModeAtom, "screen");
+		store.set(screenshotModeAtom, null);
+		expect(store.get(screenshotModeAtom)).toBeNull();
+	});
+
+	it("can mark capture as in-progress", () => {
+		store.set(isCapturingAtom, true);
+		expect(store.get(isCapturingAtom)).toBe(true);
+	});
+
+	it("can store a recording start timestamp", () => {
+		const ts = 1_700_000_000_000;
+		store.set(recordingStartAtom, ts);
+		expect(store.get(recordingStartAtom)).toBe(ts);
+	});
+
+	it("can update recordingElapsedAtom to track elapsed seconds", () => {
+		store.set(recordingElapsedAtom, 42);
+		expect(store.get(recordingElapsedAtom)).toBe(42);
+	});
+
+	it("can change selectedSourceAtom to a window name", () => {
+		store.set(selectedSourceAtom, "Safari – GitHub");
+		expect(store.get(selectedSourceAtom)).toBe("Safari – GitHub");
+	});
+
+	it("can clear hasSelectedSourceAtom when no source is selected", () => {
+		store.set(hasSelectedSourceAtom, false);
+		expect(store.get(hasSelectedSourceAtom)).toBe(false);
+	});
+
+	it("resets recordingStartAtom back to null (unmount-cleanup pattern)", () => {
+		store.set(recordingStartAtom, Date.now());
+		store.set(recordingStartAtom, null);
+		expect(store.get(recordingStartAtom)).toBeNull();
+	});
+
+	it("resets recordingElapsedAtom to 0 (unmount-cleanup pattern)", () => {
+		store.set(recordingElapsedAtom, 99);
+		store.set(recordingElapsedAtom, 0);
+		expect(store.get(recordingElapsedAtom)).toBe(0);
+	});
+});
+
+// ─── Store isolation ─────────────────────────────────────────────────────────
+
+describe("launch atoms – store isolation", () => {
+	it("two independent stores do not share launchViewAtom state", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(launchViewAtom, "recording");
+		expect(storeB.get(launchViewAtom)).toBe("choice");
+	});
+
+	it("setting isCapturingAtom in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(isCapturingAtom, true);
+		expect(storeB.get(isCapturingAtom)).toBe(false);
+	});
+
+	it("setting recordingStartAtom in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(recordingStartAtom, 12345);
+		expect(storeB.get(recordingStartAtom)).toBeNull();
+	});
+});
+
+// ─── Subscriptions ───────────────────────────────────────────────────────────
+
+describe("launch atoms – subscriptions", () => {
+	it("subscriber is notified when launchViewAtom changes", () => {
+		const store = createStore();
+		const listener = vi.fn();
+		const unsub = store.sub(launchViewAtom, listener);
+
+		store.set(launchViewAtom, "recording");
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		store.set(launchViewAtom, "screenshot");
+		expect(listener).toHaveBeenCalledTimes(2);
+
+		unsub();
+	});
+
+	it("unsubscribed listener is not called after unsubscribing", () => {
+		const store = createStore();
+		const listener = vi.fn();
+		const unsub = store.sub(launchViewAtom, listener);
+
+		store.set(launchViewAtom, "recording");
+		unsub();
+		store.set(launchViewAtom, "screenshot");
+
+		// Only the first change fires; the second is after unsub
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+});

--- a/apps/desktop/src/atoms/recording.jotai.test.ts
+++ b/apps/desktop/src/atoms/recording.jotai.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Jotai atom tests for recording.ts and sourceSelector.ts
+ *
+ * Tests cover:
+ * - Default values
+ * - Enabling / disabling devices
+ * - Switching source selector tabs
+ * - Managing the source list
+ * - Store isolation
+ */
+
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	cameraDeviceIdAtom,
+	cameraEnabledAtom,
+	microphoneDeviceIdAtom,
+	microphoneEnabledAtom,
+	recordingActiveAtom,
+	systemAudioEnabledAtom,
+} from "./recording";
+import {
+	selectedDesktopSourceAtom,
+	sourceSelectorTabAtom,
+	sourcesAtom,
+	sourcesLoadingAtom,
+	windowsLoadingAtom,
+} from "./sourceSelector";
+
+// ─── recording.ts – defaults ─────────────────────────────────────────────────
+
+describe("recording atoms – defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("recordingActiveAtom defaults to false", () => {
+		expect(store.get(recordingActiveAtom)).toBe(false);
+	});
+
+	it("microphoneEnabledAtom defaults to false", () => {
+		expect(store.get(microphoneEnabledAtom)).toBe(false);
+	});
+
+	it("microphoneDeviceIdAtom defaults to undefined", () => {
+		expect(store.get(microphoneDeviceIdAtom)).toBeUndefined();
+	});
+
+	it("systemAudioEnabledAtom defaults to false", () => {
+		expect(store.get(systemAudioEnabledAtom)).toBe(false);
+	});
+
+	it("cameraEnabledAtom defaults to false", () => {
+		expect(store.get(cameraEnabledAtom)).toBe(false);
+	});
+
+	it("cameraDeviceIdAtom defaults to undefined", () => {
+		expect(store.get(cameraDeviceIdAtom)).toBeUndefined();
+	});
+});
+
+// ─── recording.ts – mutations ────────────────────────────────────────────────
+
+describe("recording atoms – mutations", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can activate recording", () => {
+		store.set(recordingActiveAtom, true);
+		expect(store.get(recordingActiveAtom)).toBe(true);
+	});
+
+	it("can enable microphone", () => {
+		store.set(microphoneEnabledAtom, true);
+		expect(store.get(microphoneEnabledAtom)).toBe(true);
+	});
+
+	it("can set a specific microphone device ID", () => {
+		store.set(microphoneDeviceIdAtom, "mic-device-123");
+		expect(store.get(microphoneDeviceIdAtom)).toBe("mic-device-123");
+	});
+
+	it("can enable system audio", () => {
+		store.set(systemAudioEnabledAtom, true);
+		expect(store.get(systemAudioEnabledAtom)).toBe(true);
+	});
+
+	it("can enable camera", () => {
+		store.set(cameraEnabledAtom, true);
+		expect(store.get(cameraEnabledAtom)).toBe(true);
+	});
+
+	it("can set a specific camera device ID", () => {
+		store.set(cameraDeviceIdAtom, "cam-device-456");
+		expect(store.get(cameraDeviceIdAtom)).toBe("cam-device-456");
+	});
+
+	it("can disable all devices after enabling them", () => {
+		store.set(microphoneEnabledAtom, true);
+		store.set(cameraEnabledAtom, true);
+		store.set(systemAudioEnabledAtom, true);
+
+		store.set(microphoneEnabledAtom, false);
+		store.set(cameraEnabledAtom, false);
+		store.set(systemAudioEnabledAtom, false);
+
+		expect(store.get(microphoneEnabledAtom)).toBe(false);
+		expect(store.get(cameraEnabledAtom)).toBe(false);
+		expect(store.get(systemAudioEnabledAtom)).toBe(false);
+	});
+});
+
+// ─── recording.ts – store isolation ──────────────────────────────────────────
+
+describe("recording atoms – store isolation", () => {
+	it("enabling microphone in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(microphoneEnabledAtom, true);
+		expect(storeB.get(microphoneEnabledAtom)).toBe(false);
+	});
+
+	it("activating recording in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(recordingActiveAtom, true);
+		expect(storeB.get(recordingActiveAtom)).toBe(false);
+	});
+});
+
+// ─── sourceSelector.ts – defaults ────────────────────────────────────────────
+
+describe("sourceSelector atoms – defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("sourcesAtom defaults to an empty array", () => {
+		expect(store.get(sourcesAtom)).toEqual([]);
+	});
+
+	it("selectedDesktopSourceAtom defaults to null", () => {
+		expect(store.get(selectedDesktopSourceAtom)).toBeNull();
+	});
+
+	it("sourceSelectorTabAtom defaults to 'screens'", () => {
+		expect(store.get(sourceSelectorTabAtom)).toBe("screens");
+	});
+
+	it("sourcesLoadingAtom defaults to true", () => {
+		expect(store.get(sourcesLoadingAtom)).toBe(true);
+	});
+
+	it("windowsLoadingAtom defaults to true", () => {
+		expect(store.get(windowsLoadingAtom)).toBe(true);
+	});
+});
+
+// ─── sourceSelector.ts – mutations ───────────────────────────────────────────
+
+describe("sourceSelector atoms – mutations", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can switch selector tab to 'windows'", () => {
+		store.set(sourceSelectorTabAtom, "windows");
+		expect(store.get(sourceSelectorTabAtom)).toBe("windows");
+	});
+
+	it("can switch selector tab back to 'screens'", () => {
+		store.set(sourceSelectorTabAtom, "windows");
+		store.set(sourceSelectorTabAtom, "screens");
+		expect(store.get(sourceSelectorTabAtom)).toBe("screens");
+	});
+
+	it("can populate sources list", () => {
+		const fakeSource = {
+			id: "screen:1",
+			name: "Display 1",
+			thumbnail: null,
+			display_id: "1",
+			appIcon: null,
+			originalName: "Display 1",
+			sourceType: "screen" as const,
+		};
+		store.set(sourcesAtom, [fakeSource]);
+		expect(store.get(sourcesAtom)).toHaveLength(1);
+		expect(store.get(sourcesAtom)[0].id).toBe("screen:1");
+	});
+
+	it("can select a desktop source", () => {
+		const fakeSource = {
+			id: "screen:1",
+			name: "Display 1",
+			thumbnail: null,
+			display_id: "1",
+			appIcon: null,
+			originalName: "Display 1",
+			sourceType: "screen" as const,
+		};
+		store.set(selectedDesktopSourceAtom, fakeSource);
+		expect(store.get(selectedDesktopSourceAtom)?.id).toBe("screen:1");
+	});
+
+	it("can mark sources as loaded (sourcesLoadingAtom)", () => {
+		store.set(sourcesLoadingAtom, false);
+		expect(store.get(sourcesLoadingAtom)).toBe(false);
+	});
+
+	it("can mark windows as loaded (windowsLoadingAtom)", () => {
+		store.set(windowsLoadingAtom, false);
+		expect(store.get(windowsLoadingAtom)).toBe(false);
+	});
+});
+
+// ─── sourceSelector.ts – store isolation ─────────────────────────────────────
+
+describe("sourceSelector atoms – store isolation", () => {
+	it("switching tab in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(sourceSelectorTabAtom, "windows");
+		expect(storeB.get(sourceSelectorTabAtom)).toBe("screens");
+	});
+});

--- a/apps/desktop/src/atoms/settingsPanel.jotai.test.ts
+++ b/apps/desktop/src/atoms/settingsPanel.jotai.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Jotai atom tests for settingsPanel.ts
+ *
+ * Tests cover:
+ * - Default values for all settings atoms
+ * - Tab switching (sidebar + background sub-tabs)
+ * - Custom image list management
+ * - Color / gradient updates
+ * - Crop modal visibility
+ * - Store isolation
+ */
+
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	settingsActiveTabAtom,
+	settingsBackgroundTabAtom,
+	settingsCustomImagesAtom,
+	settingsGradientAtom,
+	settingsSelectedColorAtom,
+	settingsShowCropModalAtom,
+} from "./settingsPanel";
+
+// ─── Default values ─────────────────────────────────────────────────────────
+
+describe("settingsPanel atoms – defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("settingsActiveTabAtom defaults to 'appearance'", () => {
+		expect(store.get(settingsActiveTabAtom)).toBe("appearance");
+	});
+
+	it("settingsBackgroundTabAtom defaults to 'image'", () => {
+		expect(store.get(settingsBackgroundTabAtom)).toBe("image");
+	});
+
+	it("settingsCustomImagesAtom defaults to an empty array", () => {
+		expect(store.get(settingsCustomImagesAtom)).toEqual([]);
+	});
+
+	it("settingsSelectedColorAtom defaults to '#ADADAD'", () => {
+		expect(store.get(settingsSelectedColorAtom)).toBe("#ADADAD");
+	});
+
+	it("settingsGradientAtom defaults to a non-empty CSS string", () => {
+		const gradient = store.get(settingsGradientAtom);
+		expect(typeof gradient).toBe("string");
+		expect(gradient.length).toBeGreaterThan(0);
+		expect(gradient).toContain("linear-gradient");
+	});
+
+	it("settingsShowCropModalAtom defaults to false", () => {
+		expect(store.get(settingsShowCropModalAtom)).toBe(false);
+	});
+});
+
+// ─── Tab switching ───────────────────────────────────────────────────────────
+
+describe("settingsPanel atoms – sidebar tab switching", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can switch active tab to 'cursor'", () => {
+		store.set(settingsActiveTabAtom, "cursor");
+		expect(store.get(settingsActiveTabAtom)).toBe("cursor");
+	});
+
+	it("can switch active tab to 'camera'", () => {
+		store.set(settingsActiveTabAtom, "camera");
+		expect(store.get(settingsActiveTabAtom)).toBe("camera");
+	});
+
+	it("can switch active tab to 'background'", () => {
+		store.set(settingsActiveTabAtom, "background");
+		expect(store.get(settingsActiveTabAtom)).toBe("background");
+	});
+
+	it("can switch active tab to 'audio'", () => {
+		store.set(settingsActiveTabAtom, "audio");
+		expect(store.get(settingsActiveTabAtom)).toBe("audio");
+	});
+
+	it("can switch back to 'appearance' from any tab", () => {
+		store.set(settingsActiveTabAtom, "audio");
+		store.set(settingsActiveTabAtom, "appearance");
+		expect(store.get(settingsActiveTabAtom)).toBe("appearance");
+	});
+});
+
+describe("settingsPanel atoms – background sub-tab switching", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can switch background sub-tab to 'gradient'", () => {
+		store.set(settingsBackgroundTabAtom, "gradient");
+		expect(store.get(settingsBackgroundTabAtom)).toBe("gradient");
+	});
+
+	it("can switch background sub-tab to 'color'", () => {
+		store.set(settingsBackgroundTabAtom, "color");
+		expect(store.get(settingsBackgroundTabAtom)).toBe("color");
+	});
+
+	it("can switch background sub-tab back to 'image'", () => {
+		store.set(settingsBackgroundTabAtom, "gradient");
+		store.set(settingsBackgroundTabAtom, "image");
+		expect(store.get(settingsBackgroundTabAtom)).toBe("image");
+	});
+});
+
+// ─── Custom images ───────────────────────────────────────────────────────────
+
+describe("settingsPanel atoms – custom images", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can add custom image paths", () => {
+		store.set(settingsCustomImagesAtom, ["/uploads/img1.png", "/uploads/img2.jpg"]);
+		expect(store.get(settingsCustomImagesAtom)).toHaveLength(2);
+	});
+
+	it("can clear custom images back to empty array", () => {
+		store.set(settingsCustomImagesAtom, ["/uploads/img1.png"]);
+		store.set(settingsCustomImagesAtom, []);
+		expect(store.get(settingsCustomImagesAtom)).toHaveLength(0);
+	});
+});
+
+// ─── Color / gradient ────────────────────────────────────────────────────────
+
+describe("settingsPanel atoms – color and gradient", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can update selected color to a new hex string", () => {
+		store.set(settingsSelectedColorAtom, "#FF0000");
+		expect(store.get(settingsSelectedColorAtom)).toBe("#FF0000");
+	});
+
+	it("can replace the gradient string", () => {
+		const newGradient = "linear-gradient(to right, #f00, #00f)";
+		store.set(settingsGradientAtom, newGradient);
+		expect(store.get(settingsGradientAtom)).toBe(newGradient);
+	});
+});
+
+// ─── Crop modal ──────────────────────────────────────────────────────────────
+
+describe("settingsPanel atoms – crop modal visibility", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can open the crop modal", () => {
+		store.set(settingsShowCropModalAtom, true);
+		expect(store.get(settingsShowCropModalAtom)).toBe(true);
+	});
+
+	it("can close the crop modal after opening", () => {
+		store.set(settingsShowCropModalAtom, true);
+		store.set(settingsShowCropModalAtom, false);
+		expect(store.get(settingsShowCropModalAtom)).toBe(false);
+	});
+});
+
+// ─── Store isolation ─────────────────────────────────────────────────────────
+
+describe("settingsPanel atoms – store isolation", () => {
+	it("changing tab in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(settingsActiveTabAtom, "audio");
+		expect(storeB.get(settingsActiveTabAtom)).toBe("appearance");
+	});
+
+	it("opening crop modal in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(settingsShowCropModalAtom, true);
+		expect(storeB.get(settingsShowCropModalAtom)).toBe(false);
+	});
+});

--- a/apps/desktop/src/atoms/videoEditor.jotai.test.ts
+++ b/apps/desktop/src/atoms/videoEditor.jotai.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Jotai atom tests for videoEditor.ts
+ *
+ * Tests cover:
+ * - Default values for all ~47 atoms
+ * - Atom mutations (playback, export, regions, appearance)
+ * - Store isolation between independent stores
+ * - Subscriptions for key atoms
+ */
+
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	annotationRegionsAtom,
+	aspectRatioAtom,
+	audioMutedAtom,
+	audioVolumeAtom,
+	backgroundBlurAtom,
+	borderRadiusAtom,
+	connectZoomsAtom,
+	cropRegionAtom,
+	cursorSettingsAtom,
+	currentProjectPathAtom,
+	durationAtom,
+	exportErrorAtom,
+	exportFormatAtom,
+	exportProgressAtom,
+	exportQualityAtom,
+	exportedFilePathAtom,
+	facecamOffsetMsAtom,
+	facecamPlaybackPathAtom,
+	facecamVideoPathAtom,
+	gifFrameRateAtom,
+	gifLoopAtom,
+	gifSizePresetAtom,
+	hasPendingExportSaveAtom,
+	isExportingAtom,
+	isPlayingAtom,
+	lastSavedSnapshotAtom,
+	paddingAtom,
+	playbackReadyAtom,
+	selectedAnnotationIdAtom,
+	selectedSpeedIdAtom,
+	selectedTrimIdAtom,
+	selectedZoomIdAtom,
+	shadowIntensityAtom,
+	showExportDialogAtom,
+	showShortcutsDialogAtom,
+	sourceNameAtom,
+	speedRegionsAtom,
+	trimRegionsAtom,
+	videoErrorAtom,
+	videoLoadingAtom,
+	videoPathAtom,
+	videoSourcePathAtom,
+	zoomMotionBlurAtom,
+	zoomRegionsAtom,
+} from "./videoEditor";
+
+// ─── Default values ─────────────────────────────────────────────────────────
+
+describe("videoEditor atoms – source defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("videoPathAtom defaults to null", () => {
+		expect(store.get(videoPathAtom)).toBeNull();
+	});
+
+	it("videoSourcePathAtom defaults to null", () => {
+		expect(store.get(videoSourcePathAtom)).toBeNull();
+	});
+
+	it("sourceNameAtom defaults to null", () => {
+		expect(store.get(sourceNameAtom)).toBeNull();
+	});
+
+	it("facecamVideoPathAtom defaults to null", () => {
+		expect(store.get(facecamVideoPathAtom)).toBeNull();
+	});
+
+	it("facecamPlaybackPathAtom defaults to null", () => {
+		expect(store.get(facecamPlaybackPathAtom)).toBeNull();
+	});
+
+	it("facecamOffsetMsAtom defaults to 0", () => {
+		expect(store.get(facecamOffsetMsAtom)).toBe(0);
+	});
+
+	it("currentProjectPathAtom defaults to null", () => {
+		expect(store.get(currentProjectPathAtom)).toBeNull();
+	});
+});
+
+describe("videoEditor atoms – loading/error defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("videoLoadingAtom defaults to true", () => {
+		expect(store.get(videoLoadingAtom)).toBe(true);
+	});
+
+	it("playbackReadyAtom defaults to false", () => {
+		expect(store.get(playbackReadyAtom)).toBe(false);
+	});
+
+	it("videoErrorAtom defaults to null", () => {
+		expect(store.get(videoErrorAtom)).toBeNull();
+	});
+});
+
+describe("videoEditor atoms – playback defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("isPlayingAtom defaults to false", () => {
+		expect(store.get(isPlayingAtom)).toBe(false);
+	});
+
+	it("durationAtom defaults to 0", () => {
+		expect(store.get(durationAtom)).toBe(0);
+	});
+});
+
+describe("videoEditor atoms – appearance defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("shadowIntensityAtom defaults to 0.67", () => {
+		expect(store.get(shadowIntensityAtom)).toBe(0.67);
+	});
+
+	it("backgroundBlurAtom defaults to 0", () => {
+		expect(store.get(backgroundBlurAtom)).toBe(0);
+	});
+
+	it("zoomMotionBlurAtom defaults to a number between 0 and 1", () => {
+		const val = store.get(zoomMotionBlurAtom);
+		expect(typeof val).toBe("number");
+		expect(val).toBeGreaterThanOrEqual(0);
+		expect(val).toBeLessThanOrEqual(1);
+	});
+
+	it("connectZoomsAtom defaults to true", () => {
+		expect(store.get(connectZoomsAtom)).toBe(true);
+	});
+
+	it("borderRadiusAtom defaults to 12.5", () => {
+		expect(store.get(borderRadiusAtom)).toBe(12.5);
+	});
+
+	it("paddingAtom defaults to 50", () => {
+		expect(store.get(paddingAtom)).toBe(50);
+	});
+
+	it("audioMutedAtom defaults to a boolean", () => {
+		expect(typeof store.get(audioMutedAtom)).toBe("boolean");
+	});
+
+	it("audioVolumeAtom defaults to a positive number", () => {
+		expect(store.get(audioVolumeAtom)).toBeGreaterThan(0);
+	});
+});
+
+describe("videoEditor atoms – cursor defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("cursorSettingsAtom.showCursor defaults to true", () => {
+		expect(store.get(cursorSettingsAtom).showCursor).toBe(true);
+	});
+
+	it("cursorSettingsAtom.loopCursor defaults to false", () => {
+		expect(store.get(cursorSettingsAtom).loopCursor).toBe(false);
+	});
+
+	it("cursorSettingsAtom.cursorSize defaults to a positive number", () => {
+		expect(store.get(cursorSettingsAtom).cursorSize).toBeGreaterThan(0);
+	});
+});
+
+describe("videoEditor atoms – region defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("zoomRegionsAtom defaults to empty array", () => {
+		expect(store.get(zoomRegionsAtom)).toEqual([]);
+	});
+
+	it("trimRegionsAtom defaults to empty array", () => {
+		expect(store.get(trimRegionsAtom)).toEqual([]);
+	});
+
+	it("speedRegionsAtom defaults to empty array", () => {
+		expect(store.get(speedRegionsAtom)).toEqual([]);
+	});
+
+	it("annotationRegionsAtom defaults to empty array", () => {
+		expect(store.get(annotationRegionsAtom)).toEqual([]);
+	});
+
+	it("selectedZoomIdAtom defaults to null", () => {
+		expect(store.get(selectedZoomIdAtom)).toBeNull();
+	});
+
+	it("selectedTrimIdAtom defaults to null", () => {
+		expect(store.get(selectedTrimIdAtom)).toBeNull();
+	});
+
+	it("selectedSpeedIdAtom defaults to null", () => {
+		expect(store.get(selectedSpeedIdAtom)).toBeNull();
+	});
+
+	it("selectedAnnotationIdAtom defaults to null", () => {
+		expect(store.get(selectedAnnotationIdAtom)).toBeNull();
+	});
+
+	it("cropRegionAtom defaults to an object with numeric fields", () => {
+		const crop = store.get(cropRegionAtom);
+		expect(typeof crop).toBe("object");
+		expect(crop).not.toBeNull();
+	});
+});
+
+describe("videoEditor atoms – export defaults", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("isExportingAtom defaults to false", () => {
+		expect(store.get(isExportingAtom)).toBe(false);
+	});
+
+	it("exportProgressAtom defaults to null", () => {
+		expect(store.get(exportProgressAtom)).toBeNull();
+	});
+
+	it("exportErrorAtom defaults to null", () => {
+		expect(store.get(exportErrorAtom)).toBeNull();
+	});
+
+	it("showExportDialogAtom defaults to false", () => {
+		expect(store.get(showExportDialogAtom)).toBe(false);
+	});
+
+	it("showShortcutsDialogAtom defaults to false", () => {
+		expect(store.get(showShortcutsDialogAtom)).toBe(false);
+	});
+
+	it("aspectRatioAtom defaults to '16:9'", () => {
+		expect(store.get(aspectRatioAtom)).toBe("16:9");
+	});
+
+	it("exportQualityAtom defaults to 'good'", () => {
+		expect(store.get(exportQualityAtom)).toBe("good");
+	});
+
+	it("exportFormatAtom defaults to 'mp4'", () => {
+		expect(store.get(exportFormatAtom)).toBe("mp4");
+	});
+
+	it("gifFrameRateAtom defaults to 15", () => {
+		expect(store.get(gifFrameRateAtom)).toBe(15);
+	});
+
+	it("gifLoopAtom defaults to true", () => {
+		expect(store.get(gifLoopAtom)).toBe(true);
+	});
+
+	it("gifSizePresetAtom defaults to 'medium'", () => {
+		expect(store.get(gifSizePresetAtom)).toBe("medium");
+	});
+
+	it("exportedFilePathAtom defaults to undefined", () => {
+		expect(store.get(exportedFilePathAtom)).toBeUndefined();
+	});
+
+	it("hasPendingExportSaveAtom defaults to false", () => {
+		expect(store.get(hasPendingExportSaveAtom)).toBe(false);
+	});
+
+	it("lastSavedSnapshotAtom defaults to null", () => {
+		expect(store.get(lastSavedSnapshotAtom)).toBeNull();
+	});
+});
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+describe("videoEditor atoms – mutations", () => {
+	let store: ReturnType<typeof createStore>;
+
+	beforeEach(() => {
+		store = createStore();
+	});
+
+	it("can set videoPathAtom to a file path", () => {
+		store.set(videoPathAtom, "/recordings/video.mp4");
+		expect(store.get(videoPathAtom)).toBe("/recordings/video.mp4");
+	});
+
+	it("can toggle isPlayingAtom on then off", () => {
+		store.set(isPlayingAtom, true);
+		expect(store.get(isPlayingAtom)).toBe(true);
+		store.set(isPlayingAtom, false);
+		expect(store.get(isPlayingAtom)).toBe(false);
+	});
+
+	it("can record a video error message", () => {
+		store.set(videoErrorAtom, "Failed to decode video");
+		expect(store.get(videoErrorAtom)).toBe("Failed to decode video");
+	});
+
+	it("can mark video loading as complete", () => {
+		store.set(videoLoadingAtom, false);
+		expect(store.get(videoLoadingAtom)).toBe(false);
+	});
+
+	it("can set durationAtom after video loads", () => {
+		store.set(durationAtom, 120_000);
+		expect(store.get(durationAtom)).toBe(120_000);
+	});
+
+	it("can add a zoom region", () => {
+		store.set(zoomRegionsAtom, [{ id: "z1", startMs: 0, endMs: 2000, depth: 2, focus: { cx: 0.5, cy: 0.5 } }]);
+		expect(store.get(zoomRegionsAtom)).toHaveLength(1);
+		expect(store.get(zoomRegionsAtom)[0].id).toBe("z1");
+	});
+
+	it("can select a zoom region by ID", () => {
+		store.set(selectedZoomIdAtom, "z1");
+		expect(store.get(selectedZoomIdAtom)).toBe("z1");
+	});
+
+	it("can change aspectRatioAtom to 9:16", () => {
+		store.set(aspectRatioAtom, "9:16");
+		expect(store.get(aspectRatioAtom)).toBe("9:16");
+	});
+
+	it("can switch export format to 'gif'", () => {
+		store.set(exportFormatAtom, "gif");
+		expect(store.get(exportFormatAtom)).toBe("gif");
+	});
+
+	it("can open the export dialog", () => {
+		store.set(showExportDialogAtom, true);
+		expect(store.get(showExportDialogAtom)).toBe(true);
+	});
+
+	it("can update cursor settings with a partial patch", () => {
+		const current = store.get(cursorSettingsAtom);
+		store.set(cursorSettingsAtom, { ...current, showCursor: false });
+		expect(store.get(cursorSettingsAtom).showCursor).toBe(false);
+		// Other fields should be unchanged
+		expect(store.get(cursorSettingsAtom).loopCursor).toBe(current.loopCursor);
+	});
+
+	it("can save a snapshot string", () => {
+		store.set(lastSavedSnapshotAtom, '{"version":1}');
+		expect(store.get(lastSavedSnapshotAtom)).toBe('{"version":1}');
+	});
+});
+
+// ─── Store isolation ─────────────────────────────────────────────────────────
+
+describe("videoEditor atoms – store isolation", () => {
+	it("videoPathAtom in storeA does not bleed into storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(videoPathAtom, "/some/path.mp4");
+		expect(storeB.get(videoPathAtom)).toBeNull();
+	});
+
+	it("zoomRegionsAtom in storeA does not bleed into storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(zoomRegionsAtom, [{ id: "z1", startMs: 0, endMs: 1000, depth: 1, focus: { cx: 0.5, cy: 0.5 } }]);
+		expect(storeB.get(zoomRegionsAtom)).toHaveLength(0);
+	});
+
+	it("export state in storeA does not affect storeB", () => {
+		const storeA = createStore();
+		const storeB = createStore();
+		storeA.set(isExportingAtom, true);
+		storeA.set(showExportDialogAtom, true);
+		expect(storeB.get(isExportingAtom)).toBe(false);
+		expect(storeB.get(showExportDialogAtom)).toBe(false);
+	});
+});
+
+// ─── Subscriptions ───────────────────────────────────────────────────────────
+
+describe("videoEditor atoms – subscriptions", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("subscriber is notified when isPlayingAtom changes", () => {
+		const store = createStore();
+		const listener = vi.fn();
+		const unsub = store.sub(isPlayingAtom, listener);
+
+		store.set(isPlayingAtom, true);
+		store.set(isPlayingAtom, false);
+
+		expect(listener).toHaveBeenCalledTimes(2);
+		unsub();
+	});
+
+	it("subscriber on zoomRegionsAtom fires on each update", () => {
+		const store = createStore();
+		const listener = vi.fn();
+		const unsub = store.sub(zoomRegionsAtom, listener);
+
+		store.set(zoomRegionsAtom, []);
+		store.set(zoomRegionsAtom, [{ id: "z1", startMs: 0, endMs: 500, depth: 1, focus: { cx: 0.5, cy: 0.5 } }]);
+
+		expect(listener).toHaveBeenCalledTimes(2);
+		unsub();
+	});
+});

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	plugins: [react()],
 	test: {
 		globals: true,
 		environment: "node",
 		include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+		setupFiles: ["./src/test-setup.ts"],
 	},
 	resolve: {
 		alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,15 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.0.3
         version: 25.5.0
@@ -239,6 +248,9 @@ importers:
         version: 3.2.4(@types/node@25.5.0)(jsdom@29.0.1)(terser@5.46.1)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1386,6 +1398,35 @@ packages:
   '@tauri-apps/plugin-updater@2.10.0':
     resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@turbo/darwin-64@2.8.20':
     resolution: {integrity: sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==}
     cpu: [x64]
@@ -1415,6 +1456,9 @@ packages:
     resolution: {integrity: sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw==}
     cpu: [arm64]
     os: [win32]
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1560,6 +1604,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1573,6 +1625,13 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1661,6 +1720,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1689,6 +1751,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
@@ -1700,6 +1766,12 @@ packages:
 
   dnd-timeline@2.4.0:
     resolution: {integrity: sha512-f71y55DjT2VDongtnqVd7S6XGmpUT1PkYlooFQZxLHfPVfKsyTtMHsfbXN98k2GkA5Z4h3ibqFjwBIfckE0aEg==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1865,6 +1937,10 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -1967,6 +2043,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1987,6 +2067,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
@@ -2132,6 +2216,10 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2176,6 +2264,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2233,6 +2324,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2310,6 +2405,10 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -2575,6 +2674,8 @@ packages:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -3621,6 +3722,40 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@turbo/darwin-64@2.8.20':
     optional: true
 
@@ -3638,6 +3773,8 @@ snapshots:
 
   '@turbo/windows-arm64@2.8.20':
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3802,6 +3939,10 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -3814,6 +3955,12 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
 
@@ -3903,6 +4050,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -3922,6 +4071,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  dequal@2.0.3: {}
+
   detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
@@ -3936,6 +4087,10 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4100,6 +4255,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  indent-string@4.0.0: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -4185,6 +4342,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4204,6 +4363,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  min-indent@1.0.1: {}
 
   motion-dom@12.38.0:
     dependencies:
@@ -4318,6 +4479,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4359,6 +4526,8 @@ snapshots:
       react: 18.3.1
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -4413,6 +4582,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
 
@@ -4518,6 +4692,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-literal@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Installs `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event` as dev dependencies
- Updates `vitest.config.ts` to add the `@vitejs/plugin-react` plugin and a `src/test-setup.ts` setup file (extends `jest-dom` matchers)
- Adds **167 new passing test cases** across 5 new files covering Jotai state management in React components

### New test files

| File | Tests | What is covered |
|------|-------|----------------|
| `src/atoms/launch.jotai.test.ts` | 26 | Default values for all 7 launch atoms, all `LaunchView`/`ScreenshotMode` transitions, subscription callbacks, store isolation |
| `src/atoms/videoEditor.jotai.test.ts` | 63 | All ~47 `videoEditor` atom defaults (source, loading, playback, appearance, cursor, regions, export), mutations, subscription callbacks, store isolation |
| `src/atoms/settingsPanel.jotai.test.ts` | 22 | Sidebar-tab switching, background sub-tabs, custom images, color/gradient updates, crop-modal visibility, store isolation |
| `src/atoms/recording.jotai.test.ts` | 27 | `recording.ts` atoms (recordingActive, mic, camera, systemAudio) + `sourceSelector.ts` atoms; defaults, mutations, isolation |
| `src/atoms/jotaiProvider.test.tsx` | 29 | React component tests with `@testing-library/react` + Jotai `Provider` backed by a fresh `createStore()` per test |

### Jotai Provider test scenarios (jotaiProvider.test.tsx)

1. **Atoms read correctly on mount** — each atom's default value appears in the rendered component immediately
2. **State updates propagate to the UI** — imperative `store.set()` calls and `fireEvent` interactions both update rendered output
3. **`useAtomValue` / `useSetAtom` / `useAtom` behaviour** — `useSetAtom` writer doesn't re-render when the atom changes; `useAtom` provides functional updater pattern
4. **Re-render tracking** — writer component render count is unchanged after clicking; reader component only re-renders for its own atom
5. **Unmount cleanup** — `useEffect` return callbacks correctly reset atoms; atoms without cleanup retain their values after unmount
6. **Multi-component sync** — two `useAtomValue` consumers of the same atom both update on a single `useSetAtom` write
7. **Conditional rendering** — components show/hide correctly as atom value transitions through boolean states and view names
8. **Cross-Provider isolation** — separate `<Provider store={storeA/B}>` trees cannot observe each other's atom changes

## Test plan

- [x] All 167 new tests pass (`pnpm test` in `apps/desktop`)
- [x] No regressions in the 31 pre-existing passing test files
- [x] The one pre-existing failure (`gifExporter.test.ts` — pixi.js `navigator` undefined in Node) is unchanged and unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)