### PR TITLE
chore: patch release v0.0.22

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.21",
-  "releaseName": "Open Recorder v0.0.21",
+  "tagName": "v0.0.22",
+  "releaseName": "Open Recorder v0.0.22",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-electron
 dist-ssr
 *.local
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.cjs",


### PR DESCRIPTION
## Summary
- Bump version from `0.0.21` to `0.0.22` in `apps/desktop/package.json` and `.github/release-plan.json`
- Build verified passing before version bump

## Test plan
- [x] Verified `pnpm build` passes successfully before the version change
- [ ] Confirm CI passes on the PR

https://claude.ai/code/session_01CVd1g94MBT1snrauWMFqCh