### PR TITLE
fix: prevent path traversal in read_local_file and append_recording_data

### DIFF
--- a/apps/desktop/src-tauri/src/commands/files.rs
+++ b/apps/desktop/src-tauri/src/commands/files.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use crate::app_paths;
@@ -43,8 +43,43 @@ fn get_recordings_dir(state: &AppState) -> PathBuf {
     }
 }
 
+/// Returns true only if `path` (or its parent, for not-yet-created files) resolves
+/// to a location inside the app's data dir, cache dir, or the system temp dir.
+fn is_within_allowed_dirs(path: &Path) -> bool {
+    let canonical = if path.exists() {
+        match std::fs::canonicalize(path) {
+            Ok(p) => p,
+            Err(_) => return false,
+        }
+    } else {
+        // File not created yet – canonicalize parent and re-attach the filename.
+        let parent = path.parent().unwrap_or(path);
+        match std::fs::canonicalize(parent) {
+            Ok(p) => match path.file_name() {
+                Some(name) => p.join(name),
+                None => return false,
+            },
+            Err(_) => return false,
+        }
+    };
+
+    let allowed: Vec<PathBuf> = [
+        dirs::data_dir(),
+        dirs::cache_dir(),
+        Some(std::env::temp_dir()),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    allowed.iter().any(|d| canonical.starts_with(d))
+}
+
 #[tauri::command]
 pub async fn read_local_file(path: String) -> Result<Vec<u8>, String> {
+    if !is_within_allowed_dirs(Path::new(&path)) {
+        return Err(format!("Access denied: path is outside allowed directories"));
+    }
     tokio::fs::read(&path).await.map_err(|e| e.to_string())
 }
 
@@ -103,6 +138,9 @@ pub async fn prepare_recording_file(
 
 #[tauri::command]
 pub async fn append_recording_data(path: String, data: Vec<u8>) -> Result<(), String> {
+    if !is_within_allowed_dirs(Path::new(&path)) {
+        return Err(format!("Access denied: path is outside allowed directories"));
+    }
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -357,5 +395,59 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), data);
+    }
+
+    // ==================== Path traversal / security ====================
+
+    #[tokio::test]
+    async fn test_read_local_file_path_traversal_rejected() {
+        // Both a relative traversal and an absolute sensitive path must be denied.
+        for path in &["../../etc/passwd", "/etc/passwd", "/etc/shadow"] {
+            let result = read_local_file(path.to_string()).await;
+            assert!(
+                result.is_err(),
+                "expected error for path {:?}, got Ok",
+                path
+            );
+            let err = result.unwrap_err();
+            assert!(
+                err.contains("Access denied"),
+                "expected 'Access denied' in error for path {:?}, got: {}",
+                path,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_append_recording_data_path_traversal_rejected() {
+        for path in &["../../etc/cron.d/evil", "/etc/cron.d/evil"] {
+            let result =
+                append_recording_data(path.to_string(), b"malicious".to_vec()).await;
+            assert!(
+                result.is_err(),
+                "expected error for path {:?}, got Ok",
+                path
+            );
+            let err = result.unwrap_err();
+            assert!(
+                err.contains("Access denied"),
+                "expected 'Access denied' in error for path {:?}, got: {}",
+                path,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_local_file_in_temp_dir_allowed() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("open_recorder_security_test.txt");
+        tokio::fs::write(&path, b"allowed").await.unwrap();
+
+        let result = read_local_file(path.to_string_lossy().to_string()).await;
+        let _ = tokio::fs::remove_file(&path).await;
+
+        assert!(result.is_ok(), "temp dir should be allowed: {:?}", result);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `is_within_allowed_dirs(path: &Path) -> bool` helper that canonicalizes paths and checks they fall within `dirs::data_dir()`, `dirs::cache_dir()`, or `std::env::temp_dir()`
- Guards `read_local_file` and `append_recording_data` with this check; returns `"Access denied: path is outside allowed directories"` for any path that fails
- Both relative traversals (`../../etc/passwd`) and absolute sensitive paths (`/etc/passwd`) are blocked

## Test plan

- [x] `test_read_local_file_path_traversal_rejected` — relative & absolute traversal paths return `Err` containing `"Access denied"`
- [x] `test_append_recording_data_path_traversal_rejected` — same for append
- [x] `test_read_local_file_in_temp_dir_allowed` — files in `temp_dir()` remain readable (regression guard)
- [x] Existing file I/O tests (`test_read_local_file_existing_file`, empty, binary) continue to pass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)