### PR TITLE
Prepare release v0.0.29

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.28",
-  "releaseName": "Open Recorder v0.0.28",
+  "tagName": "v0.0.29",
+  "releaseName": "Open Recorder v0.0.29",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.28",
+	"version": "0.0.29",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Release Summary
- Release type: patch
- Base version: 0.0.28 (apps/desktop/package.json)
- Next version: 0.0.29
- Tag: v0.0.29
- Release title: Open Recorder v0.0.29
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

https://claude.ai/code/session_01PVUpq4TRzxpao3LKk6CgTv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVUpq4TRzxpao3LKk6CgTv)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
