### PR TITLE
fix: add 30s timeout to waitForLoadedMetadata (issue #17)

### DIFF
--- a/apps/desktop/src/lib/exporter/audioEncoder.test.ts
+++ b/apps/desktop/src/lib/exporter/audioEncoder.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { applyAudioGainToBuffer } from "./audioEncoder";
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AudioProcessor, applyAudioGainToBuffer } from "./audioEncoder";
 
 describe("audioEncoder", () => {
 	it("applies gain to float audio buffers and clamps output", () => {
@@ -24,5 +26,37 @@ describe("audioEncoder", () => {
 		applyAudioGainToBuffer(samples.buffer, "u8", 0.5);
 
 		expect(Array.from(samples)).toEqual([128, 192, 64]);
+	});
+});
+
+describe("AudioProcessor metadata load timeout", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("rejects with a timeout error when loadedmetadata never fires", async () => {
+		const processor = new AudioProcessor();
+
+		// jsdom never fires loadedmetadata for media elements, which simulates a corrupt
+		// or stalled file. The process() call must reject once the 30s timeout elapses.
+		const promise = processor.process(
+			{} as never, // demuxer – not reached before timeout
+			{} as never, // muxer   – not reached before timeout
+			"blob:never-fires",
+			[],
+			[{ id: "s1", startMs: 0, endMs: 1000, speed: 2 as const }],
+		);
+
+		// Advance fake timers past the 30-second threshold.
+		// Use the synchronous variant so the microtask queue is not flushed until the
+		// subsequent `await`, by which point `expect().rejects` has already attached a
+		// rejection handler to `promise` (avoiding an unhandled-rejection warning).
+		vi.advanceTimersByTime(31_000);
+
+		await expect(promise).rejects.toThrow("Metadata load timed out after 30s");
 	});
 });

--- a/apps/desktop/src/lib/exporter/audioEncoder.ts
+++ b/apps/desktop/src/lib/exporter/audioEncoder.ts
@@ -446,11 +446,18 @@ export class AudioProcessor {
 		}
 
 		return new Promise<void>((resolve, reject) => {
+			const timeoutId = setTimeout(() => {
+				cleanup();
+				reject(new Error("Metadata load timed out after 30s"));
+			}, 30_000);
+
 			const onLoaded = () => {
+				clearTimeout(timeoutId);
 				cleanup();
 				resolve();
 			};
 			const onError = () => {
+				clearTimeout(timeoutId);
 				cleanup();
 				reject(new Error("Failed to load media metadata for speed-adjusted audio"));
 			};


### PR DESCRIPTION
## Summary

- **Root cause**: `waitForLoadedMetadata` in `audioEncoder.ts` had no timeout. A corrupt or stalled video file that never fires `loadedmetadata` would cause the export pipeline to hang indefinitely.
- **Fix**: Added a 30-second `setTimeout` inside the single `Promise` returned by `waitForLoadedMetadata`. The timeout clears itself on success/error, and rejects with `"Metadata load timed out after 30s"` if neither event fires in time.
- **Why not `Promise.race`?** Putting the timeout inside the promise (rather than racing two separate promises at the call site) keeps the implementation clean and avoids orphaned promise rejections that Node.js reports as warnings.

## Changes

- `apps/desktop/src/lib/exporter/audioEncoder.ts` — `waitForLoadedMetadata` now includes a 30 s deadline
- `apps/desktop/src/lib/exporter/audioEncoder.test.ts` — new test suite using jsdom + `vi.useFakeTimers()` that asserts the export rejects with the timeout error when `loadedmetadata` never fires

## Test plan

- [x] All 3 tests in `audioEncoder.test.ts` pass (`pnpm --filter desktop exec vitest --run`)
- [x] No unhandled-rejection warnings in vitest output
- [x] Existing `applyAudioGainToBuffer` tests unaffected

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)