### PR TITLE
fix: add error logging to silent permission IPC catch handlers

### DIFF
--- a/apps/desktop/src/lib/backend.permissions.test.ts
+++ b/apps/desktop/src/lib/backend.permissions.test.ts
@@ -51,6 +51,21 @@ describe("permission backend wrappers", () => {
 				expect(result).toBe(status);
 			}
 		});
+
+		it("logs error and returns 'unknown' when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.getMicrophonePermissionStatus();
+
+			expect(result).toBe("unknown");
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] getMicrophonePermissionStatus failed:",
+				ipcError,
+			);
+		});
 	});
 
 	describe("openMicrophonePreferences", () => {
@@ -68,6 +83,21 @@ describe("permission backend wrappers", () => {
 			expect(invoke).toHaveBeenCalledWith("request_microphone_permission");
 			expect(result).toBe(true);
 		});
+
+		it("logs error and returns false when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.requestMicrophonePermission();
+
+			expect(result).toBe(false);
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] requestMicrophonePermission failed:",
+				ipcError,
+			);
+		});
 	});
 
 	// ==================== Camera ====================
@@ -78,6 +108,21 @@ describe("permission backend wrappers", () => {
 			const result = await backend.getCameraPermissionStatus();
 			expect(invoke).toHaveBeenCalledWith("get_camera_permission_status");
 			expect(result).toBe("not_determined");
+		});
+
+		it("logs error and returns 'unknown' when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.getCameraPermissionStatus();
+
+			expect(result).toBe("unknown");
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] getCameraPermissionStatus failed:",
+				ipcError,
+			);
 		});
 	});
 
@@ -96,6 +141,21 @@ describe("permission backend wrappers", () => {
 			expect(invoke).toHaveBeenCalledWith("request_camera_permission");
 			expect(result).toBe(false);
 		});
+
+		it("logs error and returns false when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.requestCameraPermission();
+
+			expect(result).toBe(false);
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] requestCameraPermission failed:",
+				ipcError,
+			);
+		});
 	});
 
 	// ==================== Screen Recording (existing, verify still works) ====================
@@ -107,6 +167,21 @@ describe("permission backend wrappers", () => {
 			expect(invoke).toHaveBeenCalledWith("get_screen_recording_permission_status");
 			expect(result).toBe("granted");
 		});
+
+		it("logs error and returns 'unknown' when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.getScreenRecordingPermissionStatus();
+
+			expect(result).toBe("unknown");
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] getScreenRecordingPermissionStatus failed:",
+				ipcError,
+			);
+		});
 	});
 
 	describe("requestScreenRecordingPermission", () => {
@@ -115,6 +190,21 @@ describe("permission backend wrappers", () => {
 			const result = await backend.requestScreenRecordingPermission();
 			expect(invoke).toHaveBeenCalledWith("request_screen_recording_permission");
 			expect(result).toBe(true);
+		});
+
+		it("logs error and returns false when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.requestScreenRecordingPermission();
+
+			expect(result).toBe(false);
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] requestScreenRecordingPermission failed:",
+				ipcError,
+			);
 		});
 	});
 
@@ -134,6 +224,38 @@ describe("permission backend wrappers", () => {
 			const result = await backend.getAccessibilityPermissionStatus();
 			expect(invoke).toHaveBeenCalledWith("get_accessibility_permission_status");
 			expect(result).toBe("granted");
+		});
+
+		it("logs error and returns 'unknown' when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.getAccessibilityPermissionStatus();
+
+			expect(result).toBe("unknown");
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] getAccessibilityPermissionStatus failed:",
+				ipcError,
+			);
+		});
+	});
+
+	describe("requestAccessibilityPermission", () => {
+		it("logs error and returns false when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.requestAccessibilityPermission();
+
+			expect(result).toBe(false);
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] requestAccessibilityPermission failed:",
+				ipcError,
+			);
 		});
 	});
 

--- a/apps/desktop/src/lib/backend.ts
+++ b/apps/desktop/src/lib/backend.ts
@@ -186,11 +186,17 @@ export function getSystemCursorAssets(): Promise<any> {
 // ─── Permissions ────────────────────────────────────────────────────────────
 
 export function getScreenRecordingPermissionStatus(): Promise<string> {
-	return invoke("get_screen_recording_permission_status");
+	return invoke("get_screen_recording_permission_status").catch((err) => {
+		console.error("[backend] getScreenRecordingPermissionStatus failed:", err);
+		return "unknown";
+	});
 }
 
 export function requestScreenRecordingPermission(): Promise<boolean> {
-	return invoke("request_screen_recording_permission");
+	return invoke("request_screen_recording_permission").catch((err) => {
+		console.error("[backend] requestScreenRecordingPermission failed:", err);
+		return false;
+	});
 }
 
 export function openScreenRecordingPreferences(): Promise<void> {
@@ -198,11 +204,17 @@ export function openScreenRecordingPreferences(): Promise<void> {
 }
 
 export function getAccessibilityPermissionStatus(): Promise<string> {
-	return invoke("get_accessibility_permission_status");
+	return invoke("get_accessibility_permission_status").catch((err) => {
+		console.error("[backend] getAccessibilityPermissionStatus failed:", err);
+		return "unknown";
+	});
 }
 
 export function requestAccessibilityPermission(): Promise<boolean> {
-	return invoke("request_accessibility_permission");
+	return invoke("request_accessibility_permission").catch((err) => {
+		console.error("[backend] requestAccessibilityPermission failed:", err);
+		return false;
+	});
 }
 
 export function openAccessibilityPreferences(): Promise<void> {
@@ -210,19 +222,31 @@ export function openAccessibilityPreferences(): Promise<void> {
 }
 
 export function getMicrophonePermissionStatus(): Promise<string> {
-	return invoke("get_microphone_permission_status");
+	return invoke("get_microphone_permission_status").catch((err) => {
+		console.error("[backend] getMicrophonePermissionStatus failed:", err);
+		return "unknown";
+	});
 }
 
 export function requestMicrophonePermission(): Promise<boolean> {
-	return invoke("request_microphone_permission");
+	return invoke("request_microphone_permission").catch((err) => {
+		console.error("[backend] requestMicrophonePermission failed:", err);
+		return false;
+	});
 }
 
 export function getCameraPermissionStatus(): Promise<string> {
-	return invoke("get_camera_permission_status");
+	return invoke("get_camera_permission_status").catch((err) => {
+		console.error("[backend] getCameraPermissionStatus failed:", err);
+		return "unknown";
+	});
 }
 
 export function requestCameraPermission(): Promise<boolean> {
-	return invoke("request_camera_permission");
+	return invoke("request_camera_permission").catch((err) => {
+		console.error("[backend] requestCameraPermission failed:", err);
+		return false;
+	});
 }
 
 export function openMicrophonePreferences(): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixes Issue #3: silent error swallowing in `apps/desktop/src/lib/backend.ts`
- Added `.catch((err) => { console.error(...); return fallback; })` to all 8 permission-related IPC wrappers that can meaningfully return fallback values
- Status getters (`get*PermissionStatus`) fall back to `'unknown'`; request functions (`request*Permission`) fall back to `false`
- Added 8 new error-path tests to `backend.permissions.test.ts` verifying `console.error` is called with a `[backend]`-prefixed message and the fallback is returned

## Affected functions
| Function | Fallback |
|---|---|
| `getScreenRecordingPermissionStatus` | `'unknown'` |
| `requestScreenRecordingPermission` | `false` |
| `getAccessibilityPermissionStatus` | `'unknown'` |
| `requestAccessibilityPermission` | `false` |
| `getMicrophonePermissionStatus` | `'unknown'` |
| `requestMicrophonePermission` | `false` |
| `getCameraPermissionStatus` | `'unknown'` |
| `requestCameraPermission` | `false` |

## Test plan
- [x] All 20 tests in `backend.permissions.test.ts` pass
- [x] Full test suite: 986 tests pass (pre-existing `gifExporter` failure unrelated to this change)