### PR TITLE
fix: surface errors from source-check interval (Issue #16)

### DIFF
--- a/apps/desktop/src/atoms/launch.ts
+++ b/apps/desktop/src/atoms/launch.ts
@@ -18,3 +18,4 @@ export const recordingStartAtom = atom<number | null>(null);
 export const recordingElapsedAtom = atom<number>(0);
 export const selectedSourceAtom = atom<string>("Main Display");
 export const hasSelectedSourceAtom = atom<boolean>(true);
+export const sourceCheckErrorAtom = atom<Error | null>(null);

--- a/apps/desktop/src/components/launch/LaunchWindow.sourceCheck.test.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.sourceCheck.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the source-checking interval error handling in LaunchWindow.
+ *
+ * Covers Issue #16: silent error swallowing in the setInterval callback.
+ * When backend.getSelectedSource() rejects the error must be:
+ *   1. Logged via console.warn
+ *   2. Surfaced in sourceCheckErrorAtom (not silently dropped)
+ *   3. Not cause the component to crash
+ *
+ * NOTE: checkSelectedSource() is invoked immediately on mount AND on each
+ * interval tick. All tests validate the on-mount invocation so that no timer
+ * manipulation is needed (avoiding the act()+fakeTimers deadlock).
+ */
+
+import { Provider, createStore, useAtom } from "jotai";
+import { useEffect } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	hasSelectedSourceAtom,
+	selectedSourceAtom,
+	sourceCheckErrorAtom,
+} from "@/atoms/launch";
+import { resolveSelectedSourceState } from "./launchWindowState";
+
+// ─── Mock backend ─────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/backend", () => ({
+	getSelectedSource: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const backend = vi.mocked(await import("@/lib/backend"));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function flushMicrotasks() {
+	await act(async () => {
+		// Drain microtasks then a macro-task so async effects settle
+		await Promise.resolve();
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+/**
+ * Minimal harness that replicates only the source-checking useEffect from
+ * LaunchWindow so we can test its error-handling behaviour in isolation.
+ *
+ * `intervalMs` defaults to 500 (matching the real component) but can be
+ * reduced in tests that need to observe the interval tick without fake timers.
+ */
+function SourceCheckHarness({ intervalMs = 500 }: { intervalMs?: number }) {
+	const [, setSelectedSource] = useAtom(selectedSourceAtom);
+	const [, setHasSelectedSource] = useAtom(hasSelectedSourceAtom);
+	const [, setSourceCheckError] = useAtom(sourceCheckErrorAtom);
+
+	useEffect(() => {
+		const checkSelectedSource = async () => {
+			try {
+				const source = await backend.getSelectedSource();
+				const nextState = resolveSelectedSourceState(source);
+				setSelectedSource(nextState.selectedSource);
+				setHasSelectedSource(nextState.hasSelectedSource);
+				setSourceCheckError(null);
+			} catch (err) {
+				const error = err instanceof Error ? err : new Error(String(err));
+				console.warn("[LaunchWindow] source check failed:", error);
+				setSourceCheckError(error);
+			}
+		};
+
+		void checkSelectedSource();
+		const interval = setInterval(checkSelectedSource, intervalMs);
+		return () => clearInterval(interval);
+	}, [intervalMs, setHasSelectedSource, setSelectedSource, setSourceCheckError]);
+
+	return null;
+}
+
+// ─── Mount helper ─────────────────────────────────────────────────────────────
+
+type Harness = {
+	store: ReturnType<typeof createStore>;
+	unmount: () => Promise<void>;
+};
+
+async function mountHarness(opts: { intervalMs?: number } = {}): Promise<Harness> {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const root: Root = createRoot(container);
+	const store = createStore();
+
+	await act(async () => {
+		root.render(
+			<Provider store={store}>
+				<SourceCheckHarness intervalMs={opts.intervalMs} />
+			</Provider>,
+		);
+	});
+	// Let the immediate async checkSelectedSource() call settle
+	await flushMicrotasks();
+
+	return {
+		store,
+		unmount: async () => {
+			await act(async () => {
+				root.unmount();
+				container.remove();
+			});
+		},
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("LaunchWindow source-check interval – error handling", () => {
+	it("logs a warning when getSelectedSource rejects", async () => {
+		const networkError = new Error("IPC call failed");
+		backend.getSelectedSource.mockRejectedValue(networkError);
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const { unmount } = await mountHarness();
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			"[LaunchWindow] source check failed:",
+			networkError,
+		);
+
+		await unmount();
+	});
+
+	it("sets sourceCheckErrorAtom when getSelectedSource rejects", async () => {
+		const networkError = new Error("IPC call failed");
+		backend.getSelectedSource.mockRejectedValue(networkError);
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const { store, unmount } = await mountHarness();
+
+		const storedError = store.get(sourceCheckErrorAtom);
+		expect(storedError).toBeInstanceOf(Error);
+		expect(storedError?.message).toBe("IPC call failed");
+
+		await unmount();
+	});
+
+	it("does not crash the component when getSelectedSource rejects", async () => {
+		backend.getSelectedSource.mockRejectedValue(new Error("backend down"));
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		// Should resolve without throwing – the component must stay alive
+		const { unmount } = await mountHarness();
+		await expect(unmount()).resolves.toBeUndefined();
+	});
+
+	it("clears sourceCheckErrorAtom when a subsequent call succeeds", async () => {
+		const networkError = new Error("transient failure");
+		backend.getSelectedSource
+			.mockRejectedValueOnce(networkError)
+			.mockResolvedValue({ name: "Display 1" });
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		// Use a 10 ms interval so we can wait for the second tick with real timers
+		const { store, unmount } = await mountHarness({ intervalMs: 10 });
+
+		// Initial (on-mount) call failed – error must be set
+		expect(store.get(sourceCheckErrorAtom)).toBeInstanceOf(Error);
+
+		// Wait for the interval to fire at least once (>10 ms) and flush React
+		await act(async () => {
+			await new Promise<void>((resolve) => setTimeout(resolve, 30));
+		});
+		await flushMicrotasks();
+
+		// After the successful interval tick the error must be cleared
+		expect(store.get(sourceCheckErrorAtom)).toBeNull();
+		expect(store.get(selectedSourceAtom)).toBe("Display 1");
+
+		await unmount();
+	});
+
+	it("does not warn or set error when getSelectedSource succeeds", async () => {
+		backend.getSelectedSource.mockResolvedValue({ name: "Screen 2" });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const { store, unmount } = await mountHarness();
+
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(store.get(sourceCheckErrorAtom)).toBeNull();
+		expect(store.get(selectedSourceAtom)).toBe("Screen 2");
+
+		await unmount();
+	});
+});

--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -23,6 +23,7 @@ import {
 	type ScreenshotMode,
 	screenshotModeAtom,
 	selectedSourceAtom,
+	sourceCheckErrorAtom,
 } from "@/atoms/launch";
 import { buildEditorWindowQuery } from "@/components/video-editor/editorWindowParams";
 import * as backend from "@/lib/backend";
@@ -293,6 +294,7 @@ export function LaunchWindow() {
 	// Source tracking
 	const [selectedSource, setSelectedSource] = useAtom(selectedSourceAtom);
 	const [hasSelectedSource, setHasSelectedSource] = useAtom(hasSelectedSourceAtom);
+	const [, setSourceCheckError] = useAtom(sourceCheckErrorAtom);
 	useEffect(() => {
 		const checkSelectedSource = async () => {
 			try {
@@ -300,15 +302,18 @@ export function LaunchWindow() {
 				const nextState = resolveSelectedSourceState(source);
 				setSelectedSource(nextState.selectedSource);
 				setHasSelectedSource(nextState.hasSelectedSource);
-			} catch {
-				// ignore
+				setSourceCheckError(null);
+			} catch (err) {
+				const error = err instanceof Error ? err : new Error(String(err));
+				console.warn("[LaunchWindow] source check failed:", error);
+				setSourceCheckError(error);
 			}
 		};
 
 		void checkSelectedSource();
 		const interval = setInterval(checkSelectedSource, 500);
 		return () => clearInterval(interval);
-	}, [setHasSelectedSource, setSelectedSource]);
+	}, [setHasSelectedSource, setSelectedSource, setSourceCheckError]);
 
 	const openSourceSelector = useCallback(
 		async (tab?: "screens" | "windows") => {


### PR DESCRIPTION
## Summary

Fixes #16 — the `setInterval` callback in `LaunchWindow.tsx` was catching all errors from `backend.getSelectedSource()` and doing nothing, leaving the UI stuck showing stale source data with zero indication that anything was wrong.

- **`atoms/launch.ts`** — add `sourceCheckErrorAtom: atom<Error | null>(null)` so components can observe backend failures
- **`LaunchWindow.tsx`** — replace the silent `catch { // ignore }` with `console.warn` + `setSourceCheckError(error)`; on a successful tick the atom is cleared back to `null`
- **`LaunchWindow.sourceCheck.test.tsx`** — 5 new tests covering:
  1. `console.warn` is called when `getSelectedSource` rejects
  2. `sourceCheckErrorAtom` is set to the error
  3. Component does not crash on rejection
  4. Error is cleared when a subsequent call succeeds
  5. No warning or error atom set on a successful call

## Test plan

- [x] `npx vitest run LaunchWindow` — all 9 tests pass (4 existing + 5 new)
- [x] No regressions in existing `LaunchWindow.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)