### PR TITLE
chore(deps): remove unused fix-webm-duration legacy package

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -65,7 +65,6 @@
 		"dnd-timeline": "^2.2.0",
 		"electron-updater": "^6.3.9",
 		"emoji-picker-react": "^4.16.1",
-		"fix-webm-duration": "^1.0.6",
 		"gif.js": "^0.2.0",
 		"gsap": "^3.13.0",
 		"jotai": "^2.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       emoji-picker-react:
         specifier: ^4.16.1
         version: 4.18.0(react@18.3.1)
-      fix-webm-duration:
-        specifier: ^1.0.6
-        version: 1.0.6
       gif.js:
         specifier: ^0.2.0
         version: 0.2.0
@@ -2387,9 +2384,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  fix-webm-duration@1.0.6:
-    resolution: {integrity: sha512-zVAqi4gE+8ywxJuAyV/rlJVX6CMtvyapEbQx6jyoeX9TMjdqAlt/FdG5d7rXSSkDVzTvS0H7CtwzHcH/vh4FPA==}
 
   flairup@1.0.0:
     resolution: {integrity: sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==}
@@ -6138,8 +6132,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  fix-webm-duration@1.0.6: {}
 
   flairup@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Investigated all usages of `fix-webm-duration`, `@fix-webm-duration/fix`, and `@fix-webm-duration/parser` across the entire codebase
- Found that `fix-webm-duration` (unscoped, v1.0.6) is **not imported anywhere** in source code
- The scoped packages `@fix-webm-duration/fix` and `@fix-webm-duration/parser` are the only ones actually used — in `src/hooks/useScreenRecorder.ts` and its test file
- Removed the redundant `fix-webm-duration` entry from `apps/desktop/package.json`

## Details

| Package | Used? | Where |
|---------|-------|-------|
| `@fix-webm-duration/fix` | Yes | `useScreenRecorder.ts:1` — `fixParsedWebmDuration()` |
| `@fix-webm-duration/parser` | Yes | `useScreenRecorder.ts:2` — `WebmFile` class |
| `fix-webm-duration` | **No** | Not imported anywhere |

## Test plan

- [x] `pnpm install` — clean install succeeds
- [x] `pnpm test` — all 1054 tests pass across 70 test files
- [x] `pnpm --filter @open-recorder/desktop typecheck` — pre-existing errors only (none related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)