### PR TITLE
fix(types): replace 'any' types in backend.ts with proper interfaces

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,7 +32,8 @@
 		"preview": "vite preview",
 		"i18n:check": "node scripts/i18n-check.mjs",
 		"test": "vitest --run",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@fix-webm-duration/fix": "^1.0.1",

--- a/apps/desktop/src/__tests__/types/backend-types.typecheck.ts
+++ b/apps/desktop/src/__tests__/types/backend-types.typecheck.ts
@@ -1,0 +1,117 @@
+/**
+ * TypeScript type-level assertions for backend.ts.
+ *
+ * This file is NOT a runtime test. It is checked by the TypeScript compiler
+ * (`tsc --noEmit` / `pnpm typecheck`) to verify that the domain interfaces
+ * used in backend.ts are correctly typed.
+ *
+ * How it works:
+ *   - Lines marked `// @ts-expect-error` must produce a TypeScript error.
+ *     If the error is absent (e.g., because a type regresses to `any`),
+ *     TypeScript flags the directive itself as an "Unused '@ts-expect-error'
+ *     directive" error, failing the type-check.
+ *   - Positive assertions use `satisfies` to confirm valid property access.
+ *
+ * Run: pnpm typecheck
+ */
+
+import type { RecordingSession, FacecamSettings } from "@/lib/recordingSession";
+import type { ShortcutsConfig, ShortcutBinding } from "@/lib/shortcuts";
+import type { DesktopSource } from "@/components/launch/sourceSelectorState";
+import type { SourceListOptions, NativeRecordingOptions } from "@/lib/backend";
+
+// ─── RecordingSession ────────────────────────────────────────────────────────
+
+declare const session: RecordingSession;
+
+// Valid required property
+void (session.screenVideoPath satisfies string);
+
+// Valid optional properties
+void (session.facecamVideoPath satisfies string | undefined);
+void (session.facecamOffsetMs satisfies number | undefined);
+void (session.facecamSettings satisfies FacecamSettings | undefined);
+void (session.sourceName satisfies string | undefined);
+
+// @ts-expect-error: 'nonExistentField' does not exist on RecordingSession
+void session.nonExistentField;
+
+// @ts-expect-error: typo — 'screenVideoPah' does not exist on RecordingSession
+void session.screenVideoPah;
+
+// @ts-expect-error: 'videoPath' does not exist (correct name is screenVideoPath)
+void session.videoPath;
+
+// ─── ShortcutsConfig ─────────────────────────────────────────────────────────
+
+declare const shortcuts: ShortcutsConfig;
+
+// Valid shortcut keys
+void (shortcuts.addZoom satisfies ShortcutBinding);
+void (shortcuts.addTrim satisfies ShortcutBinding);
+void (shortcuts.playPause satisfies ShortcutBinding);
+void (shortcuts.deleteSelected satisfies ShortcutBinding);
+
+// @ts-expect-error: 'addZomm' does not exist on ShortcutsConfig (typo)
+void shortcuts.addZomm;
+
+// @ts-expect-error: 'startStopRecording' is not an editor shortcut key
+void shortcuts.startStopRecording;
+
+// @ts-expect-error: 'pauseRecording' is not an editor shortcut key
+void shortcuts.pauseRecording;
+
+// ─── DesktopSource ───────────────────────────────────────────────────────────
+
+declare const source: DesktopSource;
+
+// Valid required properties
+void (source.id satisfies string);
+void (source.name satisfies string);
+
+// Valid optional properties
+void (source.sourceType satisfies "screen" | "window");
+void (source.appName satisfies string | undefined);
+void (source.windowTitle satisfies string | undefined);
+void (source.windowId satisfies number | undefined);
+
+// @ts-expect-error: 'nonExistentProp' does not exist on DesktopSource
+void source.nonExistentProp;
+
+// @ts-expect-error: typo — 'souceType' does not exist (correct: sourceType)
+void source.souceType;
+
+// @ts-expect-error: 'source_type' is the Rust snake_case name; TS type uses camelCase
+void source.source_type;
+
+// ─── SourceListOptions ───────────────────────────────────────────────────────
+
+declare const opts: SourceListOptions;
+
+// Valid properties
+void (opts.types satisfies string[] | undefined);
+void (opts.withThumbnails satisfies boolean | undefined);
+void (opts.timeoutMs satisfies number | undefined);
+void (opts.thumbnailSize satisfies { width?: number; height?: number } | undefined);
+
+// @ts-expect-error: 'timeout' is not a valid key (correct name is timeoutMs)
+void opts.timeout;
+
+// @ts-expect-error: 'thumbnail_size' is the Rust snake_case name; TS type uses camelCase
+void opts.thumbnail_size;
+
+// ─── NativeRecordingOptions ──────────────────────────────────────────────────
+
+declare const nativeOpts: NativeRecordingOptions;
+
+// Valid properties
+void (nativeOpts.captureCursor satisfies boolean | undefined);
+void (nativeOpts.capturesSystemAudio satisfies boolean | undefined);
+void (nativeOpts.capturesMicrophone satisfies boolean | undefined);
+void (nativeOpts.microphoneDeviceId satisfies string | undefined);
+void (nativeOpts.microphoneLabel satisfies string | undefined);
+
+// @ts-expect-error: 'captureAudio' is not a valid key (correct: capturesSystemAudio)
+void nativeOpts.captureAudio;
+
+export {};

--- a/apps/desktop/src/contexts/ShortcutsContext.tsx
+++ b/apps/desktop/src/contexts/ShortcutsContext.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from 'jotai'
 import { createContext, useCallback, useContext, useEffect, useMemo, type ReactNode } from 'react'
-import { DEFAULT_SHORTCUTS, mergeWithDefaults, type ShortcutsConfig } from '@/lib/shortcuts'
+import { mergeWithDefaults, type ShortcutsConfig } from '@/lib/shortcuts'
 import { isMac as getIsMac } from '@/utils/platformUtils'
 import { getShortcuts as backendGetShortcuts, saveShortcuts as backendSaveShortcuts } from '@/lib/backend'
 import { isMacOSAtom } from '@/atoms/app'

--- a/apps/desktop/src/lib/backend.ts
+++ b/apps/desktop/src/lib/backend.ts
@@ -5,6 +5,28 @@
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { resolveMediaPlaybackUrl as resolveMediaPlaybackAssetUrl } from "@/lib/mediaPlaybackUrl";
+import type { RecordingSession } from "./recordingSession";
+import type { ShortcutsConfig } from "./shortcuts";
+import type { DesktopSource } from "../components/launch/sourceSelectorState";
+
+// ─── Source List Options ─────────────────────────────────────────────────────
+
+export interface SourceListOptions {
+	types?: string[];
+	thumbnailSize?: { width?: number; height?: number };
+	withThumbnails?: boolean;
+	timeoutMs?: number;
+}
+
+// ─── Native Recording Options ────────────────────────────────────────────────
+
+export interface NativeRecordingOptions {
+	captureCursor?: boolean;
+	capturesSystemAudio?: boolean;
+	capturesMicrophone?: boolean;
+	microphoneDeviceId?: string;
+	microphoneLabel?: string;
+}
 
 export type { UnlistenFn };
 
@@ -99,11 +121,11 @@ export function clearCurrentVideoPath(): Promise<void> {
 
 // ─── Recording Session ──────────────────────────────────────────────────────
 
-export function getCurrentRecordingSession(): Promise<any | null> {
+export function getCurrentRecordingSession(): Promise<RecordingSession | null> {
 	return invoke("get_current_recording_session");
 }
 
-export function setCurrentRecordingSession(session: any): Promise<void> {
+export function setCurrentRecordingSession(session: RecordingSession): Promise<void> {
 	return invoke("set_current_recording_session", { session });
 }
 
@@ -117,29 +139,29 @@ export function chooseRecordingsDirectory(): Promise<string | null> {
 	return invoke("choose_recordings_directory");
 }
 
-export function getShortcuts(): Promise<any | null> {
+export function getShortcuts(): Promise<ShortcutsConfig | null> {
 	return invoke("get_shortcuts");
 }
 
-export function saveShortcuts(shortcuts: any): Promise<void> {
+export function saveShortcuts(shortcuts: ShortcutsConfig): Promise<void> {
 	return invoke("save_shortcuts", { shortcuts });
 }
 
 // ─── Sources ────────────────────────────────────────────────────────────────
 
-export function selectSource(source: any): Promise<void> {
+export function selectSource(source: DesktopSource): Promise<void> {
 	return invoke("select_source", { source });
 }
 
-export function flashSelectedScreen(source: any): Promise<void> {
+export function flashSelectedScreen(source: DesktopSource): Promise<void> {
 	return invoke("flash_selected_screen", { source });
 }
 
-export function getSelectedSource(): Promise<any | null> {
+export function getSelectedSource(): Promise<DesktopSource | null> {
 	return invoke("get_selected_source");
 }
 
-export function getSources(opts?: any): Promise<any[]> {
+export function getSources(opts?: SourceListOptions): Promise<ProcessedDesktopSource[]> {
 	return invoke("get_sources", { opts });
 }
 
@@ -149,7 +171,10 @@ export function setRecordingState(recording: boolean): Promise<void> {
 	return invoke("set_recording_state", { recording });
 }
 
-export function startNativeScreenRecording(source: any, options: any): Promise<string> {
+export function startNativeScreenRecording(
+	source: DesktopSource,
+	options: NativeRecordingOptions,
+): Promise<string> {
 	return invoke("start_native_screen_recording", { source, options });
 }
 

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -5,6 +5,7 @@
 		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"module": "ESNext",
 		"skipLibCheck": true,
+		"ignoreDeprecations": "5.0",
 		"baseUrl": ".",
 		"paths": {
 			"@/*": ["src/*"]


### PR DESCRIPTION
## Summary

Fixes #21. Replaces bare `any` parameter/return types in `apps/desktop/src/lib/backend.ts` with accurate TypeScript interfaces, so typos in property access are caught at compile time instead of silently passing.

**Changes to `backend.ts`:**
- `RecordingSession` (existing, from `./recordingSession`) replaces `any` in `getCurrentRecordingSession` / `setCurrentRecordingSession`
- `ShortcutsConfig` (existing, from `./shortcuts`) replaces `any` in `getShortcuts` / `saveShortcuts`
- `DesktopSource` (existing, from `../components/launch/sourceSelectorState`) replaces `any` in `selectSource`, `flashSelectedScreen`, `getSelectedSource`, `startNativeScreenRecording`
- New exported `SourceListOptions` interface for `getSources` opts — matches the Rust `SourceListOptions` struct (`types`, `thumbnailSize`, `withThumbnails`, `timeoutMs`)
- New exported `NativeRecordingOptions` interface for `startNativeScreenRecording` — matches call-site usage
- `getSources` return type changed from `any[]` → `ProcessedDesktopSource[]` (global type used by `mapSources` at all call sites)

**Type assertion test:**
Added `src/__tests__/types/backend-types.typecheck.ts` — a compile-time-only file (not a vitest test) that uses `@ts-expect-error` directives to assert that invalid property access causes TypeScript errors. If any type regresses to `any`, the unused `@ts-expect-error` directive itself becomes a compiler error, failing `pnpm typecheck`.

**Infrastructure:**
- `"typecheck": "tsc --noEmit"` added to `package.json` scripts
- `"ignoreDeprecations": "5.0"` added to `tsconfig.json` to suppress a pre-existing `baseUrl` deprecation warning that was blocking `tsc`
- Removed unused `DEFAULT_SHORTCUTS` import from `ShortcutsContext.tsx` (pre-existing lint error now surfaced by `pnpm typecheck`)

## Runtime behaviour

No runtime behaviour changes — only TypeScript types were updated. The JavaScript emitted is identical.

## Why no runtime tests?

This is a types-only fix. Runtime tests would test the same Tauri IPC calls that already have integration-level coverage. The compile-time type assertions in `backend-types.typecheck.ts` verify the type contracts are correct; `pnpm typecheck` is the appropriate gate.

## Test plan

- [x] `pnpm test` — 978 tests pass (1 pre-existing failing suite unrelated to this change)
- [x] `pnpm typecheck` — no new errors from changed files (remaining errors are pre-existing in `cursorTelemetryPayload.ts`, `useScreenRecorder.ts`, `clipboard.ts`, `pixiRuntime.ts`)
- [x] Type assertion file verifies `RecordingSession`, `ShortcutsConfig`, `DesktopSource`, `SourceListOptions`, `NativeRecordingOptions` reject typos and non-existent properties at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)