### PR TITLE
fix: add error logging for failed native recording start (issue #25)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "macos-private-api", "protocol-asset"] }
+tauri = { version = "2", features = ["tray-icon", "macos-private-api", "protocol-asset", "test"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"

--- a/apps/desktop/src-tauri/src/commands/recording.rs
+++ b/apps/desktop/src-tauri/src/commands/recording.rs
@@ -91,18 +91,31 @@ pub async fn start_native_screen_recording(
     #[cfg(target_os = "macos")]
     {
         crate::native::macos_capture::start_capture(&app, &source, &options, &output_path_str)
-            .await?;
+            .await
+            .map_err(|e| {
+                eprintln!("[start_native_screen_recording] Failed to start recording: {}", e);
+                e
+            })?;
     }
 
     #[cfg(target_os = "windows")]
     {
         crate::native::wgc_capture::start_capture(&app, &source, &options, &output_path_str)
-            .await?;
+            .await
+            .map_err(|e| {
+                eprintln!("[start_native_screen_recording] Failed to start recording: {}", e);
+                e
+            })?;
     }
 
     #[cfg(target_os = "linux")]
     {
-        crate::native::ffmpeg::start_capture(&app, &source, &options, &output_path_str).await?;
+        crate::native::ffmpeg::start_capture(&app, &source, &options, &output_path_str)
+            .await
+            .map_err(|e| {
+                eprintln!("[start_native_screen_recording] Failed to start recording: {}", e);
+                e
+            })?;
     }
 
     {
@@ -281,6 +294,48 @@ mod tests {
             s.current_video_path.clone().unwrap_or_default()
         };
         assert_eq!(output_path, "");
+    }
+
+    // ==================== Error Logging / Propagation ====================
+
+    /// Mirrors the map_err closure used in `start_native_screen_recording` so the
+    /// error-propagation logic can be tested without a live Tauri AppHandle.
+    ///
+    /// NOTE: The `eprintln!` side-effect is intentionally exercised here to prove
+    /// the closure compiles and runs, but Rust's standard test runner captures
+    /// stderr by default, so we cannot assert on the logged text in a unit test.
+    /// Integration / end-to-end tests would be required to verify the log output.
+    fn log_and_propagate_capture_error(result: Result<(), String>) -> Result<(), String> {
+        result.map_err(|e| {
+            eprintln!("[start_native_screen_recording] Failed to start recording: {}", e);
+            e
+        })
+    }
+
+    #[test]
+    fn test_capture_error_is_returned_unchanged() {
+        let msg = "Permission denied: screen capture not authorized".to_string();
+        let result = log_and_propagate_capture_error(Err(msg.clone()));
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), msg);
+    }
+
+    #[test]
+    fn test_capture_error_contains_original_message() {
+        let msg = "capture device unavailable".to_string();
+        let result = log_and_propagate_capture_error(Err(msg.clone()));
+        let err_str = result.unwrap_err();
+        assert!(
+            err_str.contains("capture device unavailable"),
+            "error string should contain original message, got: {}",
+            err_str
+        );
+    }
+
+    #[test]
+    fn test_capture_success_passes_through() {
+        let result = log_and_propagate_capture_error(Ok(()));
+        assert!(result.is_ok());
     }
 
     // ==================== Directory Creation ====================

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -95,7 +95,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(target_os = "macos")]
-fn tray_icon_image(_app: &tauri::App) -> Result<Image<'static>, Box<dyn std::error::Error>> {
+fn tray_icon_image<R: tauri::Runtime>(_app: &tauri::App<R>) -> Result<Image<'static>, Box<dyn std::error::Error>> {
     Ok(Image::new_owned(
         include_bytes!("../icons/tray-icon.rgba.bin").to_vec(),
         793,
@@ -104,7 +104,7 @@ fn tray_icon_image(_app: &tauri::App) -> Result<Image<'static>, Box<dyn std::err
 }
 
 #[cfg(not(target_os = "macos"))]
-fn tray_icon_image(app: &tauri::App) -> Result<Image<'static>, Box<dyn std::error::Error>> {
+fn tray_icon_image<R: tauri::Runtime>(app: &tauri::App<R>) -> Result<Image<'static>, Box<dyn std::error::Error>> {
     app.default_window_icon()
         .cloned()
         .map(into_owned_tray_image)


### PR DESCRIPTION
## Summary

- **Root cause**: In `start_native_screen_recording`, errors from platform-specific capture (`macos_capture::start_capture`, `wgc_capture::start_capture`, `ffmpeg::start_capture`) were propagated via bare `?` with zero log output, making failures completely opaque.
- **Fix**: Replaced bare `?` with `.map_err(|e| { eprintln!("[start_native_screen_recording] Failed to start recording: {}", e); e })?` on all three platform paths (macOS, Windows, Linux).
- **Collateral fixes**: Added `tauri/test` feature (required for existing tests in `tray.rs` / `macos_capture.rs` to compile) and made `tray_icon_image` generic over `tauri::Runtime` to resolve a pre-existing type mismatch with `MockRuntime`.

## Test plan

- [x] 3 new unit tests in `commands::recording::tests` verify the error-propagation pattern: error string is returned unchanged, error message is preserved, and `Ok(())` passes through.
- [x] All 15 tests in `commands::recording::tests` pass (`cargo test commands::recording::tests`).
- **Note on logging assertability**: `eprintln!` writes to stderr, which Rust's test runner captures by default. Asserting on the logged text requires an integration/e2e test. The unit tests here exercise the closure (proving it compiles and runs) but cannot assert the stderr output.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)