### PR TITLE
fix: prevent video event listener leaks in VideoPlayback cleanup

### DIFF
--- a/apps/desktop/src/components/video-editor/VideoPlayback.test.tsx
+++ b/apps/desktop/src/components/video-editor/VideoPlayback.test.tsx
@@ -496,4 +496,43 @@ describe("VideoPlayback", () => {
 		expect(video.volume).toBeCloseTo(0.8);
 		await harness.unmount();
 	});
+
+	it("removes playback event listeners on unmount using the captured video reference", async () => {
+		const addEventSpy = vi.spyOn(HTMLVideoElement.prototype, "addEventListener");
+		const removeEventSpy = vi.spyOn(HTMLVideoElement.prototype, "removeEventListener");
+
+		const harness = await renderPlayback();
+		const video = getPrimaryVideo(harness.container);
+
+		defineMediaProperty(video, "videoWidth", 1920);
+		defineMediaProperty(video, "videoHeight", 1080);
+		defineMediaProperty(video, "duration", 10);
+		defineMediaProperty(video, "readyState", HTMLMediaElement.HAVE_CURRENT_DATA);
+
+		await act(async () => {
+			video.dispatchEvent(new Event("loadedmetadata"));
+			video.dispatchEvent(new Event("loadeddata"));
+		});
+		await flushEffects();
+
+		// The effect may run more than once as state settles, so capture the most-recent
+		// handler registered for each playback event — those are the live listeners.
+		const playbackEvents = new Set(["play", "pause", "ended", "seeked", "seeking"]);
+		const latestHandlers = new Map<string, EventListener>();
+		for (const [event, handler] of addEventSpy.mock.calls) {
+			if (playbackEvents.has(event as string)) {
+				latestHandlers.set(event as string, handler as EventListener);
+			}
+		}
+		expect(latestHandlers.size).toBe(5);
+
+		await harness.unmount();
+
+		// Each live listener must be removed with the exact same handler reference that was
+		// added, proving cleanup used the captured videoRef.current from effect setup time
+		// rather than reading the (possibly null) ref at teardown time.
+		for (const [event, handler] of latestHandlers) {
+			expect(removeEventSpy).toHaveBeenCalledWith(event, handler);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- Confirmed that `VideoPlayback.tsx` already captures `const video = videoRef.current` at the **start** of the effect (line 990) and uses that captured reference in the cleanup function — the correct pattern is already in place.
- Added a regression test that mounts `VideoPlayback`, drives the Pixi/video scene to ready state, then unmounts and asserts that `removeEventListener` was called for each of the five playback events (`play`, `pause`, `ended`, `seeked`, `seeking`) with the **exact same handler reference** that was passed to `addEventListener`.

## Test plan

- [ ] `pnpm --filter @open-recorder/desktop test` passes (all `VideoPlayback` tests green)
- [ ] New test fails if you change the cleanup to use `videoRef.current` instead of the captured `video` variable

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)