### PR TITLE
chore: upgrade TypeScript from 5.2.2 to 6.0.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -108,7 +108,7 @@
 		"postcss": "^8.5.6",
 		"tailwindcss": "^3.4.18",
 		"terser": "^5.44.1",
-		"typescript": "^5.2.2",
+		"typescript": "^6.0.3",
 		"vite": "^5.1.6",
 		"vitest": "3.2.4",
 		"wait-on": "^8.0.3"

--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -259,7 +259,7 @@ export function LaunchWindow() {
 
 	// Elapsed timer
 	useEffect(() => {
-		let timer: NodeJS.Timeout | null = null;
+		let timer: ReturnType<typeof setTimeout> | null = null;
 		if (recording) {
 			if (!recordingStart) setRecordingStart(Date.now());
 			const startTime = recordingStart || Date.now();

--- a/apps/desktop/src/components/ui/content-clamp.tsx
+++ b/apps/desktop/src/components/ui/content-clamp.tsx
@@ -20,7 +20,7 @@ function ContentClamp({
   const isTruncated = text.length > truncateLength
 
   const [open, setOpen] = React.useState(false)
-  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleMouseEnter = () => {
     if (timeoutRef.current) {

--- a/apps/desktop/src/components/video-editor/cursorTelemetryPayload.ts
+++ b/apps/desktop/src/components/video-editor/cursorTelemetryPayload.ts
@@ -195,7 +195,7 @@ function normalizeEntry(
 	entry: unknown,
 	context: NormalizationContext,
 	defaultInteractionType?: CursorInteractionType,
-) {
+): CursorTelemetryPoint | null {
 	if (!isRecord(entry)) {
 		return null;
 	}

--- a/apps/desktop/src/components/video-editor/videoPlayback/cursorRenderer.ts
+++ b/apps/desktop/src/components/video-editor/videoPlayback/cursorRenderer.ts
@@ -202,11 +202,11 @@ export async function preloadCursorAssets() {
 			let systemCursors: Record<string, SystemCursorAsset> = {};
 
 			try {
-				const result = await getSystemCursorAssets();
+				const result = await getSystemCursorAssets() as { cursors?: Record<string, SystemCursorAsset> } | null;
 				if (result && result.cursors) {
 					systemCursors = result.cursors;
 				} else if (result && typeof result === "object") {
-					systemCursors = result as Record<string, SystemCursorAsset>;
+					systemCursors = result as unknown as Record<string, SystemCursorAsset>;
 				}
 			} catch (error) {
 				console.warn("[CursorRenderer] Failed to fetch system cursor assets:", error);

--- a/apps/desktop/src/contexts/I18nContext.tsx
+++ b/apps/desktop/src/contexts/I18nContext.tsx
@@ -10,7 +10,6 @@ import { useAtom } from 'jotai'
 import {
   DEFAULT_LOCALE,
   I18N_NAMESPACES,
-  SUPPORTED_LOCALES,
   type AppLocale,
   type I18nNamespace,
 } from '@/i18n/config'
@@ -60,10 +59,6 @@ interface I18nContextValue {
 }
 
 const I18nContext = createContext<I18nContextValue | null>(null)
-
-function isSupportedLocale(locale: string): locale is AppLocale {
-  return SUPPORTED_LOCALES.includes(locale as AppLocale)
-}
 
 function getMessageValue(source: unknown, key: string): string | undefined {
   const parts = key.split('.')

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -874,7 +874,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						maxHeight: TARGET_HEIGHT,
 						maxFrameRate: TARGET_FRAME_RATE,
 						minFrameRate: MIN_FRAME_RATE,
-						cursor: shouldHideSourceCursor ? "never" : "always",
+						cursor: (shouldHideSourceCursor ? "never" : "always") as "never" | "always",
 					},
 				};
 
@@ -978,7 +978,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
 						height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
 						frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-						cursor: shouldHideSourceCursor ? "never" : "always",
+						cursor: (shouldHideSourceCursor ? "never" : "always") as "never" | "always",
 					},
 					selfBrowserSurface: "exclude",
 					surfaceSwitching: "exclude",

--- a/apps/desktop/src/lib/backend.ts
+++ b/apps/desktop/src/lib/backend.ts
@@ -320,11 +320,11 @@ export function saveProjectFile(
 	return invoke("save_project_file", { data, suggestedName, existingPath });
 }
 
-export function loadProjectFile(): Promise<unknown | null> {
+export function loadProjectFile(): Promise<{ data?: unknown; filePath?: string | null } | null> {
 	return invoke("load_project_file");
 }
 
-export function loadCurrentProjectFile(): Promise<unknown | null> {
+export function loadCurrentProjectFile(): Promise<{ data?: unknown; filePath?: string | null } | null> {
 	return invoke("load_current_project_file");
 }
 

--- a/apps/desktop/src/lib/exporter/gifExporter.ts
+++ b/apps/desktop/src/lib/exporter/gifExporter.ts
@@ -1,5 +1,5 @@
 import GIF from 'gif.js';
-import type { ExportProgress, ExportResult, GifFrameRate, GifSizePreset, GIF_SIZE_PRESETS } from './types';
+import type { ExportProgress, ExportResult, GifFrameRate, GifSizePreset } from './types';
 import { StreamingVideoDecoder } from './streamingDecoder';
 import { FrameRenderer } from './frameRenderer';
 import { SyncedVideoProvider } from './syncedVideoProvider';

--- a/apps/desktop/src/types/pixi-unsafe-eval.d.ts
+++ b/apps/desktop/src/types/pixi-unsafe-eval.d.ts
@@ -1,0 +1,1 @@
+declare module 'pixi.js/unsafe-eval';

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -54,4 +54,6 @@ declare global {
   }
 }
 
+declare module 'pixi.js/unsafe-eval';
+
 export {};

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -5,10 +5,8 @@
 		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"module": "ESNext",
 		"skipLibCheck": true,
-		"ignoreDeprecations": "5.0",
-		"baseUrl": ".",
 		"paths": {
-			"@/*": ["src/*"]
+			"@/*": ["./src/*"]
 		},
 
 		/* Bundler mode */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: ^5.44.1
         version: 5.46.1
       typescript:
-        specifier: ^5.2.2
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^5.1.6
         version: 5.4.21(@types/node@25.5.0)(terser@5.46.1)
@@ -3666,8 +3666,8 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7433,7 +7433,7 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

- Upgrades `typescript` dev dependency from `^5.2.2` to `^6.0.3` (latest stable)
- Removes deprecated `ignoreDeprecations: "5.0"` tsconfig option
- Fixes `baseUrl` deprecation: removes the option and updates `paths` to use `./src/*`
- Fixes all resulting type errors introduced by TS 6's stricter checks

## Changes

### Config
- `apps/desktop/package.json` — typescript `^5.2.2` → `^6.0.3`
- `apps/desktop/tsconfig.json` — remove `ignoreDeprecations`, remove deprecated `baseUrl`, update `paths` to `"./src/*"`

### Type fixes (TS 6 stricter rules)
| File | Fix |
|---|---|
| `LaunchWindow.tsx`, `content-clamp.tsx` | `NodeJS.Timeout` → `ReturnType<typeof setTimeout>` |
| `lib/backend.ts` | `loadProjectFile` / `loadCurrentProjectFile` return type `unknown` → `{ data?: unknown; filePath?: string \| null } \| null` |
| `cursorTelemetryPayload.ts` | Add explicit `CursorTelemetryPoint \| null` return type to `normalizeEntry` (fixes TS2677 type predicate check) |
| `videoPlayback/cursorRenderer.ts` | Cast `getSystemCursorAssets()` result to typed shape |
| `contexts/I18nContext.tsx` | Remove unused `isSupportedLocale` function and `SUPPORTED_LOCALES` import |
| `lib/exporter/gifExporter.ts` | Remove unused `GIF_SIZE_PRESETS` type import |
| `hooks/useScreenRecorder.ts` | Add `as "never" \| "always"` cast on cursor literal |
| `src/types/pixi-unsafe-eval.d.ts` | New ambient module declaration for `pixi.js/unsafe-eval` |

## Test plan
- [x] `pnpm install` — clean install with TS 6.0.3
- [x] `pnpm --filter @open-recorder/desktop typecheck` — zero errors
- [x] `pnpm test` — 70 test files, 1054 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)