### PR TITLE
Prepare release v0.0.30

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.29",
-  "releaseName": "Open Recorder v0.0.29",
+  "tagName": "v0.0.30",
+  "releaseName": "Open Recorder v0.0.30",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.29",
+	"version": "0.0.30",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Patch release: bump version from `0.0.29` to `0.0.30`
- Updated `apps/desktop/package.json` and `.github/release-plan.json`
- Build verified passing before version bump

## Test plan
- [x] Verified `pnpm run build` passes successfully
- [ ] Merging this PR will trigger `.github/workflows/release.yml` to build desktop artifacts and publish the GitHub release

https://claude.ai/code/session_01Nt7MJfVF4mqh1QtidHuFpM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt7MJfVF4mqh1QtidHuFpM)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
