### PR TITLE
chore: patch release v0.0.22

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.21",
-  "releaseName": "Open Recorder v0.0.21",
+  "tagName": "v0.0.22",
+  "releaseName": "Open Recorder v0.0.22",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-electron
 dist-ssr
 *.local
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Bump desktop app version from `0.0.21` → `0.0.22` (patch release)
- Update `apps/desktop/package.json` and `.github/release-plan.json` with new version
- Build verified passing before version bump

## Test plan
- [x] `pnpm run build` passes with updated version
- [ ] Verify release workflow triggers correctly after merge

https://claude.ai/code/session_014s7kBAzb8iBdzv3t6YKmvw