### PR TITLE
release: bump version to v0.0.25 (patch)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.24",
+	"version": "0.0.25",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Bumps desktop app version from `0.0.24` to `0.0.25` (patch release)
- Build verified passing before and after the version bump

## Test plan
- [x] Verified `pnpm run build` passes with the new version
- [x] Confirmed version change is isolated to `apps/desktop/package.json`

https://claude.ai/code/session_01NcVQP9f5JAcKz9UmGDYdtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcVQP9f5JAcKz9UmGDYdtq)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
