### PR TITLE
Prepare release v0.0.28

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.27",
-  "releaseName": "Open Recorder v0.0.27",
+  "tagName": "v0.0.28",
+  "releaseName": "Open Recorder v0.0.28",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.27",
+	"version": "0.0.28",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Patch release bump from `v0.0.27` → `v0.0.28`
- Updated `apps/desktop/package.json` version to `0.0.28`
- Updated `.github/release-plan.json` with new tag and release name

## Release Summary
- Release type: patch
- Base version: 0.0.27 (apps/desktop/package.json)
- Next version: 0.0.28
- Tag: v0.0.28
- Release title: Open Recorder v0.0.28
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

## Test plan
- [x] Build passes with bumped version (`pnpm run build` succeeds)
- [ ] Verify CI checks pass on PR

https://claude.ai/code/session_01EibydTVfJbWJYGNtrXfR1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01EibydTVfJbWJYGNtrXfR1d)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
