### PR TITLE
chore: set pnpm minimum release age to 7 days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - apps/*
   - packages/*
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- set the workspace-level pnpm `minimumReleaseAge` to `10080` minutes
- enforce a 7 day delay before newly published packages are installable in the repo

## Test plan
- ran `pnpm config get minimumReleaseAge --location project`
- verified it returns `10080`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
