### PR TITLE
release: bump version to v0.0.24 (patch)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.23",
+	"version": "0.0.24",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary

- Bump desktop app version from `0.0.23` → `0.0.24` (patch release)
- Build verified passing before version bump

## Test plan

- [x] `pnpm run build` passes successfully (vite build + electron build)
- [ ] Verify version string shows `0.0.24` in the built app

https://claude.ai/code/session_019Yaq8QGsxLWSzNrwWkPSci

---
_Generated by [Claude Code](https://claude.ai/code/session_019Yaq8QGsxLWSzNrwWkPSci)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
