### PR TITLE
feat: add collapsible left sidebar with Projects page

### DIFF
--- a/apps/desktop/src/atoms/navigation.ts
+++ b/apps/desktop/src/atoms/navigation.ts
@@ -1,0 +1,10 @@
+import { atomWithStorage } from "jotai/utils";
+
+export type InternalView = "editor" | "projects";
+
+const INTERNAL_VIEW_STORAGE_KEY = "open-recorder.internal-view";
+const SIDEBAR_EXPANDED_STORAGE_KEY = "open-recorder.sidebar-expanded";
+
+export const internalViewAtom = atomWithStorage<InternalView>(INTERNAL_VIEW_STORAGE_KEY, "editor");
+
+export const sidebarExpandedAtom = atomWithStorage<boolean>(SIDEBAR_EXPANDED_STORAGE_KEY, false);

--- a/apps/desktop/src/components/projects/ProjectsPage.tsx
+++ b/apps/desktop/src/components/projects/ProjectsPage.tsx
@@ -1,0 +1,94 @@
+import { useSetAtom } from "jotai";
+import { FolderOpen, Plus } from "lucide-react";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { internalViewAtom } from "@/atoms/navigation";
+import { Button } from "@/components/ui/button";
+import {
+	Empty,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@/components/ui/empty";
+import * as backend from "@/lib/backend";
+
+export function ProjectsPage() {
+	const setView = useSetAtom(internalViewAtom);
+
+	const handleOpenProject = useCallback(async () => {
+		try {
+			const result = await backend.loadProjectFile();
+			if (!result?.filePath) return;
+			setView("editor");
+		} catch (err) {
+			toast.error(`Failed to open project: ${String(err)}`);
+		}
+	}, [setView]);
+
+	const handleOpenRecordingsFolder = useCallback(async () => {
+		try {
+			await backend.openRecordingsFolder();
+		} catch (err) {
+			toast.error(`Failed to open recordings folder: ${String(err)}`);
+		}
+	}, []);
+
+	return (
+		<div className="flex-1 min-h-0 overflow-auto bg-[#09090b] text-slate-200">
+			<div className="mx-auto w-full max-w-4xl px-8 py-10">
+				<div className="flex items-end justify-between gap-4 mb-8">
+					<div>
+						<h1 className="text-2xl font-semibold tracking-tight text-white">Projects</h1>
+						<p className="mt-1 text-sm text-white/60">
+							Open a saved project or jump back into the editor.
+						</p>
+					</div>
+					<Button
+						type="button"
+						size="sm"
+						onClick={handleOpenProject}
+						className="h-8 gap-1.5 bg-[#2563EB] text-white text-xs font-medium hover:bg-[#2563EB]/90"
+					>
+						<Plus className="h-3.5 w-3.5" />
+						Open project file
+					</Button>
+				</div>
+
+				<Empty className="max-w-none border-white/10 bg-white/[0.02]">
+					<EmptyHeader>
+						<EmptyMedia className="size-16 border-[#2563EB]/20 bg-[#2563EB]/10 text-[#93c5fd]">
+							<FolderOpen className="size-7" />
+						</EmptyMedia>
+						<EmptyTitle>No recent projects yet</EmptyTitle>
+						<EmptyDescription>
+							Load a saved project file, or open your recordings folder to browse existing captures.
+						</EmptyDescription>
+					</EmptyHeader>
+					<div className="flex items-center justify-center gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={handleOpenProject}
+							className="h-8 gap-1.5 border-white/10 bg-white/5 text-xs text-white hover:bg-white/10"
+						>
+							<Plus className="h-3.5 w-3.5" />
+							Open project
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={handleOpenRecordingsFolder}
+							className="h-8 gap-1.5 border-white/10 bg-white/5 text-xs text-white hover:bg-white/10"
+						>
+							<FolderOpen className="h-3.5 w-3.5" />
+							Browse recordings
+						</Button>
+					</div>
+				</Empty>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/components/shell/AppSidebar.tsx
+++ b/apps/desktop/src/components/shell/AppSidebar.tsx
@@ -1,0 +1,63 @@
+import { useAtom } from "jotai";
+import { FolderGit2, Video } from "lucide-react";
+import { type InternalView, internalViewAtom, sidebarExpandedAtom } from "@/atoms/navigation";
+import { cn } from "@/lib/utils";
+
+type NavItem = {
+	view: InternalView;
+	label: string;
+	icon: typeof Video;
+};
+
+const NAV_ITEMS: readonly NavItem[] = [
+	{ view: "editor", label: "Editor", icon: Video },
+	{ view: "projects", label: "Projects", icon: FolderGit2 },
+];
+
+export function AppSidebar() {
+	const [expanded] = useAtom(sidebarExpandedAtom);
+	const [activeView, setActiveView] = useAtom(internalViewAtom);
+
+	return (
+		<aside
+			data-testid="app-sidebar"
+			aria-label="Primary navigation"
+			className={cn(
+				"flex-shrink-0 h-full bg-[#09090b] border-r border-white/5 flex flex-col py-3 transition-[width] duration-200 ease-out overflow-hidden",
+				expanded ? "w-52" : "w-12",
+			)}
+		>
+			<nav className="flex flex-col gap-1 px-2 mt-2">
+				{NAV_ITEMS.map(({ view, label, icon: Icon }) => {
+					const isActive = activeView === view;
+					return (
+						<button
+							key={view}
+							type="button"
+							onClick={() => setActiveView(view)}
+							title={expanded ? undefined : label}
+							aria-label={label}
+							aria-current={isActive ? "page" : undefined}
+							className={cn(
+								"group flex items-center gap-3 rounded-md h-8 px-2 text-xs font-medium transition-colors cursor-pointer",
+								isActive
+									? "bg-white/10 text-white"
+									: "text-white/60 hover:bg-white/5 hover:text-white",
+							)}
+						>
+							<Icon className="h-4 w-4 flex-shrink-0" />
+							<span
+								className={cn(
+									"truncate transition-opacity duration-150",
+									expanded ? "opacity-100" : "opacity-0 pointer-events-none",
+								)}
+							>
+								{label}
+							</span>
+						</button>
+					);
+				})}
+			</nav>
+		</aside>
+	);
+}

--- a/apps/desktop/src/components/video-editor/VideoEditor.tsx
+++ b/apps/desktop/src/components/video-editor/VideoEditor.tsx
@@ -1,4 +1,5 @@
 import type { Span } from "dnd-timeline";
+import { useAtom, useSetAtom } from "jotai";
 import {
 	ChevronDown,
 	Download,
@@ -7,9 +8,12 @@ import {
 	HelpCircle,
 	Image,
 	LoaderCircle,
+	PanelLeft,
 } from "lucide-react";
-import { useAtom, useSetAtom } from "jotai";
 import { Profiler, useCallback, useEffect, useMemo, useRef } from "react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { toast } from "sonner";
+import { internalViewAtom, sidebarExpandedAtom } from "@/atoms/navigation";
 import {
 	annotationRegionsAtom,
 	aspectRatioAtom,
@@ -17,18 +21,18 @@ import {
 	audioVolumeAtom,
 	backgroundBlurAtom,
 	borderRadiusAtom,
+	type CursorSettings,
 	connectZoomsAtom,
 	cropRegionAtom,
-	type CursorSettings,
+	currentProjectPathAtom,
 	cursorSettingsAtom,
 	cursorTelemetryAtom,
-	currentProjectPathAtom,
 	durationAtom,
 	exportErrorAtom,
+	exportedFilePathAtom,
 	exportFormatAtom,
 	exportProgressAtom,
 	exportQualityAtom,
-	exportedFilePathAtom,
 	facecamOffsetMsAtom,
 	facecamPlaybackPathAtom,
 	facecamSettingsAtom,
@@ -60,8 +64,8 @@ import {
 	zoomMotionBlurAtom,
 	zoomRegionsAtom,
 } from "@/atoms/videoEditor";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-import { toast } from "sonner";
+import { ProjectsPage } from "@/components/projects/ProjectsPage";
+import { AppSidebar } from "@/components/shell/AppSidebar";
 import { Button } from "@/components/ui/button";
 import {
 	Empty,
@@ -74,6 +78,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Toaster } from "@/components/ui/sonner";
 import { Switch } from "@/components/ui/switch";
 import { useShortcuts } from "@/contexts/ShortcutsContext";
+import { useWaveformData } from "@/hooks/useWaveformData";
 import { getAssetPath } from "@/lib/assetPath";
 import * as backend from "@/lib/backend";
 import {
@@ -97,7 +102,6 @@ import {
 } from "@/lib/recordingSession";
 import { matchesShortcut } from "@/lib/shortcuts";
 import { cn } from "@/lib/utils";
-import { useWaveformData } from "@/hooks/useWaveformData";
 import { DEFAULT_WALLPAPER_RELATIVE_PATH, WALLPAPER_PATHS } from "@/lib/wallpapers";
 import { getAspectRatioValue } from "@/utils/aspectRatioUtils";
 import { AllShortcutsDialog } from "./AllShortcutsDialog";
@@ -239,7 +243,14 @@ export default function VideoEditor() {
 	const [zoomMotionBlur, setZoomMotionBlur] = useAtom(zoomMotionBlurAtom);
 	const [connectZooms, setConnectZooms] = useAtom(connectZoomsAtom);
 	const [cursorSettings, setCursorSettings] = useAtom(cursorSettingsAtom);
-	const { showCursor, loopCursor, cursorSize, cursorSmoothing, cursorMotionBlur, cursorClickBounce } = cursorSettings;
+	const {
+		showCursor,
+		loopCursor,
+		cursorSize,
+		cursorSmoothing,
+		cursorMotionBlur,
+		cursorClickBounce,
+	} = cursorSettings;
 	const [borderRadius, setBorderRadius] = useAtom(borderRadiusAtom);
 	const [padding, setPadding] = useAtom(paddingAtom);
 	const [cropRegion, setCropRegion] = useAtom(cropRegionAtom);
@@ -269,6 +280,8 @@ export default function VideoEditor() {
 	const setExportedFilePath = useSetAtom(exportedFilePathAtom);
 	const [hasPendingExportSave, setHasPendingExportSave] = useAtom(hasPendingExportSaveAtom);
 	const [lastSavedSnapshot, setLastSavedSnapshot] = useAtom(lastSavedSnapshotAtom);
+	const [internalView] = useAtom(internalViewAtom);
+	const [sidebarExpanded, setSidebarExpanded] = useAtom(sidebarExpandedAtom);
 
 	const videoPlaybackRef = useRef<VideoPlaybackRef>(null);
 	const nextZoomIdRef = useRef(1);
@@ -1171,15 +1184,18 @@ export default function VideoEditor() {
 		[setCursorSettings],
 	);
 	const setCursorSmoothing = useCallback(
-		(v: CursorSettings["cursorSmoothing"]) => setCursorSettings((p) => ({ ...p, cursorSmoothing: v })),
+		(v: CursorSettings["cursorSmoothing"]) =>
+			setCursorSettings((p) => ({ ...p, cursorSmoothing: v })),
 		[setCursorSettings],
 	);
 	const setCursorMotionBlur = useCallback(
-		(v: CursorSettings["cursorMotionBlur"]) => setCursorSettings((p) => ({ ...p, cursorMotionBlur: v })),
+		(v: CursorSettings["cursorMotionBlur"]) =>
+			setCursorSettings((p) => ({ ...p, cursorMotionBlur: v })),
 		[setCursorSettings],
 	);
 	const setCursorClickBounce = useCallback(
-		(v: CursorSettings["cursorClickBounce"]) => setCursorSettings((p) => ({ ...p, cursorClickBounce: v })),
+		(v: CursorSettings["cursorClickBounce"]) =>
+			setCursorSettings((p) => ({ ...p, cursorClickBounce: v })),
 		[setCursorSettings],
 	);
 
@@ -1792,7 +1808,9 @@ export default function VideoEditor() {
 				const previewWidth = containerElement?.clientWidth || 1920;
 				const previewHeight = containerElement?.clientHeight || 1080;
 				const sourceVideoUrl = await backend.resolveMediaPlaybackUrl(sourcePath);
-				const facecamSourceUrl = facecamVideoPath ? await backend.resolveMediaPlaybackUrl(facecamVideoPath) : undefined;
+				const facecamSourceUrl = facecamVideoPath
+					? await backend.resolveMediaPlaybackUrl(facecamVideoPath)
+					: undefined;
 
 				if (settings.format === "gif" && settings.gifConfig) {
 					// GIF Export
@@ -2194,7 +2212,7 @@ export default function VideoEditor() {
 	}
 
 	return (
-		<div className="flex flex-col h-screen bg-[#09090b] text-slate-200 overflow-hidden selection:bg-[#2563EB]/30">
+		<div className="flex h-screen bg-[#09090b] text-slate-200 overflow-hidden selection:bg-[#2563EB]/30">
 			{showPlaybackLoadingOverlay && (
 				<div className="fixed inset-0 z-[120] flex items-center justify-center bg-[#09090b]/92 px-6 backdrop-blur-sm">
 					<Empty className="border-white/10 bg-white/[0.02]">
@@ -2210,402 +2228,426 @@ export default function VideoEditor() {
 					</Empty>
 				</div>
 			)}
-			<div
-				className="relative h-10 flex-shrink-0 bg-[#09090b]/80 backdrop-blur-md border-b border-white/5 flex items-center justify-center px-6 z-50"
-				style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-			>
-				<span className="text-sm font-semibold tracking-tight text-white/90">
-					{editorNavbarTitle}
-				</span>
+			<AppSidebar />
+			<div className="flex flex-col flex-1 min-w-0">
 				<div
-					className="absolute right-4 flex items-center gap-2"
-					style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+					className="relative h-10 flex-shrink-0 bg-[#09090b]/80 backdrop-blur-md border-b border-white/5 flex items-center justify-center px-6 z-50"
+					style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
 				>
-					<button
-						type="button"
-						onClick={() => setShowShortcutsDialog(true)}
-						className="inline-flex h-7 w-7 items-center justify-center rounded-md text-white/60 transition hover:bg-white/8 hover:text-white cursor-pointer"
-						title="Keyboard shortcuts"
-						aria-label="Keyboard shortcuts"
+					<div
+						className="absolute left-2 flex items-center"
+						style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
 					>
-						<HelpCircle className="h-4 w-4" />
-					</button>
-					<button
-						type="button"
-						onClick={() => void openRecordingsFolder()}
-						className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-white/90 transition hover:bg-white/8 hover:text-white cursor-pointer"
-						title="Open recordings folder"
-						aria-label="Open recordings folder"
-					>
-						<FolderOpen className="h-4 w-4" />
-						<span className="text-xs font-normal">Manage recordings</span>
-					</button>
-
-					<Popover>
-						<div className="flex">
-							<Button
-								type="button"
-								size="sm"
-								onClick={handleOpenExportDialog}
-								className="h-7 rounded-r-none gap-1.5 bg-[#2563EB] text-white text-xs font-medium hover:bg-[#2563EB]/90 active:scale-[0.98] transition-all"
-							>
-								<Download className="w-3.5 h-3.5" />
-								Export {exportFormat === "gif" ? "GIF" : "Video"}
-							</Button>
-							<PopoverTrigger asChild>
-								<Button
-									type="button"
-									size="sm"
-									className="h-7 w-7 p-0 rounded-l-none border-l border-[#2563EB]/50 bg-[#2563EB] text-white hover:bg-[#2563EB]/90 active:scale-[0.98] transition-all"
-								>
-									<ChevronDown className="w-3.5 h-3.5" />
-								</Button>
-							</PopoverTrigger>
-						</div>
-						<PopoverContent
-							side="bottom"
-							align="end"
-							sideOffset={8}
-							className="w-[280px] bg-[#09090b] border-white/10 p-3 rounded-xl"
+						<button
+							type="button"
+							onClick={() => setSidebarExpanded(!sidebarExpanded)}
+							aria-label={sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"}
+							aria-expanded={sidebarExpanded}
+							title={sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"}
+							className="inline-flex h-7 w-7 items-center justify-center rounded-md text-white/60 transition hover:bg-white/8 hover:text-white cursor-pointer"
 						>
-							<div className="space-y-3">
-								<div className="flex items-center gap-2">
-									<button
-										onClick={() => setExportFormat("mp4")}
-										className={cn(
-											"flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border transition-all text-xs font-medium",
-											exportFormat === "mp4"
-												? "bg-[#2563EB]/10 border-[#2563EB]/50 text-white"
-												: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-slate-200",
-										)}
+							<PanelLeft className="h-4 w-4" />
+						</button>
+					</div>
+					<span className="text-sm font-semibold tracking-tight text-white/90">
+						{internalView === "projects" ? "Projects" : editorNavbarTitle}
+					</span>
+					{internalView === "editor" && (
+						<div
+							className="absolute right-4 flex items-center gap-2"
+							style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+						>
+							<button
+								type="button"
+								onClick={() => setShowShortcutsDialog(true)}
+								className="inline-flex h-7 w-7 items-center justify-center rounded-md text-white/60 transition hover:bg-white/8 hover:text-white cursor-pointer"
+								title="Keyboard shortcuts"
+								aria-label="Keyboard shortcuts"
+							>
+								<HelpCircle className="h-4 w-4" />
+							</button>
+							<button
+								type="button"
+								onClick={() => void openRecordingsFolder()}
+								className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-white/90 transition hover:bg-white/8 hover:text-white cursor-pointer"
+								title="Open recordings folder"
+								aria-label="Open recordings folder"
+							>
+								<FolderOpen className="h-4 w-4" />
+								<span className="text-xs font-normal">Manage recordings</span>
+							</button>
+
+							<Popover>
+								<div className="flex">
+									<Button
+										type="button"
+										size="sm"
+										onClick={handleOpenExportDialog}
+										className="h-7 rounded-r-none gap-1.5 bg-[#2563EB] text-white text-xs font-medium hover:bg-[#2563EB]/90 active:scale-[0.98] transition-all"
 									>
-										<Film className="w-3.5 h-3.5" />
-										MP4
-									</button>
-									<button
-										onClick={() => setExportFormat("gif")}
-										className={cn(
-											"flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border transition-all text-xs font-medium",
-											exportFormat === "gif"
-												? "bg-[#2563EB]/10 border-[#2563EB]/50 text-white"
-												: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-slate-200",
-										)}
-									>
-										<Image className="w-3.5 h-3.5" />
-										GIF
-									</button>
+										<Download className="w-3.5 h-3.5" />
+										Export {exportFormat === "gif" ? "GIF" : "Video"}
+									</Button>
+									<PopoverTrigger asChild>
+										<Button
+											type="button"
+											size="sm"
+											className="h-7 w-7 p-0 rounded-l-none border-l border-[#2563EB]/50 bg-[#2563EB] text-white hover:bg-[#2563EB]/90 active:scale-[0.98] transition-all"
+										>
+											<ChevronDown className="w-3.5 h-3.5" />
+										</Button>
+									</PopoverTrigger>
 								</div>
-
-								{exportFormat === "mp4" && (
-									<div className="bg-white/5 border border-white/5 p-0.5 w-full grid grid-cols-3 h-7 rounded-lg">
-										<button
-											onClick={() => setExportQuality("medium")}
-											className={cn(
-												"rounded-md transition-all text-[10px] font-medium",
-												exportQuality === "medium"
-													? "bg-white text-black"
-													: "text-slate-400 hover:text-slate-200",
-											)}
-										>
-											Low
-										</button>
-										<button
-											onClick={() => setExportQuality("good")}
-											className={cn(
-												"rounded-md transition-all text-[10px] font-medium",
-												exportQuality === "good"
-													? "bg-white text-black"
-													: "text-slate-400 hover:text-slate-200",
-											)}
-										>
-											Medium
-										</button>
-										<button
-											onClick={() => setExportQuality("source")}
-											className={cn(
-												"rounded-md transition-all text-[10px] font-medium",
-												exportQuality === "source"
-													? "bg-white text-black"
-													: "text-slate-400 hover:text-slate-200",
-											)}
-										>
-											High
-										</button>
-									</div>
-								)}
-
-								{exportFormat === "gif" && (
-									<div className="space-y-2">
-										<div className="flex items-center gap-2">
-											<div className="flex-1 bg-white/5 border border-white/5 p-0.5 grid grid-cols-4 h-7 rounded-lg">
-												{GIF_FRAME_RATES.map((rate) => (
-													<button
-														key={rate.value}
-														onClick={() => setGifFrameRate(rate.value)}
-														className={cn(
-															"rounded-md transition-all text-[10px] font-medium",
-															gifFrameRate === rate.value
-																? "bg-white text-black"
-																: "text-slate-400 hover:text-slate-200",
-														)}
-													>
-														{rate.value}
-													</button>
-												))}
-											</div>
-											<div className="flex-1 bg-white/5 border border-white/5 p-0.5 grid grid-cols-3 h-7 rounded-lg">
-												{Object.entries(GIF_SIZE_PRESETS).map(([key, _preset]) => (
-													<button
-														key={key}
-														onClick={() => setGifSizePreset(key as GifSizePreset)}
-														className={cn(
-															"rounded-md transition-all text-[10px] font-medium",
-															gifSizePreset === key
-																? "bg-white text-black"
-																: "text-slate-400 hover:text-slate-200",
-														)}
-													>
-														{key === "original"
-															? "Orig"
-															: key.charAt(0).toUpperCase() + key.slice(1, 3)}
-													</button>
-												))}
-											</div>
-										</div>
-										<div className="flex items-center justify-between">
-											<span className="text-[10px] text-slate-500">
-												{gifOutputDimensions.width} × {gifOutputDimensions.height}px
-											</span>
-											<div className="flex items-center gap-2">
-												<span className="text-[10px] text-slate-400">Loop</span>
-												<Switch
-													checked={gifLoop}
-													onCheckedChange={setGifLoop}
-													className="data-[state=checked]:bg-[#2563EB] scale-75"
-												/>
-											</div>
-										</div>
-									</div>
-								)}
-							</div>
-						</PopoverContent>
-					</Popover>
-				</div>
-			</div>
-
-			<div className="flex-1 p-5 gap-4 flex min-h-0 relative">
-				{/* Left Column - Video & Timeline */}
-				<div className="flex-[7] flex flex-col gap-3 min-w-0 h-full">
-					<PanelGroup direction="vertical" className="gap-3">
-						{/* Top section: video preview and controls */}
-						<Panel defaultSize={70} minSize={40}>
-							<div className="w-full h-full flex flex-col items-center justify-center bg-black/40 rounded-2xl border border-white/5 shadow-2xl overflow-hidden">
-								{/* Video preview */}
-								<div
-									className="w-full flex justify-center items-center"
-									style={{ flex: "1 1 auto", margin: "6px 0 0" }}
+								<PopoverContent
+									side="bottom"
+									align="end"
+									sideOffset={8}
+									className="w-[280px] bg-[#09090b] border-white/10 p-3 rounded-xl"
 								>
-									<div
-										className="relative"
-										style={{
-											width: "auto",
-											height: "100%",
-											aspectRatio: getAspectRatioValue(
-												aspectRatio,
-												(() => {
-													const previewVideo = videoPlaybackRef.current?.video;
-													if (previewVideo && previewVideo.videoHeight > 0) {
-														return previewVideo.videoWidth / previewVideo.videoHeight;
-													}
-													return 16 / 9;
-												})(),
-											),
-											maxWidth: "100%",
-											margin: "0 auto",
-											boxSizing: "border-box",
-										}}
-									>
-										<Profiler id="VideoPlayback" onRender={onRenderProfiler}>
-											<VideoPlayback
-												aspectRatio={aspectRatio}
-												ref={videoPlaybackRef}
-												videoPath={videoPath || ""}
-												facecamVideoPath={facecamPlaybackPath || undefined}
-												facecamOffsetMs={facecamOffsetMs}
-												facecamSettings={facecamSettings}
-												onDurationChange={setDuration}
-												onTimeUpdate={timeStore.setTime}
-												onPlayStateChange={setIsPlaying}
-												onError={setError}
-												wallpaper={wallpaper}
-												audioMuted={audioMuted}
-												audioVolume={audioVolume}
+									<div className="space-y-3">
+										<div className="flex items-center gap-2">
+											<button
+												onClick={() => setExportFormat("mp4")}
+												className={cn(
+													"flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border transition-all text-xs font-medium",
+													exportFormat === "mp4"
+														? "bg-[#2563EB]/10 border-[#2563EB]/50 text-white"
+														: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-slate-200",
+												)}
+											>
+												<Film className="w-3.5 h-3.5" />
+												MP4
+											</button>
+											<button
+												onClick={() => setExportFormat("gif")}
+												className={cn(
+													"flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border transition-all text-xs font-medium",
+													exportFormat === "gif"
+														? "bg-[#2563EB]/10 border-[#2563EB]/50 text-white"
+														: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-slate-200",
+												)}
+											>
+												<Image className="w-3.5 h-3.5" />
+												GIF
+											</button>
+										</div>
+
+										{exportFormat === "mp4" && (
+											<div className="bg-white/5 border border-white/5 p-0.5 w-full grid grid-cols-3 h-7 rounded-lg">
+												<button
+													onClick={() => setExportQuality("medium")}
+													className={cn(
+														"rounded-md transition-all text-[10px] font-medium",
+														exportQuality === "medium"
+															? "bg-white text-black"
+															: "text-slate-400 hover:text-slate-200",
+													)}
+												>
+													Low
+												</button>
+												<button
+													onClick={() => setExportQuality("good")}
+													className={cn(
+														"rounded-md transition-all text-[10px] font-medium",
+														exportQuality === "good"
+															? "bg-white text-black"
+															: "text-slate-400 hover:text-slate-200",
+													)}
+												>
+													Medium
+												</button>
+												<button
+													onClick={() => setExportQuality("source")}
+													className={cn(
+														"rounded-md transition-all text-[10px] font-medium",
+														exportQuality === "source"
+															? "bg-white text-black"
+															: "text-slate-400 hover:text-slate-200",
+													)}
+												>
+													High
+												</button>
+											</div>
+										)}
+
+										{exportFormat === "gif" && (
+											<div className="space-y-2">
+												<div className="flex items-center gap-2">
+													<div className="flex-1 bg-white/5 border border-white/5 p-0.5 grid grid-cols-4 h-7 rounded-lg">
+														{GIF_FRAME_RATES.map((rate) => (
+															<button
+																key={rate.value}
+																onClick={() => setGifFrameRate(rate.value)}
+																className={cn(
+																	"rounded-md transition-all text-[10px] font-medium",
+																	gifFrameRate === rate.value
+																		? "bg-white text-black"
+																		: "text-slate-400 hover:text-slate-200",
+																)}
+															>
+																{rate.value}
+															</button>
+														))}
+													</div>
+													<div className="flex-1 bg-white/5 border border-white/5 p-0.5 grid grid-cols-3 h-7 rounded-lg">
+														{Object.entries(GIF_SIZE_PRESETS).map(([key, _preset]) => (
+															<button
+																key={key}
+																onClick={() => setGifSizePreset(key as GifSizePreset)}
+																className={cn(
+																	"rounded-md transition-all text-[10px] font-medium",
+																	gifSizePreset === key
+																		? "bg-white text-black"
+																		: "text-slate-400 hover:text-slate-200",
+																)}
+															>
+																{key === "original"
+																	? "Orig"
+																	: key.charAt(0).toUpperCase() + key.slice(1, 3)}
+															</button>
+														))}
+													</div>
+												</div>
+												<div className="flex items-center justify-between">
+													<span className="text-[10px] text-slate-500">
+														{gifOutputDimensions.width} × {gifOutputDimensions.height}px
+													</span>
+													<div className="flex items-center gap-2">
+														<span className="text-[10px] text-slate-400">Loop</span>
+														<Switch
+															checked={gifLoop}
+															onCheckedChange={setGifLoop}
+															className="data-[state=checked]:bg-[#2563EB] scale-75"
+														/>
+													</div>
+												</div>
+											</div>
+										)}
+									</div>
+								</PopoverContent>
+							</Popover>
+						</div>
+					)}
+				</div>
+
+				{internalView === "projects" ? (
+					<ProjectsPage />
+				) : (
+					<div className="flex-1 p-5 gap-4 flex min-h-0 relative">
+						{/* Left Column - Video & Timeline */}
+						<div className="flex-[7] flex flex-col gap-3 min-w-0 h-full">
+							<PanelGroup direction="vertical" className="gap-3">
+								{/* Top section: video preview and controls */}
+								<Panel defaultSize={70} minSize={40}>
+									<div className="w-full h-full flex flex-col items-center justify-center bg-black/40 rounded-2xl border border-white/5 shadow-2xl overflow-hidden">
+										{/* Video preview */}
+										<div
+											className="w-full flex justify-center items-center"
+											style={{ flex: "1 1 auto", margin: "6px 0 0" }}
+										>
+											<div
+												className="relative"
+												style={{
+													width: "auto",
+													height: "100%",
+													aspectRatio: getAspectRatioValue(
+														aspectRatio,
+														(() => {
+															const previewVideo = videoPlaybackRef.current?.video;
+															if (previewVideo && previewVideo.videoHeight > 0) {
+																return previewVideo.videoWidth / previewVideo.videoHeight;
+															}
+															return 16 / 9;
+														})(),
+													),
+													maxWidth: "100%",
+													margin: "0 auto",
+													boxSizing: "border-box",
+												}}
+											>
+												<Profiler id="VideoPlayback" onRender={onRenderProfiler}>
+													<VideoPlayback
+														aspectRatio={aspectRatio}
+														ref={videoPlaybackRef}
+														videoPath={videoPath || ""}
+														facecamVideoPath={facecamPlaybackPath || undefined}
+														facecamOffsetMs={facecamOffsetMs}
+														facecamSettings={facecamSettings}
+														onDurationChange={setDuration}
+														onTimeUpdate={timeStore.setTime}
+														onPlayStateChange={setIsPlaying}
+														onError={setError}
+														wallpaper={wallpaper}
+														audioMuted={audioMuted}
+														audioVolume={audioVolume}
+														zoomRegions={effectiveZoomRegions}
+														selectedZoomId={selectedZoomId}
+														onSelectZoom={handleSelectZoom}
+														onZoomFocusChange={handleZoomFocusChange}
+														isPlaying={isPlaying}
+														showShadow={shadowIntensity > 0}
+														shadowIntensity={shadowIntensity}
+														backgroundBlur={backgroundBlur}
+														zoomMotionBlur={zoomMotionBlur}
+														connectZooms={connectZooms}
+														borderRadius={borderRadius}
+														padding={padding}
+														cropRegion={cropRegion}
+														trimRegions={trimRegions}
+														speedRegions={speedRegions}
+														annotationRegions={annotationRegions}
+														selectedAnnotationId={selectedAnnotationId}
+														onSelectAnnotation={handleSelectAnnotation}
+														onAnnotationPositionChange={handleAnnotationPositionChange}
+														onAnnotationSizeChange={handleAnnotationSizeChange}
+														cursorTelemetry={effectiveCursorTelemetry}
+														showCursor={showCursor}
+														cursorSize={cursorSize}
+														cursorSmoothing={cursorSmoothing}
+														cursorMotionBlur={cursorMotionBlur}
+														cursorClickBounce={cursorClickBounce}
+														onReadyChange={setPlaybackReady}
+														onFacecamPositionChange={handleFacecamPositionChange}
+													/>
+												</Profiler>
+											</div>
+										</div>
+										{/* Playback controls */}
+										<div
+											className="w-full flex justify-center items-center"
+											style={{
+												height: "48px",
+												flexShrink: 0,
+												padding: "6px 12px",
+												margin: "6px 0 6px 0",
+											}}
+										>
+											<div style={{ width: "100%", maxWidth: "700px" }}>
+												<Profiler id="PlaybackControls" onRender={onRenderProfiler}>
+													<PlaybackControls
+														isPlaying={isPlaying}
+														timeStore={timeStore}
+														duration={duration}
+														onTogglePlayPause={togglePlayPause}
+														onSeek={handleSeek}
+													/>
+												</Profiler>
+											</div>
+										</div>
+									</div>
+								</Panel>
+
+								<PanelResizeHandle className="h-3 bg-[#09090b]/80 hover:bg-[#09090b] transition-colors rounded-full mx-4 flex items-center justify-center">
+									<div className="w-8 h-1 bg-white/20 rounded-full"></div>
+								</PanelResizeHandle>
+
+								{/* Timeline section */}
+								<Panel defaultSize={30} minSize={20}>
+									<div className="h-full min-h-0 bg-[#09090b] rounded-2xl border border-white/5 shadow-lg overflow-auto flex flex-col">
+										<Profiler id="TimelineEditor" onRender={onRenderProfiler}>
+											<TimelineEditor
+												videoDuration={duration}
+												timeStore={timeStore}
+												onSeek={handleSeek}
+												cursorTelemetry={effectiveCursorTelemetry}
 												zoomRegions={effectiveZoomRegions}
+												onZoomAdded={handleZoomAdded}
+												onZoomSuggested={handleZoomSuggested}
+												onZoomSpanChange={handleZoomSpanChange}
+												onZoomDelete={handleZoomDelete}
 												selectedZoomId={selectedZoomId}
 												onSelectZoom={handleSelectZoom}
-												onZoomFocusChange={handleZoomFocusChange}
-												isPlaying={isPlaying}
-												showShadow={shadowIntensity > 0}
-												shadowIntensity={shadowIntensity}
-												backgroundBlur={backgroundBlur}
-												zoomMotionBlur={zoomMotionBlur}
-												connectZooms={connectZooms}
-												borderRadius={borderRadius}
-												padding={padding}
-												cropRegion={cropRegion}
 												trimRegions={trimRegions}
+												onTrimAdded={handleTrimAdded}
+												onTrimSpanChange={handleTrimSpanChange}
+												onTrimDelete={handleTrimDelete}
+												selectedTrimId={selectedTrimId}
+												onSelectTrim={handleSelectTrim}
 												speedRegions={speedRegions}
+												onSpeedAdded={handleSpeedAdded}
+												onSpeedSpanChange={handleSpeedSpanChange}
+												onSpeedDelete={handleSpeedDelete}
+												selectedSpeedId={selectedSpeedId}
+												onSelectSpeed={handleSelectSpeed}
 												annotationRegions={annotationRegions}
+												onAnnotationAdded={handleAnnotationAdded}
+												onAnnotationSpanChange={handleAnnotationSpanChange}
+												onAnnotationDelete={handleAnnotationDelete}
 												selectedAnnotationId={selectedAnnotationId}
 												onSelectAnnotation={handleSelectAnnotation}
-												onAnnotationPositionChange={handleAnnotationPositionChange}
-												onAnnotationSizeChange={handleAnnotationSizeChange}
-												cursorTelemetry={effectiveCursorTelemetry}
-												showCursor={showCursor}
-												cursorSize={cursorSize}
-												cursorSmoothing={cursorSmoothing}
-												cursorMotionBlur={cursorMotionBlur}
-												cursorClickBounce={cursorClickBounce}
-												onReadyChange={setPlaybackReady}
-												onFacecamPositionChange={handleFacecamPositionChange}
+												aspectRatio={aspectRatio}
+												onAspectRatioChange={setAspectRatio}
+												waveformData={waveformData}
+												waveformLoading={waveformLoading}
+												audioMuted={audioMuted}
 											/>
 										</Profiler>
 									</div>
-								</div>
-								{/* Playback controls */}
-								<div
-									className="w-full flex justify-center items-center"
-									style={{
-										height: "48px",
-										flexShrink: 0,
-										padding: "6px 12px",
-										margin: "6px 0 6px 0",
-									}}
-								>
-									<div style={{ width: "100%", maxWidth: "700px" }}>
-										<Profiler id="PlaybackControls" onRender={onRenderProfiler}>
-											<PlaybackControls
-												isPlaying={isPlaying}
-												timeStore={timeStore}
-												duration={duration}
-												onTogglePlayPause={togglePlayPause}
-												onSeek={handleSeek}
-											/>
-										</Profiler>
-									</div>
-								</div>
-							</div>
-						</Panel>
+								</Panel>
+							</PanelGroup>
+						</div>
 
-						<PanelResizeHandle className="h-3 bg-[#09090b]/80 hover:bg-[#09090b] transition-colors rounded-full mx-4 flex items-center justify-center">
-							<div className="w-8 h-1 bg-white/20 rounded-full"></div>
-						</PanelResizeHandle>
-
-						{/* Timeline section */}
-						<Panel defaultSize={30} minSize={20}>
-							<div className="h-full min-h-0 bg-[#09090b] rounded-2xl border border-white/5 shadow-lg overflow-auto flex flex-col">
-								<Profiler id="TimelineEditor" onRender={onRenderProfiler}>
-									<TimelineEditor
-										videoDuration={duration}
-										timeStore={timeStore}
-										onSeek={handleSeek}
-										cursorTelemetry={effectiveCursorTelemetry}
-										zoomRegions={effectiveZoomRegions}
-										onZoomAdded={handleZoomAdded}
-										onZoomSuggested={handleZoomSuggested}
-										onZoomSpanChange={handleZoomSpanChange}
-										onZoomDelete={handleZoomDelete}
-										selectedZoomId={selectedZoomId}
-										onSelectZoom={handleSelectZoom}
-										trimRegions={trimRegions}
-										onTrimAdded={handleTrimAdded}
-										onTrimSpanChange={handleTrimSpanChange}
-										onTrimDelete={handleTrimDelete}
-										selectedTrimId={selectedTrimId}
-										onSelectTrim={handleSelectTrim}
-										speedRegions={speedRegions}
-										onSpeedAdded={handleSpeedAdded}
-										onSpeedSpanChange={handleSpeedSpanChange}
-										onSpeedDelete={handleSpeedDelete}
-										selectedSpeedId={selectedSpeedId}
-										onSelectSpeed={handleSelectSpeed}
-										annotationRegions={annotationRegions}
-										onAnnotationAdded={handleAnnotationAdded}
-										onAnnotationSpanChange={handleAnnotationSpanChange}
-										onAnnotationDelete={handleAnnotationDelete}
-										selectedAnnotationId={selectedAnnotationId}
-										onSelectAnnotation={handleSelectAnnotation}
-										aspectRatio={aspectRatio}
-										onAspectRatioChange={setAspectRatio}
-										waveformData={waveformData}
-										waveformLoading={waveformLoading}
-										audioMuted={audioMuted}
-									/>
-								</Profiler>
-							</div>
-						</Panel>
-					</PanelGroup>
-				</div>
-
-				{/* Right section: settings panel */}
-				<Profiler id="SettingsPanel" onRender={onRenderProfiler}>
-					<SettingsPanel
-						selected={wallpaper}
-						onWallpaperChange={setWallpaper}
-						audioMuted={audioMuted}
-						onAudioMutedChange={setAudioMuted}
-						audioVolume={audioVolume}
-						onAudioVolumeChange={setAudioVolume}
-						selectedZoomDepth={selectedZoomDepth}
-						onZoomDepthChange={handleZoomDepthChange}
-						selectedZoomId={selectedZoomId}
-						onZoomDelete={handleZoomDelete}
-						selectedTrimId={selectedTrimId}
-						onTrimDelete={handleTrimDelete}
-						shadowIntensity={shadowIntensity}
-						onShadowChange={setShadowIntensity}
-						backgroundBlur={backgroundBlur}
-						onBackgroundBlurChange={setBackgroundBlur}
-						zoomMotionBlur={zoomMotionBlur}
-						onZoomMotionBlurChange={setZoomMotionBlur}
-						connectZooms={connectZooms}
-						onConnectZoomsChange={setConnectZooms}
-						showCursor={showCursor}
-						onShowCursorChange={setShowCursor}
-						loopCursor={loopCursor}
-						onLoopCursorChange={setLoopCursor}
-						cursorSize={cursorSize}
-						onCursorSizeChange={setCursorSize}
-						cursorSmoothing={cursorSmoothing}
-						onCursorSmoothingChange={setCursorSmoothing}
-						cursorMotionBlur={cursorMotionBlur}
-						onCursorMotionBlurChange={setCursorMotionBlur}
-						cursorClickBounce={cursorClickBounce}
-						onCursorClickBounceChange={setCursorClickBounce}
-						borderRadius={borderRadius}
-						onBorderRadiusChange={setBorderRadius}
-						padding={padding}
-						onPaddingChange={setPadding}
-						cropRegion={cropRegion}
-						onCropChange={setCropRegion}
-						facecamVideoPath={facecamVideoPath}
-						facecamSettings={facecamSettings}
-						onFacecamSettingsChange={setFacecamSettings}
-						aspectRatio={aspectRatio}
-						videoElement={videoPlaybackRef.current?.video || null}
-						selectedAnnotationId={selectedAnnotationId}
-						annotationRegions={annotationRegions}
-						onAnnotationContentChange={handleAnnotationContentChange}
-						onAnnotationTypeChange={handleAnnotationTypeChange}
-						onAnnotationStyleChange={handleAnnotationStyleChange}
-						onAnnotationFigureDataChange={handleAnnotationFigureDataChange}
-						onAnnotationDelete={handleAnnotationDelete}
-						selectedSpeedId={selectedSpeedId}
-						selectedSpeedValue={selectedSpeedValue}
-						onSpeedChange={handleSpeedChange}
-						onSpeedDelete={handleSpeedDelete}
-					/>
-				</Profiler>
+						{/* Right section: settings panel */}
+						<Profiler id="SettingsPanel" onRender={onRenderProfiler}>
+							<SettingsPanel
+								selected={wallpaper}
+								onWallpaperChange={setWallpaper}
+								audioMuted={audioMuted}
+								onAudioMutedChange={setAudioMuted}
+								audioVolume={audioVolume}
+								onAudioVolumeChange={setAudioVolume}
+								selectedZoomDepth={selectedZoomDepth}
+								onZoomDepthChange={handleZoomDepthChange}
+								selectedZoomId={selectedZoomId}
+								onZoomDelete={handleZoomDelete}
+								selectedTrimId={selectedTrimId}
+								onTrimDelete={handleTrimDelete}
+								shadowIntensity={shadowIntensity}
+								onShadowChange={setShadowIntensity}
+								backgroundBlur={backgroundBlur}
+								onBackgroundBlurChange={setBackgroundBlur}
+								zoomMotionBlur={zoomMotionBlur}
+								onZoomMotionBlurChange={setZoomMotionBlur}
+								connectZooms={connectZooms}
+								onConnectZoomsChange={setConnectZooms}
+								showCursor={showCursor}
+								onShowCursorChange={setShowCursor}
+								loopCursor={loopCursor}
+								onLoopCursorChange={setLoopCursor}
+								cursorSize={cursorSize}
+								onCursorSizeChange={setCursorSize}
+								cursorSmoothing={cursorSmoothing}
+								onCursorSmoothingChange={setCursorSmoothing}
+								cursorMotionBlur={cursorMotionBlur}
+								onCursorMotionBlurChange={setCursorMotionBlur}
+								cursorClickBounce={cursorClickBounce}
+								onCursorClickBounceChange={setCursorClickBounce}
+								borderRadius={borderRadius}
+								onBorderRadiusChange={setBorderRadius}
+								padding={padding}
+								onPaddingChange={setPadding}
+								cropRegion={cropRegion}
+								onCropChange={setCropRegion}
+								facecamVideoPath={facecamVideoPath}
+								facecamSettings={facecamSettings}
+								onFacecamSettingsChange={setFacecamSettings}
+								aspectRatio={aspectRatio}
+								videoElement={videoPlaybackRef.current?.video || null}
+								selectedAnnotationId={selectedAnnotationId}
+								annotationRegions={annotationRegions}
+								onAnnotationContentChange={handleAnnotationContentChange}
+								onAnnotationTypeChange={handleAnnotationTypeChange}
+								onAnnotationStyleChange={handleAnnotationStyleChange}
+								onAnnotationFigureDataChange={handleAnnotationFigureDataChange}
+								onAnnotationDelete={handleAnnotationDelete}
+								selectedSpeedId={selectedSpeedId}
+								selectedSpeedValue={selectedSpeedValue}
+								onSpeedChange={handleSpeedChange}
+								onSpeedDelete={handleSpeedDelete}
+							/>
+						</Profiler>
+					</div>
+				)}
 			</div>
 
 			<Toaster theme="dark" className="pointer-events-auto" />


### PR DESCRIPTION
## Summary
- Adds a collapsible left sidebar to the editor window, collapsed to icon-only by default, with a `PanelLeft` trigger in the navbar that toggles the expanded label view.
- Introduces a new **Projects** page accessible from the sidebar — scaffolded with an empty state and actions to open a saved project file or browse the recordings folder.
- Persists navigation state (`internalViewAtom`, `sidebarExpandedAtom`) to `localStorage` via `jotai/utils` so the view survives reloads.
- Editor-only navbar controls (Export, Manage recordings, Shortcuts help) are hidden while on the Projects view; the navbar title swaps to "Projects".

## Files
- `apps/desktop/src/atoms/navigation.ts` — new atoms for internal view + sidebar state
- `apps/desktop/src/components/shell/AppSidebar.tsx` — sidebar with Editor / Projects links
- `apps/desktop/src/components/projects/ProjectsPage.tsx` — projects landing page
- `apps/desktop/src/components/video-editor/VideoEditor.tsx` — wraps layout with sidebar, adds trigger in navbar, conditionally renders Projects vs editor content

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all 1054 tests pass
- [ ] Launch editor: verify sidebar renders collapsed on first load
- [ ] Click the navbar trigger: sidebar expands and shows "Editor" / "Projects" labels; click again collapses
- [ ] Click "Projects" in sidebar: navbar title swaps to "Projects", editor controls hidden, Projects page renders
- [ ] Click "Editor" in sidebar: returns to editor view, state (zooms/trims/etc.) preserved
- [ ] Reload window: active view and sidebar expansion state persist

https://claude.ai/code/session_01XFpXcRZF4SLQofAsTBPUuU
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
