### PR TITLE
fix: restore macOS microphone permission prompts

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -24,7 +24,9 @@ mac:
         - x64
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
-    NSAudioCaptureUsageDescription: Open Recorder uses the microphone for audio recording.
+    NSMicrophoneUsageDescription: Open Recorder uses the microphone for audio commentary during recordings.
+    NSCameraUsageDescription: Open Recorder uses the camera for facecam recordings.
+    NSAudioCaptureUsageDescription: Open Recorder captures system audio when you choose to record it.
 
 win:
   target:

--- a/apps/desktop/scripts/patch-electron-plist.mjs
+++ b/apps/desktop/scripts/patch-electron-plist.mjs
@@ -31,6 +31,11 @@ const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..", "..");
 
 const DEV_NAME = "OpenRecorderDev";
 const DEV_BUNDLE_ID = "dev.openrecorder.app.dev";
+const MICROPHONE_USAGE_DESCRIPTION =
+	"Open Recorder uses the microphone for audio commentary during recordings.";
+const CAMERA_USAGE_DESCRIPTION = "Open Recorder uses the camera for facecam recordings.";
+const AUDIO_CAPTURE_USAGE_DESCRIPTION =
+	"Open Recorder captures system audio when you choose to record it.";
 
 // ─── Locate the electron package directory ───────────────────────────────────
 
@@ -103,6 +108,9 @@ const mainPlist = path.join(originalApp, "Contents", "Info.plist");
 plistSet(mainPlist, "CFBundleName", DEV_NAME);
 plistSet(mainPlist, "CFBundleDisplayName", DEV_NAME);
 plistSet(mainPlist, "CFBundleIdentifier", DEV_BUNDLE_ID);
+plistSet(mainPlist, "NSMicrophoneUsageDescription", MICROPHONE_USAGE_DESCRIPTION);
+plistSet(mainPlist, "NSCameraUsageDescription", CAMERA_USAGE_DESCRIPTION);
+plistSet(mainPlist, "NSAudioCaptureUsageDescription", AUDIO_CAPTURE_USAGE_DESCRIPTION);
 // Keep CFBundleExecutable as "Electron" — do NOT change it.
 
 // ─── 3. Rename only the .app directory ───────────────────────────────────────

--- a/apps/desktop/src/lib/backend.permissions.test.ts
+++ b/apps/desktop/src/lib/backend.permissions.test.ts
@@ -48,6 +48,12 @@ describe("permission backend wrappers", () => {
 			}
 		});
 
+		it("normalizes Electron's 'not-determined' status", async () => {
+			invoke.mockResolvedValue("not-determined");
+			const result = await backend.getMicrophonePermissionStatus();
+			expect(result).toBe("not_determined");
+		});
+
 		it("logs error and returns 'unknown' when IPC call rejects", async () => {
 			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 			const ipcError = new Error("IPC channel closed");
@@ -120,6 +126,12 @@ describe("permission backend wrappers", () => {
 				ipcError,
 			);
 		});
+
+		it("normalizes Electron's 'not-determined' status", async () => {
+			invoke.mockResolvedValue("not-determined");
+			const result = await backend.getCameraPermissionStatus();
+			expect(result).toBe("not_determined");
+		});
 	});
 
 	describe("openCameraPreferences", () => {
@@ -177,6 +189,12 @@ describe("permission backend wrappers", () => {
 				"[backend] getScreenRecordingPermissionStatus failed:",
 				ipcError,
 			);
+		});
+
+		it("normalizes Electron's 'not-determined' status", async () => {
+			invoke.mockResolvedValue("not-determined");
+			const result = await backend.getScreenRecordingPermissionStatus();
+			expect(result).toBe("not_determined");
 		});
 	});
 

--- a/apps/desktop/src/lib/backend.ts
+++ b/apps/desktop/src/lib/backend.ts
@@ -15,6 +15,10 @@ import type { DesktopSource } from "../components/launch/sourceSelectorState";
 
 export type UnlistenFn = () => void;
 
+function normalizePermissionStatus(status: string): string {
+	return status === "not-determined" ? "not_determined" : status;
+}
+
 // ─── Source List Options ─────────────────────────────────────────────────────
 
 export interface SourceListOptions {
@@ -221,10 +225,12 @@ export function getSystemCursorAssets(): Promise<unknown> {
 // ─── Permissions ────────────────────────────────────────────────────────────
 
 export function getScreenRecordingPermissionStatus(): Promise<string> {
-	return invoke<string>("get_screen_recording_permission_status").catch((err) => {
-		console.error("[backend] getScreenRecordingPermissionStatus failed:", err);
-		return "unknown";
-	});
+	return invoke<string>("get_screen_recording_permission_status")
+		.then(normalizePermissionStatus)
+		.catch((err) => {
+			console.error("[backend] getScreenRecordingPermissionStatus failed:", err);
+			return "unknown";
+		});
 }
 
 export function requestScreenRecordingPermission(): Promise<boolean> {
@@ -257,10 +263,12 @@ export function openAccessibilityPreferences(): Promise<void> {
 }
 
 export function getMicrophonePermissionStatus(): Promise<string> {
-	return invoke<string>("get_microphone_permission_status").catch((err) => {
-		console.error("[backend] getMicrophonePermissionStatus failed:", err);
-		return "unknown";
-	});
+	return invoke<string>("get_microphone_permission_status")
+		.then(normalizePermissionStatus)
+		.catch((err) => {
+			console.error("[backend] getMicrophonePermissionStatus failed:", err);
+			return "unknown";
+		});
 }
 
 export function requestMicrophonePermission(): Promise<boolean> {
@@ -271,10 +279,12 @@ export function requestMicrophonePermission(): Promise<boolean> {
 }
 
 export function getCameraPermissionStatus(): Promise<string> {
-	return invoke<string>("get_camera_permission_status").catch((err) => {
-		console.error("[backend] getCameraPermissionStatus failed:", err);
-		return "unknown";
-	});
+	return invoke<string>("get_camera_permission_status")
+		.then(normalizePermissionStatus)
+		.catch((err) => {
+			console.error("[backend] getCameraPermissionStatus failed:", err);
+			return "unknown";
+		});
 }
 
 export function requestCameraPermission(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add the correct macOS Info.plist usage strings for microphone, camera, and system-audio capture in the Electron build config
- patch the dev Electron app bundle with the same usage strings so TCC can attribute prompts during local macOS runs
- normalize Electron's `not-determined` permission status to the app's existing `not_determined` contract and cover it with tests

## Diagnosis
The app was requesting microphone access through Electron's `systemPreferences.askForMediaAccess("microphone")`, but the app bundle never declared `NSMicrophoneUsageDescription`. The only usage string present was `NSAudioCaptureUsageDescription`, which is not the key Electron requires for microphone permission prompts. That prevents the app from registering normally in macOS Privacy > Microphone. A secondary issue was that Electron returns `not-determined` while the renderer expected `not_determined`.

## Verification
- `pnpm --filter @open-recorder/desktop exec npx vitest run src/lib/backend.permissions.test.ts`
- `pnpm --filter @open-recorder/desktop exec npx vitest run src/hooks/usePermissions.test.tsx`

## Notes
- I could not reproduce the macOS TCC dialog directly in this Ubuntu environment, so the macOS-specific result is verified statically from the repo config and Electron docs rather than by running the app on macOS.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
