### PR TITLE
Prepare release v0.0.26

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.23",
-  "releaseName": "Open Recorder v0.0.23",
+  "tagName": "v0.0.26",
+  "releaseName": "Open Recorder v0.0.26",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Bump desktop version from 0.0.25 → 0.0.26 (patch release)
- Update `.github/release-plan.json` with v0.0.26 tag and release name
- Build verified passing before and after version bump

## Release Summary
- Release type: patch
- Base version: 0.0.25 (apps/desktop/package.json)
- Next version: 0.0.26
- Tag: v0.0.26
- Release title: Open Recorder v0.0.26
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

## Test plan
- [x] Build passes with `pnpm run build` before version bump
- [x] Build passes with `pnpm run build` after version bump
- [ ] Verify CI passes on this PR

https://claude.ai/code/session_0184G7sLi3SZrPbTK4AAjdDT

---
_Generated by [Claude Code](https://claude.ai/code/session_0184G7sLi3SZrPbTK4AAjdDT)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
