### PR TITLE
release: bump version to v0.0.27 (patch)

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.26",
-  "releaseName": "Open Recorder v0.0.26",
+  "tagName": "v0.0.27",
+  "releaseName": "Open Recorder v0.0.27",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary

- Bump desktop app version from `0.0.26` → `0.0.27` (patch release)
- Updated `apps/desktop/package.json` and `.github/release-plan.json`
- Build verified passing before and after the version bump

## Test plan

- [x] `pnpm run build` passes successfully at v0.0.27
- [ ] CI checks pass on this PR

https://claude.ai/code/session_0119YuffaqtsBiu683gGBiWL

---
_Generated by [Claude Code](https://claude.ai/code/session_0119YuffaqtsBiu683gGBiWL)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
