### PR TITLE
Fix Electron release automation surface

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -45,10 +45,18 @@ jobs:
           ref: ${{ github.event.inputs.base_ref }}
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Fetch release tags
         run: git fetch --tags origin
@@ -68,6 +76,65 @@ jobs:
             --latest "$MAKE_LATEST" \
             --output "$GITHUB_OUTPUT"
 
+      - name: Verify changed release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only -- apps/desktop/package.json .github/release-plan.json)
+          if [ "${#changed_files[@]}" -ne 2 ]; then
+            echo "Expected release preparation to update exactly 2 files." >&2
+            git diff --name-only >&2
+            exit 1
+          fi
+
+          unexpected=$(git diff --name-only -- . ':(exclude)apps/desktop/package.json' ':(exclude).github/release-plan.json')
+          if [ -n "$unexpected" ]; then
+            echo "Unexpected files changed during release preparation:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+
+      - name: Verify release context resolves from Electron package version
+        run: |
+          node scripts/resolve-release-context.mjs \
+            --event-name push \
+            --before HEAD \
+            --output "$RUNNER_TEMP/release-context.out"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop app
+        run: pnpm --filter @open-recorder/desktop build
+
+      - name: Linux packaging smoke test
+        run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --linux AppImage --x64
+
+      - name: Verify Linux packaging artifacts
+        env:
+          EXPECTED_PATTERNS: '["\\.AppImage$","^latest-linux\\.yml$"]'
+        run: |
+          node <<'NODE'
+          const { readdirSync, statSync } = require("node:fs");
+          const { join } = require("node:path");
+
+          const releaseDir = "apps/desktop/release";
+          const files = readdirSync(releaseDir)
+            .filter((name) => statSync(join(releaseDir, name)).isFile())
+            .sort();
+
+          console.log(files.join("\n"));
+
+          const patterns = JSON.parse(process.env.EXPECTED_PATTERNS);
+          for (const source of patterns) {
+            const regex = new RegExp(source);
+            if (!files.some((file) => regex.test(file))) {
+              console.error(`Missing packaging artifact matching ${source}`);
+              process.exit(1);
+            }
+          }
+          NODE
+
       - name: Create or update release PR
         uses: peter-evans/create-pull-request@v7
         with:
@@ -79,6 +146,3 @@ jobs:
           add-paths: |
             .github/release-plan.json
             apps/desktop/package.json
-            apps/desktop/src-tauri/Cargo.lock
-            apps/desktop/src-tauri/Cargo.toml
-            apps/desktop/src-tauri/tauri.conf.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
-name: Release Tauri App
+name: Release Electron App
 
 on:
   push:
     branches:
       - main
     paths:
+      - .github/release-plan.json
       - apps/desktop/package.json
   workflow_dispatch:
     inputs:
@@ -70,28 +71,16 @@ jobs:
     if: needs.resolve-release.outputs.should_release == 'true'
     runs-on: macos-14
     env:
-      TAURI_TARGET_TRIPLE: aarch64-apple-darwin
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE || secrets.CSC_LINK }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || secrets.CSC_NAME }}
+      CSC_LINK: ${{ secrets.APPLE_CERTIFICATE || secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+      CSC_NAME: ${{ secrets.APPLE_SIGNING_IDENTITY || secrets.CSC_NAME }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/desktop/src-tauri
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -106,58 +95,63 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install frontend dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build sidecars
-        run: pnpm --filter @open-recorder/desktop build:sidecars
+      - name: Build desktop app
+        run: pnpm --filter @open-recorder/desktop build
 
-      - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+      - name: Package macOS arm64 artifacts
+        run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --mac dmg zip --arm64
+
+      - name: Verify macOS arm64 artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          projectPath: apps/desktop
-          args: --target aarch64-apple-darwin
+          EXPECTED_PATTERNS: '["\\.dmg$","\\.zip$","^latest-mac.*\\.yml$"]'
+        run: |
+          node <<'NODE'
+          const { readdirSync, statSync } = require("node:fs");
+          const { join } = require("node:path");
 
-      - name: Upload macOS arm64 artifact
+          const releaseDir = "apps/desktop/release";
+          const files = readdirSync(releaseDir)
+            .filter((name) => statSync(join(releaseDir, name)).isFile())
+            .sort();
+
+          console.log(files.join("\n"));
+
+          const patterns = JSON.parse(process.env.EXPECTED_PATTERNS);
+          for (const source of patterns) {
+            const regex = new RegExp(source);
+            if (!files.some((file) => regex.test(file))) {
+              console.error(`Missing packaging artifact matching ${source}`);
+              process.exit(1);
+            }
+          }
+          NODE
+
+      - name: Upload macOS arm64 artifact set
         uses: actions/upload-artifact@v4
         with:
           name: macos-arm64
-          path: |
-            apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
-            apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz
-            apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
+          path: apps/desktop/release/**/*
           if-no-files-found: error
 
   build-macos-x64:
     name: Build macOS x64
     needs: resolve-release
     if: needs.resolve-release.outputs.should_release == 'true'
-    runs-on: macos-14
+    runs-on: macos-13
     env:
-      TAURI_TARGET_TRIPLE: x86_64-apple-darwin
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE || secrets.CSC_LINK }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || secrets.CSC_NAME }}
+      CSC_LINK: ${{ secrets.APPLE_CERTIFICATE || secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+      CSC_NAME: ${{ secrets.APPLE_SIGNING_IDENTITY || secrets.CSC_NAME }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-apple-darwin
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/desktop/src-tauri
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -172,28 +166,45 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install frontend dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build sidecars
-        run: pnpm --filter @open-recorder/desktop build:sidecars
+      - name: Build desktop app
+        run: pnpm --filter @open-recorder/desktop build
 
-      - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+      - name: Package macOS x64 artifacts
+        run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --mac dmg zip --x64
+
+      - name: Verify macOS x64 artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          projectPath: apps/desktop
-          args: --target x86_64-apple-darwin
+          EXPECTED_PATTERNS: '["\\.dmg$","\\.zip$","^latest-mac.*\\.yml$"]'
+        run: |
+          node <<'NODE'
+          const { readdirSync, statSync } = require("node:fs");
+          const { join } = require("node:path");
 
-      - name: Upload macOS x64 artifact
+          const releaseDir = "apps/desktop/release";
+          const files = readdirSync(releaseDir)
+            .filter((name) => statSync(join(releaseDir, name)).isFile())
+            .sort();
+
+          console.log(files.join("\n"));
+
+          const patterns = JSON.parse(process.env.EXPECTED_PATTERNS);
+          for (const source of patterns) {
+            const regex = new RegExp(source);
+            if (!files.some((file) => regex.test(file))) {
+              console.error(`Missing packaging artifact matching ${source}`);
+              process.exit(1);
+            }
+          }
+          NODE
+
+      - name: Upload macOS x64 artifact set
         uses: actions/upload-artifact@v4
         with:
           name: macos-x64
-          path: |
-            apps/desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
-            apps/desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz
-            apps/desktop/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
+          path: apps/desktop/release/**/*
           if-no-files-found: error
 
   build-windows-x64:
@@ -202,19 +213,10 @@ jobs:
     if: needs.resolve-release.outputs.should_release == 'true'
     runs-on: windows-latest
     env:
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/desktop/src-tauri
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -229,20 +231,46 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install frontend dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build sidecars
-        run: pnpm --filter @open-recorder/desktop build:sidecars
+      - name: Build desktop app
+        run: pnpm --filter @open-recorder/desktop build
 
-      - name: Build Tauri app
-        run: pnpm --filter @open-recorder/desktop tauri build
+      - name: Package Windows x64 artifacts
+        run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --win nsis --x64
 
-      - name: Upload Windows x64 artifact
+      - name: Verify Windows x64 artifacts
+        shell: bash
+        env:
+          EXPECTED_PATTERNS: '["\\.exe$","^latest\\.yml$"]'
+        run: |
+          node <<'NODE'
+          const { readdirSync, statSync } = require("node:fs");
+          const { join } = require("node:path");
+
+          const releaseDir = "apps/desktop/release";
+          const files = readdirSync(releaseDir)
+            .filter((name) => statSync(join(releaseDir, name)).isFile())
+            .sort();
+
+          console.log(files.join("\n"));
+
+          const patterns = JSON.parse(process.env.EXPECTED_PATTERNS);
+          for (const source of patterns) {
+            const regex = new RegExp(source);
+            if (!files.some((file) => regex.test(file))) {
+              console.error(`Missing packaging artifact matching ${source}`);
+              process.exit(1);
+            }
+          }
+          NODE
+
+      - name: Upload Windows x64 artifact set
         uses: actions/upload-artifact@v4
         with:
           name: windows-x64
-          path: "apps/desktop/src-tauri/target/release/bundle/nsis/*"
+          path: apps/desktop/release/**/*
           if-no-files-found: error
 
   build-linux-x64:
@@ -251,24 +279,10 @@ jobs:
     if: needs.resolve-release.outputs.should_release == 'true'
     runs-on: ubuntu-22.04
     env:
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/desktop/src-tauri
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -283,27 +297,53 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install frontend dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Tauri app
-        run: pnpm --filter @open-recorder/desktop tauri build
+      - name: Build desktop app
+        run: pnpm --filter @open-recorder/desktop build
 
-      - name: Upload Linux x64 artifact
+      - name: Package Linux x64 artifacts
+        run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --linux AppImage --x64
+
+      - name: Verify Linux x64 artifacts
+        env:
+          EXPECTED_PATTERNS: '["\\.AppImage$","^latest-linux\\.yml$"]'
+        run: |
+          node <<'NODE'
+          const { readdirSync, statSync } = require("node:fs");
+          const { join } = require("node:path");
+
+          const releaseDir = "apps/desktop/release";
+          const files = readdirSync(releaseDir)
+            .filter((name) => statSync(join(releaseDir, name)).isFile())
+            .sort();
+
+          console.log(files.join("\n"));
+
+          const patterns = JSON.parse(process.env.EXPECTED_PATTERNS);
+          for (const source of patterns) {
+            const regex = new RegExp(source);
+            if (!files.some((file) => regex.test(file))) {
+              console.error(`Missing packaging artifact matching ${source}`);
+              process.exit(1);
+            }
+          }
+          NODE
+
+      - name: Upload Linux x64 artifact set
         uses: actions/upload-artifact@v4
         with:
           name: linux-x64
-          path: |
-            apps/desktop/src-tauri/target/release/bundle/appimage/*
-            apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+          path: apps/desktop/release/**/*
           if-no-files-found: error
 
   publish-release:
     name: Publish release
     needs:
       - resolve-release
-      - build-macos-x64
       - build-macos-arm64
+      - build-macos-x64
       - build-windows-x64
       - build-linux-x64
     if: needs.resolve-release.outputs.should_release == 'true'
@@ -317,121 +357,80 @@ jobs:
       - name: List artifacts
         run: find release-assets -type f | sort
 
-      - name: Prepare release assets
+      - name: Prepare Electron release assets
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p release-upload
 
-          copy_match() {
+          copy_unique() {
+            local source_path="$1"
+            local dest_name="$2"
+            local dest_path="release-upload/$dest_name"
+
+            if [ -e "$dest_path" ]; then
+              echo "Duplicate release asset: $dest_name" >&2
+              exit 1
+            fi
+
+            cp "$source_path" "$dest_path"
+          }
+
+          copy_matches() {
             local source_dir="$1"
             local pattern="$2"
-            local dest_name="$3"
-            local found=""
+            local found=0
 
-            if [ -d "$source_dir" ]; then
-              found=$(find "$source_dir" -name "$pattern" -type f | head -1)
-            fi
+            while IFS= read -r file_path; do
+              found=1
+              copy_unique "$file_path" "$(basename "$file_path")"
+            done < <(find "$source_dir" -type f -name "$pattern" | sort)
 
-            if [ -n "$found" ]; then
-              cp "$found" "release-upload/$dest_name"
-            fi
-          }
-
-          copy_match "release-assets/macos-arm64" "*.dmg" "open-recorder-macos-arm64.dmg"
-          copy_match "release-assets/macos-arm64" "*.app.tar.gz" "open-recorder-macos-arm64.app.tar.gz"
-          copy_match "release-assets/macos-arm64" "*.app.tar.gz.sig" "open-recorder-macos-arm64.app.tar.gz.sig"
-
-          copy_match "release-assets/macos-x64" "*.dmg" "open-recorder-macos-x64.dmg"
-          copy_match "release-assets/macos-x64" "*.app.tar.gz" "open-recorder-macos-x64.app.tar.gz"
-          copy_match "release-assets/macos-x64" "*.app.tar.gz.sig" "open-recorder-macos-x64.app.tar.gz.sig"
-
-          copy_match "release-assets/windows-x64" "*setup.exe" "open-recorder-windows-x64-setup.exe"
-          copy_match "release-assets/windows-x64" "*setup.exe.sig" "open-recorder-windows-x64-setup.exe.sig"
-
-          copy_match "release-assets/linux-x64" "*.AppImage" "open-recorder-linux-x64.appimage"
-          copy_match "release-assets/linux-x64" "*.AppImage.sig" "open-recorder-linux-x64.appimage.sig"
-          copy_match "release-assets/linux-x64" "*.deb" "open-recorder-linux-x64.deb"
-
-          require_file() {
-            local file_path="$1"
-            if [ ! -f "$file_path" ]; then
-              echo "Missing required updater artifact: $file_path" >&2
+            if [ "$found" -eq 0 ]; then
+              echo "Missing required artifact pattern '$pattern' in $source_dir" >&2
               exit 1
             fi
           }
 
-          require_file "release-upload/open-recorder-macos-arm64.app.tar.gz"
-          require_file "release-upload/open-recorder-macos-arm64.app.tar.gz.sig"
-          require_file "release-upload/open-recorder-macos-x64.app.tar.gz"
-          require_file "release-upload/open-recorder-macos-x64.app.tar.gz.sig"
-          require_file "release-upload/open-recorder-windows-x64-setup.exe"
-          require_file "release-upload/open-recorder-windows-x64-setup.exe.sig"
-          require_file "release-upload/open-recorder-linux-x64.appimage"
-          require_file "release-upload/open-recorder-linux-x64.appimage.sig"
+          copy_alias() {
+            local source_dir="$1"
+            local pattern="$2"
+            local alias_name="$3"
+            local file_path
+
+            file_path=$(find "$source_dir" -type f -name "$pattern" | sort | head -1)
+            if [ -z "$file_path" ]; then
+              echo "Missing alias source pattern '$pattern' in $source_dir" >&2
+              exit 1
+            fi
+
+            copy_unique "$file_path" "$alias_name"
+          }
+
+          copy_matches "release-assets/macos-arm64" "*.dmg"
+          copy_matches "release-assets/macos-arm64" "*.zip"
+          copy_matches "release-assets/macos-arm64" "*.blockmap"
+          copy_matches "release-assets/macos-arm64" "latest-mac*.yml"
+
+          copy_matches "release-assets/macos-x64" "*.dmg"
+          copy_matches "release-assets/macos-x64" "*.zip"
+          copy_matches "release-assets/macos-x64" "*.blockmap"
+          copy_matches "release-assets/macos-x64" "latest-mac*.yml"
+
+          copy_matches "release-assets/windows-x64" "*.exe"
+          copy_matches "release-assets/windows-x64" "*.blockmap"
+          copy_matches "release-assets/windows-x64" "latest*.yml"
+
+          copy_matches "release-assets/linux-x64" "*.AppImage"
+          copy_matches "release-assets/linux-x64" "*.blockmap"
+          copy_matches "release-assets/linux-x64" "latest-linux*.yml"
+
+          copy_alias "release-assets/macos-arm64" "*.dmg" "open-recorder-macos-arm64.dmg"
+          copy_alias "release-assets/macos-x64" "*.dmg" "open-recorder-macos-x64.dmg"
+          copy_alias "release-assets/windows-x64" "*.exe" "open-recorder-windows-x64-setup.exe"
+          copy_alias "release-assets/linux-x64" "*.AppImage" "open-recorder-linux-x64.AppImage"
 
           find release-upload -type f | sort
-
-      - name: Generate updater manifest (latest.json)
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ needs.resolve-release.outputs.tag_name }}
-          RELEASE_NOTES: ${{ needs.resolve-release.outputs.release_notes }}
-        run: |
-          set -euo pipefail
-          TAG="$RELEASE_TAG"
-          VERSION="${TAG#v}"
-          REPO="imbhargav5/open-recorder"
-          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          NOTES=$(node -p 'JSON.stringify(process.env.RELEASE_NOTES ?? "").slice(1, -1)')
-
-          read_required_file() {
-            local file_path="$1"
-            if [ ! -s "$file_path" ]; then
-              echo "Required file is missing or empty: $file_path" >&2
-              exit 1
-            fi
-            cat "$file_path"
-          }
-
-          MAC_ARM64_SIG=$(read_required_file "release-upload/open-recorder-macos-arm64.app.tar.gz.sig")
-          MAC_ARM64_FILE="open-recorder-macos-arm64.app.tar.gz"
-          MAC_X64_SIG=$(read_required_file "release-upload/open-recorder-macos-x64.app.tar.gz.sig")
-          MAC_X64_FILE="open-recorder-macos-x64.app.tar.gz"
-          WIN_SIG=$(read_required_file "release-upload/open-recorder-windows-x64-setup.exe.sig")
-          WIN_FILE="open-recorder-windows-x64-setup.exe"
-          LINUX_SIG=$(read_required_file "release-upload/open-recorder-linux-x64.appimage.sig")
-          LINUX_FILE="open-recorder-linux-x64.appimage"
-
-          cat > release-upload/latest.json << MANIFEST
-          {
-            "version": "${VERSION}",
-            "notes": "${NOTES}",
-            "pub_date": "${PUB_DATE}",
-            "platforms": {
-              "darwin-aarch64": {
-                "signature": "${MAC_ARM64_SIG}",
-                "url": "${BASE_URL}/${MAC_ARM64_FILE}"
-              },
-              "darwin-x86_64": {
-                "signature": "${MAC_X64_SIG}",
-                "url": "${BASE_URL}/${MAC_X64_FILE}"
-              },
-              "windows-x86_64": {
-                "signature": "${WIN_SIG}",
-                "url": "${BASE_URL}/${WIN_FILE}"
-              },
-              "linux-x86_64": {
-                "signature": "${LINUX_SIG}",
-                "url": "${BASE_URL}/${LINUX_FILE}"
-              }
-            }
-          }
-          MANIFEST
-
-          echo "Generated latest.json:"
-          cat release-upload/latest.json
 
       - name: Create or update release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,16 @@ jobs:
         with:
           filters: |
             relevant:
+              - '.github/workflows/release-pr.yml'
+              - '.github/workflows/release.yml'
               - '.github/workflows/test.yml'
+              - '.github/release-plan.json'
               - 'apps/desktop/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
+              - 'scripts/dispatch-release-build.mjs'
+              - 'scripts/prepare-release-pr.mjs'
+              - 'scripts/resolve-release-context.mjs'
               - 'pnpm-workspace.yaml'
               - 'turbo.json'
               - 'biome.json'
@@ -89,3 +95,58 @@ jobs:
         with:
           name: playwright-report
           path: apps/desktop/e2e-results/
+
+  package-linux:
+    name: Electron package smoke
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop app
+        run: pnpm --filter @open-recorder/desktop build
+
+      - name: Package Linux artifacts
+        run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --linux AppImage --x64
+
+      - name: Verify Linux package artifacts
+        env:
+          EXPECTED_PATTERNS: '["\\.AppImage$","^latest-linux\\.yml$"]'
+        run: |
+          node <<'NODE'
+          const { readdirSync, statSync } = require("node:fs");
+          const { join } = require("node:path");
+
+          const releaseDir = "apps/desktop/release";
+          const files = readdirSync(releaseDir)
+            .filter((name) => statSync(join(releaseDir, name)).isFile())
+            .sort();
+
+          console.log(files.join("\n"));
+
+          const patterns = JSON.parse(process.env.EXPECTED_PATTERNS);
+          for (const source of patterns) {
+            const regex = new RegExp(source);
+            if (!files.some((file) => regex.test(file))) {
+              console.error(`Missing packaging artifact matching ${source}`);
+              process.exit(1);
+            }
+          }
+          NODE

--- a/scripts/dispatch-release-build.mjs
+++ b/scripts/dispatch-release-build.mjs
@@ -13,8 +13,8 @@ function usage() {
 	console.log(`Usage: node scripts/dispatch-release-build.mjs [options]
 
 Dispatches the release PR GitHub Actions workflow. That workflow computes the
-next semantic version, updates the desktop version files, and opens or updates
-the release PR. Merging that PR triggers the actual Release Tauri App workflow.
+next semantic version, updates the Electron desktop release metadata, and opens
+or updates the release PR. Merging that PR triggers the actual release build.
 
 Options:
   --release-type VALUE     Release type: patch, minor, or major. Uses a selector if omitted.
@@ -271,7 +271,7 @@ async function main() {
 	if (desktopVersion) {
 		console.log(`Current desktop package version on ${ref}: ${desktopVersion}`);
 	}
-	console.log("The workflow will compute the next version, update version files in GitHub Actions, and open or update the release PR.");
+	console.log("The workflow will compute the next version, update Electron release files in GitHub Actions, and open or update the release PR.");
 
 	const confirmed = args.yes
 		? true
@@ -305,7 +305,7 @@ async function main() {
 
 	console.log("");
 	console.log("Workflow dispatched.");
-	console.log("GitHub Actions will compute the next version, create or update the release PR, and wait for that PR to be merged before publishing the release.");
+	console.log("GitHub Actions will compute the next version, create or update the release PR, and wait for that PR to be merged before packaging and publishing the Electron release.");
 	console.log(`Check status with: gh run list --repo ${repo} --workflow release-pr.yml --limit 5`);
 }
 

--- a/scripts/dispatch-release-build.zsh
+++ b/scripts/dispatch-release-build.zsh
@@ -1,6 +1,0 @@
-#!/bin/zsh
-
-set -euo pipefail
-
-script_dir="$(cd "$(dirname "$0")" && pwd)"
-exec node "$script_dir/dispatch-release-build.mjs" "$@"

--- a/scripts/prepare-release-pr.mjs
+++ b/scripts/prepare-release-pr.mjs
@@ -9,7 +9,6 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
 const desktopAppRoot = resolve(repoRoot, "apps", "desktop");
 const desktopPackageJsonPath = resolve(desktopAppRoot, "package.json");
-const tauriRoot = resolve(desktopAppRoot, "src-tauri");
 const releasePlanPath = resolve(repoRoot, ".github", "release-plan.json");
 
 process.chdir(repoRoot);
@@ -51,8 +50,8 @@ function parseArgs(argv) {
 			case "--help":
 				console.log(`Usage: node scripts/prepare-release-pr.mjs --release-type patch|minor|major [options]
 
-Prepares the next release bump inside GitHub Actions by updating the desktop
-version files and writing .github/release-plan.json.
+Prepares the next release bump inside GitHub Actions by updating the Electron
+desktop package version and writing .github/release-plan.json.
 
 Options:
   --release-type VALUE     Release type: patch, minor, or major.
@@ -159,28 +158,7 @@ function updateJsonVersion(filePath, nextVersion, spacing) {
 	writeFileSync(filePath, `${JSON.stringify(json, null, spacing)}\n`);
 }
 
-function updateTextVersion(filePath, pattern, replacement) {
-	const current = readFileSync(filePath, "utf8");
-	if (!current.match(pattern)) {
-		die(`Could not update version in ${filePath}`);
-	}
-
-	const next = current.replace(pattern, replacement);
-	writeFileSync(filePath, next);
-}
-
 function syncVersionFiles(nextVersion) {
-	updateTextVersion(
-		resolve(tauriRoot, "Cargo.toml"),
-		/^version = "\d+\.\d+\.\d+"$/m,
-		`version = "${nextVersion}"`,
-	);
-	updateJsonVersion(resolve(tauriRoot, "tauri.conf.json"), nextVersion, 2);
-	updateTextVersion(
-		resolve(tauriRoot, "Cargo.lock"),
-		/(\[\[package\]\]\s+name = "open-recorder"\s+version = ")\d+\.\d+\.\d+(")/m,
-		`$1${nextVersion}$2`,
-	);
 	updateJsonVersion(desktopPackageJsonPath, nextVersion, "\t");
 }
 

--- a/scripts/resolve-release-context.mjs
+++ b/scripts/resolve-release-context.mjs
@@ -143,6 +143,10 @@ function readReleasePlan() {
 	return JSON.parse(readFileSync(releasePlanPath, "utf8"));
 }
 
+function hasVersionChanged(previousVersion, currentVersion) {
+	return !previousVersion || previousVersion !== currentVersion;
+}
+
 const args = parseArgs(process.argv.slice(2));
 const currentVersion = currentPackageVersion();
 const defaultTagName = `v${currentVersion}`;
@@ -162,13 +166,16 @@ if (args.eventName === "workflow_dispatch") {
 	makeLatest = args.makeLatest || "true";
 } else if (args.eventName === "push") {
 	const previousVersion = previousPackageVersion(args.before);
-	shouldRelease = !previousVersion || previousVersion !== currentVersion;
+	shouldRelease = hasVersionChanged(previousVersion, currentVersion);
+
+	if (shouldRelease && !releasePlan) {
+		die("Push-triggered releases require .github/release-plan.json to match the desktop package version bump.");
+	}
 
 	if (releasePlan?.tagName) {
 		if (releasePlan.tagName !== defaultTagName) {
 			die(`release-plan tag ${releasePlan.tagName} does not match package version ${defaultTagName}`);
 		}
-
 		tagName = releasePlan.tagName;
 		releaseName = releasePlan.releaseName || `Open Recorder ${tagName}`;
 		releaseNotes = releasePlan.releaseNotes || "";


### PR DESCRIPTION
## Summary
- remove Tauri/src-tauri assumptions from the release PR and release helper scripts
- switch the release workflow to electron-builder packaging artifacts across macOS, Windows, and Linux AppImage
- add CI packaging smoke coverage in release preparation and PR test workflows

## Verification
- parsed the updated GitHub workflow YAML files with PyYAML
- ran 
- ran Usage: node scripts/dispatch-release-build.mjs [options]

Dispatches the release PR GitHub Actions workflow. That workflow computes the
next semantic version, updates the Electron desktop release metadata, and opens
or updates the release PR. Merging that PR triggers the actual release build.

Options:
  --release-type VALUE     Release type: patch, minor, or major. Uses a selector if omitted.
  --name VALUE             Optional release title override.
  --notes VALUE            Optional release notes body.
  --latest true|false      Whether the eventual release should be marked latest. Defaults to true.
  --yes                    Skip the interactive confirmation prompt.
  --ref VALUE              Git branch that contains the workflow file. Defaults to the current branch.
  --repo OWNER/REPO        GitHub repository slug. Defaults to the current origin remote.
  -h, --help               Show this help message.
- ran No release needed for apps/desktop/package.json version 0.0.31 in a clean verification clone after a release bump prep
- ran   • electron-builder  version=26.8.1 os=6.8.0-90-generic
  • loaded configuration  file=/home/user/open-recorder/apps/desktop/electron-builder.yml
  • detected workspace root for project using packageManager field  pm=pnpm config=pnpm@10.17.1 resolved=/home/user/open-recorder projectDir=/home/user/open-recorder/apps/desktop
  • executing @electron/rebuild  electronVersion=41.2.1 arch=x64 buildFromSource=false workspaceRoot=/home/user/open-recorder projectDir=./ appDir=./
  • installing native dependencies  arch=x64
  • completed installing native dependencies
  • packaging       platform=linux arch=x64 electron=41.2.1 appOutDir=release/linux-unpacked
  • searching for node modules  pm=pnpm searchDir=/home/user/open-recorder/apps/desktop
  • building        target=AppImage arch=x64 file=release/Open Recorder-0.0.31.AppImage locally and confirmed it produced  and 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
