### PR TITLE
Fix permissions and screenshot capture surface drift

### DIFF
--- a/apps/desktop/electron/app-paths.ts
+++ b/apps/desktop/electron/app-paths.ts
@@ -21,9 +21,10 @@ export function defaultRecordingsDir(): string {
 	return path.join(home, "Videos", APP_DIR_NAME);
 }
 
-/** Default directory for screenshots. Same as recordings dir. */
+/** Default directory for screenshots (~/Pictures/Open Recorder). */
 export function defaultScreenshotsDir(): string {
-	return defaultRecordingsDir();
+	const home = os.homedir();
+	return path.join(home, "Pictures", APP_DIR_NAME);
 }
 
 /** Directory where app config/settings are persisted. */

--- a/apps/desktop/electron/handlers/screenshot.ts
+++ b/apps/desktop/electron/handlers/screenshot.ts
@@ -23,8 +23,7 @@ export function registerScreenshotHandlers(
 			windowId?: number;
 		};
 
-		const state = getState();
-		const dir = state.customRecordingsDir ?? getDefaultScreenshotsDir();
+		const dir = getDefaultScreenshotsDir();
 		await fs.promises.mkdir(dir, { recursive: true });
 
 		const timestamp = Math.floor(Date.now() / 1000);

--- a/apps/desktop/src/components/launch/LaunchWindow.test.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.test.tsx
@@ -349,4 +349,48 @@ describe("LaunchWindow event listener cleanup", () => {
 		// (the handler was not invoked post-cleanup)
 		expect(backend.openVideoFilePicker).not.toHaveBeenCalled();
 	});
+
+	it("routes tray-triggered source selection through preparePermissions only", async () => {
+		let capturedHandler: (() => void) | undefined;
+		const preparePermissions = vi.fn().mockResolvedValue(true);
+
+		backend.onMenuOpenVideoFile.mockResolvedValue(vi.fn());
+		backend.onMenuLoadProject.mockResolvedValue(vi.fn());
+		backend.onNewRecordingFromTray.mockImplementation((handler) => {
+			capturedHandler = handler;
+			return Promise.resolve(vi.fn());
+		});
+		backend.getSelectedSource.mockResolvedValue(null);
+		backend.openSourceSelector.mockResolvedValue(undefined);
+
+		useScreenRecorder.mockReturnValue({
+			recording: false,
+			toggleRecording: vi.fn(),
+			preparePermissions,
+			setMicrophoneEnabled: vi.fn(),
+			microphoneDeviceId: undefined,
+			setMicrophoneDeviceId: vi.fn(),
+			systemAudioEnabled: false,
+			setSystemAudioEnabled: vi.fn(),
+			cameraEnabled: false,
+			setCameraEnabled: vi.fn(),
+			cameraDeviceId: undefined,
+			setCameraDeviceId: vi.fn(),
+		});
+
+		const harness = await mountLaunchWindow();
+
+		await act(async () => {
+			capturedHandler?.();
+		});
+		await flushEffects();
+
+		expect(preparePermissions).toHaveBeenCalledOnce();
+		expect(backend.getScreenRecordingPermissionStatus).not.toHaveBeenCalled();
+		expect(backend.requestScreenRecordingPermission).not.toHaveBeenCalled();
+		expect(backend.openScreenRecordingPreferences).not.toHaveBeenCalled();
+		expect(backend.openSourceSelector).toHaveBeenCalledOnce();
+
+		await harness.unmount();
+	});
 });

--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -307,22 +307,6 @@ export function LaunchWindow() {
 
 	const openSourceSelector = useCallback(
 		async (tab?: "screens" | "windows") => {
-			const screenStatus = await backend
-				.getScreenRecordingPermissionStatus()
-				.catch(() => "unknown");
-			if (screenStatus !== "granted") {
-				const granted = await backend.requestScreenRecordingPermission().catch(() => false);
-				if (!granted) {
-					await backend.openScreenRecordingPreferences().catch(() => {
-						// Ignore preference-opening failures and keep showing the permission alert.
-					});
-					alert(
-						"Open Recorder needs Screen Recording permission to show live screen and window previews. System Settings has been opened. After enabling it, quit and reopen Open Recorder.",
-					);
-					return;
-				}
-			}
-
 			const permissionsReady = await preparePermissions();
 			if (!permissionsReady) return;
 

--- a/apps/desktop/src/hooks/usePermissions.additional.test.tsx
+++ b/apps/desktop/src/hooks/usePermissions.additional.test.tsx
@@ -12,6 +12,7 @@ import { usePermissions } from "./usePermissions";
 
 vi.mock("@/lib/backend", () => ({
 	getPlatform: vi.fn(),
+	getEffectiveScreenRecordingPermissionStatus: vi.fn(),
 	getScreenRecordingPermissionStatus: vi.fn(),
 	getMicrophonePermissionStatus: vi.fn(),
 	getCameraPermissionStatus: vi.fn(),
@@ -108,7 +109,7 @@ describe("usePermissions – additional coverage", () => {
 	describe("allPermissionsGranted computed flags", () => {
 		it("allRequiredPermissionsGranted is false when accessibility is denied", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("denied");
@@ -122,7 +123,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("allPermissionsGranted is false when only microphone is denied", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("denied");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -136,7 +137,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("allPermissionsGranted is false when only camera is denied", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("denied");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -150,7 +151,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("allRequiredPermissionsGranted is false when screenRecording is 'not_determined'", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("not_determined");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("not_determined");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -163,7 +164,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("treats 'restricted' status as not granted for all computed flags", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("restricted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("restricted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("restricted");
 			backend.getCameraPermissionStatus.mockResolvedValue("restricted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("restricted");
@@ -181,14 +182,14 @@ describe("usePermissions – additional coverage", () => {
 	describe("refreshPermissions – return value and side effects", () => {
 		it("returns the resolved PermissionState as its value", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("denied");
 			backend.getCameraPermissionStatus.mockResolvedValue("denied");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("denied");
 
 			const hook = await mountHook();
 
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -225,7 +226,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("sets isChecking to false after completing", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -238,7 +239,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("handles partial backend errors – succeeding checks retain their values, failing checks become 'unknown'", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockRejectedValue(new Error("IPC error"));
 			backend.getCameraPermissionStatus.mockResolvedValue("denied");
 			backend.getAccessibilityPermissionStatus.mockRejectedValue(new Error("IPC error"));
@@ -260,7 +261,7 @@ describe("usePermissions – additional coverage", () => {
 	describe("requestMicrophoneAccess – fallback and edge cases", () => {
 		it("falls back to getUserMedia when native macOS request throws", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus
 				.mockResolvedValueOnce("not_determined")
 				.mockResolvedValue("granted");
@@ -355,7 +356,7 @@ describe("usePermissions – additional coverage", () => {
 	describe("requestCameraAccess – fallback and edge cases", () => {
 		it("falls back to getUserMedia when native macOS camera request throws", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus
 				.mockResolvedValueOnce("not_determined")
@@ -407,7 +408,7 @@ describe("usePermissions – additional coverage", () => {
 	describe("requestScreenRecordingAccess – edge cases", () => {
 		it("returns false when backend throws and status remains denied", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -428,7 +429,7 @@ describe("usePermissions – additional coverage", () => {
 
 		it("returns true when backend returns false but re-check shows granted", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus
+			backend.getEffectiveScreenRecordingPermissionStatus
 				.mockResolvedValueOnce("not_determined")
 				.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
@@ -498,7 +499,7 @@ describe("usePermissions – additional coverage", () => {
 	describe("isMacOS state transitions", () => {
 		it("sets isMacOS=true when darwin is detected on mount", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -516,7 +517,7 @@ describe("usePermissions – additional coverage", () => {
 			expect(hook.getCurrent().isMacOS).toBe(false);
 
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -527,6 +528,22 @@ describe("usePermissions – additional coverage", () => {
 			await flushEffects();
 
 			expect(hook.getCurrent().isMacOS).toBe(true);
+
+			await hook.unmount();
+		});
+
+		it("prefers the effective probe over the cached screen status", async () => {
+			backend.getPlatform.mockResolvedValue("darwin");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
+			backend.getCameraPermissionStatus.mockResolvedValue("granted");
+			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+
+			const hook = await mountHook();
+
+			expect(hook.getCurrent().permissions.screenRecording).toBe("denied");
+			expect(backend.getScreenRecordingPermissionStatus).not.toHaveBeenCalled();
 
 			await hook.unmount();
 		});

--- a/apps/desktop/src/hooks/usePermissions.test.tsx
+++ b/apps/desktop/src/hooks/usePermissions.test.tsx
@@ -12,6 +12,7 @@ import { usePermissions } from "./usePermissions";
 
 vi.mock("@/lib/backend", () => ({
 	getPlatform: vi.fn(),
+	getEffectiveScreenRecordingPermissionStatus: vi.fn(),
 	getScreenRecordingPermissionStatus: vi.fn(),
 	getMicrophonePermissionStatus: vi.fn(),
 	getCameraPermissionStatus: vi.fn(),
@@ -136,6 +137,7 @@ describe("usePermissions", () => {
 		it("does not call any native permission check commands", async () => {
 			const hook = await mountHook();
 
+			expect(backend.getEffectiveScreenRecordingPermissionStatus).not.toHaveBeenCalled();
 			expect(backend.getScreenRecordingPermissionStatus).not.toHaveBeenCalled();
 			expect(backend.getMicrophonePermissionStatus).not.toHaveBeenCalled();
 			expect(backend.getCameraPermissionStatus).not.toHaveBeenCalled();
@@ -162,7 +164,7 @@ describe("usePermissions", () => {
 		});
 
 		it("fetches all permission statuses on mount", async () => {
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("not_determined");
 			backend.getCameraPermissionStatus.mockResolvedValue("denied");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -179,7 +181,8 @@ describe("usePermissions", () => {
 				accessibility: "granted",
 			});
 
-			expect(backend.getScreenRecordingPermissionStatus).toHaveBeenCalledTimes(1);
+			expect(backend.getEffectiveScreenRecordingPermissionStatus).toHaveBeenCalledTimes(1);
+			expect(backend.getScreenRecordingPermissionStatus).not.toHaveBeenCalled();
 			expect(backend.getMicrophonePermissionStatus).toHaveBeenCalledTimes(1);
 			expect(backend.getCameraPermissionStatus).toHaveBeenCalledTimes(1);
 			expect(backend.getAccessibilityPermissionStatus).toHaveBeenCalledTimes(1);
@@ -188,7 +191,7 @@ describe("usePermissions", () => {
 		});
 
 		it("reports allRequiredPermissionsGranted correctly", async () => {
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("not_determined");
 			backend.getCameraPermissionStatus.mockResolvedValue("denied");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -204,7 +207,7 @@ describe("usePermissions", () => {
 		});
 
 		it("reports allPermissionsGranted when everything is granted", async () => {
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -218,7 +221,7 @@ describe("usePermissions", () => {
 		});
 
 		it("reports allRequiredPermissionsGranted as false when screen recording is denied", async () => {
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -229,7 +232,7 @@ describe("usePermissions", () => {
 		});
 
 		it("handles backend errors gracefully, falling back to 'unknown'", async () => {
-			backend.getScreenRecordingPermissionStatus.mockRejectedValue(new Error("IPC error"));
+			backend.getEffectiveScreenRecordingPermissionStatus.mockRejectedValue(new Error("IPC error"));
 			backend.getMicrophonePermissionStatus.mockRejectedValue(new Error("IPC error"));
 			backend.getCameraPermissionStatus.mockRejectedValue(new Error("IPC error"));
 			backend.getAccessibilityPermissionStatus.mockRejectedValue(new Error("IPC error"));
@@ -251,7 +254,7 @@ describe("usePermissions", () => {
 	describe("refreshPermissions", () => {
 		it("re-fetches all statuses and updates state", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("not_determined");
 			backend.getCameraPermissionStatus.mockResolvedValue("not_determined");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("denied");
@@ -260,7 +263,7 @@ describe("usePermissions", () => {
 			expect(hook.getCurrent().permissions.screenRecording).toBe("denied");
 
 			// Simulate user granting screen recording externally
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
 
 			let result!: PermissionState;
@@ -281,7 +284,7 @@ describe("usePermissions", () => {
 	describe("requestMicrophoneAccess", () => {
 		it("uses the native request path on macOS", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("not_determined");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -307,7 +310,7 @@ describe("usePermissions", () => {
 
 		it("returns false when the native macOS request is denied", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("not_determined");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -336,7 +339,7 @@ describe("usePermissions", () => {
 	describe("requestCameraAccess", () => {
 		it("uses the native request path on macOS", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("not_determined");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -361,7 +364,7 @@ describe("usePermissions", () => {
 
 		it("returns false on native camera permission denial", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("not_determined");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -389,7 +392,7 @@ describe("usePermissions", () => {
 	describe("requestScreenRecordingAccess", () => {
 		it("delegates to backend.requestScreenRecordingPermission and refreshes on success", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -399,7 +402,7 @@ describe("usePermissions", () => {
 			expect(hook.getCurrent().permissions.screenRecording).toBe("denied");
 
 			// After granting, native API returns "granted"
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 
 			let granted!: boolean;
 			await act(async () => {
@@ -415,7 +418,7 @@ describe("usePermissions", () => {
 
 		it("falls back to re-checking status when requestScreenRecordingPermission returns false", async () => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("denied");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("denied");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
@@ -440,7 +443,7 @@ describe("usePermissions", () => {
 	describe("openPermissionSettings", () => {
 		beforeEach(() => {
 			backend.getPlatform.mockResolvedValue("darwin");
-			backend.getScreenRecordingPermissionStatus.mockResolvedValue("granted");
+			backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
 			backend.getMicrophonePermissionStatus.mockResolvedValue("granted");
 			backend.getCameraPermissionStatus.mockResolvedValue("granted");
 			backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");

--- a/apps/desktop/src/hooks/usePermissions.ts
+++ b/apps/desktop/src/hooks/usePermissions.ts
@@ -67,7 +67,7 @@ export function usePermissions(): UsePermissionsResult {
 		} else {
 			// Fetch all statuses in parallel on macOS
 			const [screenStatus, micStatus, camStatus, accessStatus] = await Promise.all([
-				backend.getScreenRecordingPermissionStatus().catch(() => "unknown"),
+				backend.getEffectiveScreenRecordingPermissionStatus().catch(() => "unknown"),
 				backend.getMicrophonePermissionStatus().catch(() => "unknown"),
 				backend.getCameraPermissionStatus().catch(() => "unknown"),
 				backend.getAccessibilityPermissionStatus().catch(() => "unknown"),

--- a/apps/desktop/src/hooks/useScreenRecorder.test.tsx
+++ b/apps/desktop/src/hooks/useScreenRecorder.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/lib/backend", () => ({
 	onStopRecordingFromTray: vi.fn(),
 	onRecordingStateChanged: vi.fn(),
 	onRecordingInterrupted: vi.fn(),
+	getEffectiveScreenRecordingPermissionStatus: vi.fn(),
 	getScreenRecordingPermissionStatus: vi.fn(),
 	requestScreenRecordingPermission: vi.fn(),
 	openScreenRecordingPreferences: vi.fn(),
@@ -210,5 +211,34 @@ describe("useScreenRecorder — async continuation after unmount", () => {
 		expect(backend.switchToEditor).not.toHaveBeenCalled();
 		expect(backend.setCurrentVideoPath).not.toHaveBeenCalled();
 		expect(backend.setCurrentRecordingSession).not.toHaveBeenCalled();
+	});
+});
+
+describe("useScreenRecorder — permission preparation", () => {
+	beforeEach(() => {
+		backend.getPlatform.mockResolvedValue("darwin");
+		backend.getEffectiveScreenRecordingPermissionStatus.mockResolvedValue("granted");
+		backend.getAccessibilityPermissionStatus.mockResolvedValue("granted");
+	});
+
+	it("uses the effective screen-recording status for the re-check path", async () => {
+		backend.getEffectiveScreenRecordingPermissionStatus
+			.mockResolvedValueOnce("denied")
+			.mockResolvedValueOnce("granted");
+		backend.requestScreenRecordingPermission.mockResolvedValue(false);
+
+		const hook = await mountHook();
+
+		let allowed = false;
+		await act(async () => {
+			allowed = await hook.getCurrent().preparePermissions();
+		});
+
+		expect(allowed).toBe(true);
+		expect(backend.getEffectiveScreenRecordingPermissionStatus).toHaveBeenCalledTimes(2);
+		expect(backend.getScreenRecordingPermissionStatus).not.toHaveBeenCalled();
+		expect(backend.openScreenRecordingPreferences).not.toHaveBeenCalled();
+
+		await hook.unmount();
 	});
 });

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -276,13 +276,13 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			}
 
 			// ── Screen Recording (required) ──────────────────────────────────
-			const screenStatus = await backend.getScreenRecordingPermissionStatus();
+			const screenStatus = await backend.getEffectiveScreenRecordingPermissionStatus();
 			if (screenStatus !== "granted") {
 				const granted = await backend.requestScreenRecordingPermission();
 				if (granted) {
 					// continue to next check
 				} else {
-					const refreshedStatus = await backend.getScreenRecordingPermissionStatus();
+					const refreshedStatus = await backend.getEffectiveScreenRecordingPermissionStatus();
 					if (refreshedStatus !== "granted") {
 						await backend.openScreenRecordingPreferences();
 						alert(

--- a/apps/desktop/src/lib/backend.permissions.test.ts
+++ b/apps/desktop/src/lib/backend.permissions.test.ts
@@ -159,10 +159,7 @@ describe("permission backend wrappers", () => {
 
 			expect(result).toBe(false);
 			expect(errorSpy).toHaveBeenCalledOnce();
-			expect(errorSpy).toHaveBeenCalledWith(
-				"[backend] requestCameraPermission failed:",
-				ipcError,
-			);
+			expect(errorSpy).toHaveBeenCalledWith("[backend] requestCameraPermission failed:", ipcError);
 		});
 	});
 
@@ -195,6 +192,58 @@ describe("permission backend wrappers", () => {
 			invoke.mockResolvedValue("not-determined");
 			const result = await backend.getScreenRecordingPermissionStatus();
 			expect(result).toBe("not_determined");
+		});
+	});
+
+	describe("probeScreenRecordingEffectiveStatus", () => {
+		it("invokes the probe command", async () => {
+			invoke.mockResolvedValue("granted");
+			const result = await backend.probeScreenRecordingEffectiveStatus();
+			expect(invoke).toHaveBeenCalledWith("probe_screen_recording_effective_status");
+			expect(result).toBe("granted");
+		});
+
+		it("normalizes Electron's 'not-determined' status", async () => {
+			invoke.mockResolvedValue("not-determined");
+			const result = await backend.probeScreenRecordingEffectiveStatus();
+			expect(result).toBe("not_determined");
+		});
+
+		it("logs error and returns 'unknown' when IPC call rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const ipcError = new Error("IPC channel closed");
+			invoke.mockRejectedValue(ipcError);
+
+			const result = await backend.probeScreenRecordingEffectiveStatus();
+
+			expect(result).toBe("unknown");
+			expect(errorSpy).toHaveBeenCalledOnce();
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[backend] probeScreenRecordingEffectiveStatus failed:",
+				ipcError,
+			);
+		});
+	});
+
+	describe("getEffectiveScreenRecordingPermissionStatus", () => {
+		it("returns the probe result when it is known", async () => {
+			invoke.mockResolvedValueOnce("granted");
+
+			const result = await backend.getEffectiveScreenRecordingPermissionStatus();
+
+			expect(result).toBe("granted");
+			expect(invoke).toHaveBeenCalledTimes(1);
+			expect(invoke).toHaveBeenCalledWith("probe_screen_recording_effective_status");
+		});
+
+		it("falls back to the cached status when the probe is unknown", async () => {
+			invoke.mockResolvedValueOnce("unknown").mockResolvedValueOnce("not-determined");
+
+			const result = await backend.getEffectiveScreenRecordingPermissionStatus();
+
+			expect(result).toBe("not_determined");
+			expect(invoke).toHaveBeenNthCalledWith(1, "probe_screen_recording_effective_status");
+			expect(invoke).toHaveBeenNthCalledWith(2, "get_screen_recording_permission_status");
 		});
 	});
 

--- a/apps/desktop/src/lib/backend.ts
+++ b/apps/desktop/src/lib/backend.ts
@@ -259,6 +259,15 @@ export function probeScreenRecordingEffectiveStatus(): Promise<string> {
 		});
 }
 
+export async function getEffectiveScreenRecordingPermissionStatus(): Promise<string> {
+	const effectiveStatus = await probeScreenRecordingEffectiveStatus();
+	if (effectiveStatus !== "unknown") {
+		return effectiveStatus;
+	}
+
+	return getScreenRecordingPermissionStatus();
+}
+
 /**
  * Relaunch the Electron app.  Required on macOS after granting screen-recording
  * permission in dev because the TCC cache only refreshes on a fresh process.

--- a/apps/desktop/src/lib/screenshotDestination.test.ts
+++ b/apps/desktop/src/lib/screenshotDestination.test.ts
@@ -1,0 +1,102 @@
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mkdirMock = vi.fn();
+const existsSyncMock = vi.fn();
+const execFileMock = vi.fn();
+const getPathMock = vi.fn();
+
+vi.mock("node:fs", () => ({
+	default: {
+		promises: {
+			mkdir: mkdirMock,
+		},
+		existsSync: existsSyncMock,
+	},
+}));
+
+vi.mock("node:child_process", () => ({
+	execFile: execFileMock,
+}));
+
+vi.mock("electron", () => ({
+	app: {
+		getPath: getPathMock,
+	},
+}));
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.resetModules();
+	mkdirMock.mockResolvedValue(undefined);
+	existsSyncMock.mockReturnValue(true);
+	execFileMock.mockImplementation(
+		(
+			_file: string,
+			_args: string[],
+			callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+		) => callback(null, "", ""),
+	);
+	getPathMock.mockReturnValue("/tmp/user-data");
+});
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", {
+		value: originalPlatform,
+		configurable: true,
+	});
+});
+
+describe("screenshot destination semantics", () => {
+	it("uses a Pictures-based screenshots directory on macOS instead of the recordings directory", async () => {
+		setPlatform("darwin");
+		const paths = await import("../../electron/app-paths.ts");
+		const home = os.homedir();
+
+		expect(paths.defaultRecordingsDir()).toBe(`${home}/Movies/Open Recorder`);
+		expect(paths.defaultScreenshotsDir()).toBe(`${home}/Pictures/Open Recorder`);
+		expect(paths.defaultScreenshotsDir()).not.toBe(paths.defaultRecordingsDir());
+	});
+
+	it("does not route screenshots into the custom recordings directory", async () => {
+		setPlatform("darwin");
+		const { registerScreenshotHandlers } = await import("../../electron/handlers/screenshot.ts");
+
+		const handlers = new Map<string, (args: unknown) => unknown>();
+		const state = {
+			customRecordingsDir: "/tmp/custom-recordings",
+			currentScreenshotPath: null,
+		};
+
+		registerScreenshotHandlers(
+			(channel, handler) => {
+				handlers.set(channel, handler);
+			},
+			() => state,
+			(updater) => updater(state),
+			() => "/tmp/default-screenshots",
+		);
+
+		const takeScreenshot = handlers.get("take_screenshot");
+		expect(takeScreenshot).toBeTypeOf("function");
+
+		const screenshotPath = await takeScreenshot?.({ captureType: "screen" });
+
+		expect(mkdirMock).toHaveBeenCalledWith("/tmp/default-screenshots", { recursive: true });
+		expect(execFileMock).toHaveBeenCalledOnce();
+		expect(execFileMock.mock.calls[0]?.[1]?.at(-1)).toMatch(
+			/^\/tmp\/default-screenshots\/screenshot-\d+\.png$/,
+		);
+		expect(screenshotPath).toMatch(/^\/tmp\/default-screenshots\/screenshot-\d+\.png$/);
+		expect(state.currentScreenshotPath).toBe(screenshotPath);
+	});
+});


### PR DESCRIPTION
## Summary
- route macOS screen-recording checks through a shared effective-status helper and remove the duplicate LaunchWindow gate
- restore explicit screenshot destination semantics so screenshots default to Pictures and do not inherit the custom recordings directory
- add focused verification for macOS permission-state handling and screenshot destination logic

## Test plan
- pnpm --filter @open-recorder/desktop test -- --run apps/desktop/src/hooks/usePermissions.test.tsx apps/desktop/src/hooks/usePermissions.additional.test.tsx apps/desktop/src/hooks/useScreenRecorder.test.tsx apps/desktop/src/components/launch/LaunchWindow.test.tsx apps/desktop/src/lib/backend.permissions.test.ts apps/desktop/src/lib/screenshotDestination.test.ts
- pnpm --filter @open-recorder/desktop typecheck

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
