### PR TITLE
fix: emit recording-interrupted on window destroy during active recording (Issue #24)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -39,5 +39,8 @@ objc = "0.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = "0.13"
 
+[dev-dependencies]
+tauri = { version = "2", features = ["test"] }
+
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,21 @@ const HUD_HEIGHT: f64 = 155.0;
 /// Bottom margin (logical pixels) between the HUD and the screen edge.
 const HUD_BOTTOM_MARGIN: f64 = 5.0;
 
+/// Checks whether a recording is currently active and, if so, clears the flag
+/// so state does not dangle after the window is gone.
+///
+/// Returns `true` when recording was active (the caller should emit a
+/// `"recording-interrupted"` event so that any surviving renderer can
+/// finalise the session gracefully).
+fn check_recording_on_window_destroy(state: &mut AppState) -> bool {
+    if state.native_screen_recording_active {
+        state.native_screen_recording_active = false;
+        true
+    } else {
+        false
+    }
+}
+
 /// Compute the physical pixel position for the HUD overlay so it sits at the
 /// bottom-center of the monitor.
 ///
@@ -171,10 +186,16 @@ pub fn run() {
             }
             tauri::WindowEvent::Destroyed => {
                 let label = window.label().to_string();
-                if commands::window_mgmt::is_editor_window_label(&label) {
-                    let state: tauri::State<'_, Mutex<AppState>> = window.state();
-                    let lock_result = state.lock();
-                    if let Ok(mut s) = lock_result {
+                let state: tauri::State<'_, Mutex<AppState>> = window.state();
+                let lock_result = state.lock();
+                if let Ok(mut s) = lock_result {
+                    // If a recording was active when this window was destroyed,
+                    // clear the flag and notify any surviving renderers so they
+                    // can finalise the session rather than silently losing data.
+                    if check_recording_on_window_destroy(&mut s) {
+                        let _ = window.app_handle().emit("recording-interrupted", ());
+                    }
+                    if commands::window_mgmt::is_editor_window_label(&label) {
                         s.unsaved_editor_windows.remove(&label);
                         s.has_unsaved_changes = !s.unsaved_editor_windows.is_empty();
                     }
@@ -294,5 +315,93 @@ mod tests {
             hud_center,
             monitor_center
         );
+    }
+
+    // ==================== check_recording_on_window_destroy ====================
+
+    #[test]
+    fn test_recording_interrupted_when_active() {
+        let mut state = AppState::default();
+        state.native_screen_recording_active = true;
+
+        let interrupted = check_recording_on_window_destroy(&mut state);
+
+        assert!(
+            interrupted,
+            "should signal interruption when recording was active"
+        );
+        assert!(
+            !state.native_screen_recording_active,
+            "recording flag must be cleared after interruption"
+        );
+    }
+
+    #[test]
+    fn test_no_interrupt_when_not_recording() {
+        let mut state = AppState::default();
+        assert!(!state.native_screen_recording_active);
+
+        let interrupted = check_recording_on_window_destroy(&mut state);
+
+        assert!(!interrupted, "must not signal interruption when not recording");
+        assert!(!state.native_screen_recording_active);
+    }
+
+    #[test]
+    fn test_window_destroy_clears_recording_flag_via_mutex() {
+        // Simulate the full Destroyed-handler path: lock state, call helper,
+        // assert the returned bool drives the "emit" decision correctly.
+        let state_mutex = std::sync::Mutex::new(AppState::default());
+
+        // Arrange: recording is active with a video path
+        {
+            let mut s = state_mutex.lock().unwrap();
+            s.native_screen_recording_active = true;
+            s.current_video_path = Some("/tmp/recording.mov".to_string());
+        }
+
+        // Act: simulate what the Destroyed handler now does
+        let should_emit = {
+            let mut s = state_mutex.lock().unwrap();
+            check_recording_on_window_destroy(&mut s)
+        };
+
+        // Assert: the handler should have decided to emit the event …
+        assert!(should_emit, "expected interrupt signal for active recording");
+
+        // … and the recording flag is cleared so state does not dangle
+        let s = state_mutex.lock().unwrap();
+        assert!(
+            !s.native_screen_recording_active,
+            "recording flag should be cleared after window destroy"
+        );
+        // The video path is intentionally preserved for potential recovery
+        assert_eq!(s.current_video_path.as_deref(), Some("/tmp/recording.mov"));
+    }
+
+    #[test]
+    fn test_window_destroy_no_emit_when_idle() {
+        let state_mutex = std::sync::Mutex::new(AppState::default());
+
+        let should_emit = {
+            let mut s = state_mutex.lock().unwrap();
+            check_recording_on_window_destroy(&mut s)
+        };
+
+        assert!(!should_emit, "no interrupt expected when recording is idle");
+    }
+
+    #[test]
+    fn test_check_recording_idempotent_when_called_twice() {
+        // Calling the helper twice on the same state must not re-signal after
+        // the first call has already cleared the flag.
+        let mut state = AppState::default();
+        state.native_screen_recording_active = true;
+
+        let first = check_recording_on_window_destroy(&mut state);
+        let second = check_recording_on_window_destroy(&mut state);
+
+        assert!(first, "first call should detect active recording");
+        assert!(!second, "second call must not re-signal after flag cleared");
     }
 }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -104,7 +104,7 @@ fn tray_icon_image(_app: &tauri::App) -> Result<Image<'static>, Box<dyn std::err
 }
 
 #[cfg(not(target_os = "macos"))]
-fn tray_icon_image(app: &tauri::App) -> Result<Image<'static>, Box<dyn std::error::Error>> {
+fn tray_icon_image<R: tauri::Runtime>(app: &tauri::App<R>) -> Result<Image<'static>, Box<dyn std::error::Error>> {
     app.default_window_icon()
         .cloned()
         .map(into_owned_tray_image)


### PR DESCRIPTION
## Summary

- **Root cause:** `WindowEvent::Destroyed` in `lib.rs` only cleaned up unsaved-editor-window tracking but never checked `native_screen_recording_active`, leaving recording state dangling when a window was force-closed mid-recording.
- **Fix:** Extracted `check_recording_on_window_destroy()` which atomically reads and clears the recording flag. The `Destroyed` handler now calls it and, if recording was active, broadcasts a `"recording-interrupted"` Tauri event so any surviving renderer can finalise the session instead of silently losing data.
- **Side-fixes:** Added `tauri/test` dev-dependency (pre-existing tests in `macos_capture.rs` and `tray.rs` needed it); made `tray_icon_image()` generic over `tauri::Runtime` so the mock-runtime test compiles.

## Changes

| File | Change |
|------|--------|
| `src/lib.rs` | New `check_recording_on_window_destroy()` helper + updated `Destroyed` handler + 5 new unit tests |
| `src/tray.rs` | Made `tray_icon_image` generic over `tauri::Runtime` (pre-existing type mismatch with `MockRuntime`) |
| `Cargo.toml` | Added `tauri = { version = "2", features = ["test"] }` as dev-dependency |

## Test plan

- [x] `cargo test` — **314 passed, 0 failed** (lib unit tests + integration tests)
- [x] `test_recording_interrupted_when_active` — flag cleared, returns `true`
- [x] `test_no_interrupt_when_not_recording` — returns `false`, flag stays clear
- [x] `test_window_destroy_clears_recording_flag_via_mutex` — full mutex path, video path preserved for recovery
- [x] `test_window_destroy_no_emit_when_idle` — no spurious emit when idle
- [x] `test_check_recording_idempotent_when_called_twice` — second call after clear never re-signals

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)