### PR TITLE
Prepare release v0.0.22

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.21",
-  "releaseName": "Open Recorder v0.0.21",
+  "tagName": "v0.0.22",
+  "releaseName": "Open Recorder v0.0.22",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-electron
 dist-ssr
 *.local
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Bump desktop version from `0.0.21` to `0.0.22` (patch release)
- Update `.github/release-plan.json` with new tag `v0.0.22`
- Build verified passing before version bump

## Release Summary
- Release type: patch
- Base version: 0.0.21 (apps/desktop/package.json)
- Next version: 0.0.22
- Tag: v0.0.22
- Release title: Open Recorder v0.0.22
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

## Test plan
- [x] `pnpm build` passes successfully
- [ ] Verify CI checks pass on the PR
- [ ] After merge, confirm release workflow triggers correctly

https://claude.ai/code/session_016Lm1dwpRntskfWnHUF6JUq