### PR TITLE
fix: prevent keydown listener leak in ShortcutsConfigDialog (Issue #11)

### DIFF
--- a/apps/desktop/src/components/video-editor/ShortcutsConfigDialog.test.tsx
+++ b/apps/desktop/src/components/video-editor/ShortcutsConfigDialog.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SHORTCUTS } from '@/lib/shortcuts';
+import type { ShortcutsConfig } from '@/lib/shortcuts';
+
+// ---------------------------------------------------------------------------
+// Mocks – set up before the module under test is imported
+// ---------------------------------------------------------------------------
+
+vi.mock('@/contexts/ShortcutsContext', () => ({
+  useShortcuts: vi.fn(),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? createElement('div', { 'data-testid': 'dialog' }, children) : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) =>
+    createElement('div', null, children),
+  DialogHeader: ({ children }: { children: React.ReactNode }) =>
+    createElement('div', null, children),
+  DialogTitle: ({ children }: { children: React.ReactNode }) =>
+    createElement('div', null, children),
+  DialogFooter: ({ children }: { children: React.ReactNode }) =>
+    createElement('div', null, children),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) =>
+    createElement('button', { onClick, ...rest }, children),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+// Lazy-import after mocks are registered
+const { useShortcuts } = vi.mocked(await import('@/contexts/ShortcutsContext'));
+const { ShortcutsConfigDialog } = await import('./ShortcutsConfigDialog');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function makeShortcutsContext(overrides: Partial<ReturnType<typeof useShortcuts>> = {}) {
+  return {
+    shortcuts: { ...DEFAULT_SHORTCUTS } as ShortcutsConfig,
+    isMac: false,
+    isConfigOpen: true,
+    setShortcuts: vi.fn(),
+    persistShortcuts: vi.fn().mockResolvedValue(undefined),
+    openConfig: vi.fn(),
+    closeConfig: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function renderDialog(contextOverrides?: Partial<ReturnType<typeof useShortcuts>>) {
+  useShortcuts.mockReturnValue(makeShortcutsContext(contextOverrides));
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  await act(async () => {
+    root.render(<ShortcutsConfigDialog />);
+  });
+  await flushEffects();
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('ShortcutsConfigDialog – keydown listener lifecycle', () => {
+  it('removes the keydown listener on unmount when captureFor is active', async () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const harness = await renderDialog();
+
+    // Enter capture mode by clicking the first "Click to change" button
+    const captureButton = Array.from(
+      harness.container.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
+    ).find((btn) => btn.getAttribute('title') === 'Click to change');
+    expect(captureButton).not.toBeUndefined();
+
+    await act(async () => {
+      captureButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+
+    // Confirm the dialog is in capture mode
+    expect(harness.container.textContent).toContain('Press a key');
+
+    // Unmount while captureFor is non-null
+    await harness.unmount();
+
+    // The window listener must have been removed
+    const keydownRemoveCalls = removeEventListenerSpy.mock.calls.filter(
+      ([event]) => event === 'keydown',
+    );
+    expect(keydownRemoveCalls.length).toBeGreaterThan(0);
+
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('does NOT intercept keydown events after the component is unmounted', async () => {
+    const harness = await renderDialog();
+
+    // Enter capture mode
+    const captureButton = Array.from(
+      harness.container.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
+    ).find((btn) => btn.getAttribute('title') === 'Click to change');
+
+    await act(async () => {
+      captureButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+
+    // Unmount while capture is active
+    await harness.unmount();
+
+    // After unmount, keydown events must propagate normally and NOT be suppressed
+    const preventDefaultSpy = vi.fn();
+    const outsideHandler = vi.fn((e: Event) => {
+      // Detect if the component's capture listener called preventDefault
+      if ((e as KeyboardEvent).defaultPrevented) {
+        preventDefaultSpy();
+      }
+    });
+
+    // Add a non-capture listener to observe events from the outside
+    window.addEventListener('keydown', outsideHandler);
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true, cancelable: true }));
+    });
+
+    // The handler must fire (event was not stopped) and must not have been preventDefault'd
+    expect(outsideHandler).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+
+    window.removeEventListener('keydown', outsideHandler);
+  });
+
+  it('registers exactly one keydown listener on mount and removes it on unmount', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const harness = await renderDialog();
+
+    const keydownAdds = addSpy.mock.calls.filter(([event]) => event === 'keydown');
+    expect(keydownAdds).toHaveLength(1);
+
+    await harness.unmount();
+
+    const keydownRemoves = removeSpy.mock.calls.filter(([event]) => event === 'keydown');
+    expect(keydownRemoves).toHaveLength(1);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('ignores keydown events when captureFor is null (dialog open, no action selected)', async () => {
+    const harness = await renderDialog();
+
+    // No capture button clicked – captureFor is null
+    const interceptedKeys: string[] = [];
+    const observer = (e: KeyboardEvent) => {
+      if (!e.defaultPrevented) interceptedKeys.push(e.key);
+    };
+    window.addEventListener('keydown', observer);
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true, cancelable: true }));
+    });
+
+    // Key must have propagated without being defaultPrevented
+    expect(interceptedKeys).toContain('z');
+
+    window.removeEventListener('keydown', observer);
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/video-editor/ShortcutsConfigDialog.tsx
+++ b/apps/desktop/src/components/video-editor/ShortcutsConfigDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Keyboard, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -28,6 +28,13 @@ export function ShortcutsConfigDialog() {
   const [captureFor, setCaptureFor] = useState<ShortcutAction | null>(null);
   const [conflict, setConflict] = useState<{ forAction: ShortcutAction; pending: ShortcutBinding; conflictWith: ShortcutConflict } | null>(null);
 
+  // Refs keep the handler closure always reading the latest values without
+  // forcing the listener to be torn down and re-added on every state change.
+  const captureForRef = useRef<ShortcutAction | null>(captureFor);
+  const draftRef = useRef<ShortcutsConfig>(draft);
+  captureForRef.current = captureFor;
+  draftRef.current = draft;
+
   useEffect(() => {
     if (isConfigOpen) {
       setDraft(shortcuts);
@@ -36,10 +43,13 @@ export function ShortcutsConfigDialog() {
     }
   }, [isConfigOpen, shortcuts]);
 
+  // Register the listener once on mount and always remove it on unmount,
+  // regardless of captureFor state, so no keydown events leak after close.
   useEffect(() => {
-    if (!captureFor) return;
-
     const handleCapture = (e: KeyboardEvent) => {
+      const currentCaptureFor = captureForRef.current;
+      if (!currentCaptureFor) return;
+
       e.preventDefault();
       e.stopPropagation();
 
@@ -57,7 +67,7 @@ export function ShortcutsConfigDialog() {
         ...(e.altKey ? { alt: true } : {}),
       };
 
-      const found = findConflict(binding, captureFor, draft);
+      const found = findConflict(binding, currentCaptureFor, draftRef.current);
       setCaptureFor(null);
 
       if (found?.type === 'fixed') {
@@ -66,16 +76,16 @@ export function ShortcutsConfigDialog() {
       }
 
       if (found?.type === 'configurable') {
-        setConflict({ forAction: captureFor, pending: binding, conflictWith: found });
+        setConflict({ forAction: currentCaptureFor, pending: binding, conflictWith: found });
         return;
       }
 
-      setDraft((prev: ShortcutsConfig) => ({ ...prev, [captureFor]: binding }));
+      setDraft((prev: ShortcutsConfig) => ({ ...prev, [currentCaptureFor]: binding }));
     };
 
     window.addEventListener('keydown', handleCapture, { capture: true });
     return () => window.removeEventListener('keydown', handleCapture, { capture: true });
-  }, [captureFor]);
+  }, []);
 
   const handleSwap = useCallback(() => {
     if (!conflict || conflict.conflictWith.type !== 'configurable') return;


### PR DESCRIPTION
## Summary

Fixes #11 — the global `keydown` capture-phase listener in `ShortcutsConfigDialog` could theoretically survive component unmount if the component was torn down while `captureFor` was non-null.

### Root cause

The old `useEffect` had `captureFor` in its dependency array and returned early when `captureFor` was null, meaning the cleanup function was conditionally registered. The listener and its corresponding `useState`-based draft were accessed via stale closures.

### Fix

- **Register once, always clean up**: the `useEffect` now uses an empty dependency array (`[]`), so the listener is registered on mount and always removed on unmount — no conditional cleanup paths.
- **Refs instead of closed-over state**: `captureForRef` and `draftRef` are updated on every render, so the handler always reads the current values without causing listener re-registration.
- **Bonus**: fixes a latent stale-closure bug where `draft` changes while a key was being captured were invisible to the old handler.

### Tests added (`ShortcutsConfigDialog.test.tsx`)

| Test | What it verifies |
|---|---|
| listener removed on unmount when captureFor is active | `window.removeEventListener` called for `keydown` |
| no interception after unmount | post-unmount `keydown` events are not `preventDefault`'d |
| exactly one listener per mount cycle | `addEventListener`/`removeEventListener` each called once |
| handler is a no-op when captureFor is null | events propagate normally when no action is being captured |

## Test plan

- [x] All 4 new tests pass
- [x] Full suite: 982 tests pass (pre-existing `gifExporter` failure is unrelated — `navigator` not defined in node env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)