### PR TITLE
chore: patch release v0.0.22

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder"
-version = "0.0.21"
+version = "0.0.22"
 description = "A free, creator-focused screen recorder"
 authors = ["imbhargav5"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Open Recorder",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "identifier": "dev.openrecorder.app",
   "build": {
     "beforeDevCommand": "pnpm exec vite",


### PR DESCRIPTION
## Summary
- Bumps version from `0.0.21` → `0.0.22` across all version files (`package.json`, `Cargo.toml`, `tauri.conf.json`)
- All 1053 unit tests pass (70 test files)
- Full Tauri native build requires `cargo-tauri` CLI (not available in CI-less environment), but frontend code is verified

## Files changed
- `apps/desktop/package.json` — version bump
- `apps/desktop/src-tauri/Cargo.toml` — version bump
- `apps/desktop/src-tauri/tauri.conf.json` — version bump

## Test plan
- [x] Verified all 1053 unit tests pass
- [ ] CI should run the full build pipeline after merge

https://claude.ai/code/session_012uD1ZXxh6GMJUhr4EDrCu3