### PR TITLE
ci: align skip-aware checks with mergify

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,37 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - '**'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '.github/workflows/test.yml'
+              - 'apps/desktop/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'biome.json'
+
   test:
     name: Run vitest suite
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,6 +62,8 @@ jobs:
 
   e2e:
     name: Playwright E2E
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,9 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
-      - '**'
+      - main
 
 jobs:
   changes:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,29 @@
+queue_rules:
+  - name: Default merge queue
+    autoqueue: true
+    draft_bot_account: imbhargav5
+    merge_bot_account: imbhargav5
+    update_bot_account: imbhargav5
+    merge_method: merge
+    merge_conditions:
+      - check-success=GitGuardian Security Checks
+      - or:
+          - check-success=Run vitest suite
+          - check-skipped=Run vitest suite
+      - or:
+          - check-success=Playwright E2E
+          - check-skipped=Playwright E2E
+
+merge_queue:
+  max_parallel_checks: 10
+
+merge_protections:
+  - name: Do not merge outdated PRs
+    description: Make sure PRs are almost up to date before merging
+    if:
+      - base = main
+    success_conditions:
+      - "#commits-behind <= 10"
+
+merge_protections_settings:
+  reporting_method: check-runs


### PR DESCRIPTION
## Summary
- add a skip-aware `changes` gate to the test workflow instead of relying on workflow-level path filtering
- keep the required check names stable so PR statuses resolve as `success` or `skipped`
- add a Mergify queue configuration that accepts those checks in either state and reports merge protections as check-runs

## Test plan
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); YAML.load_file(".mergify.yml"); puts "YAML OK"'
- reviewed the workflow diff against the `imbhargav5/unbound.computer` reference pattern
