### PR TITLE
Prepare release v0.0.32

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.31",
-  "releaseName": "Open Recorder v0.0.31",
+  "tagName": "v0.0.32",
+  "releaseName": "Open Recorder v0.0.32",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.31",
+	"version": "0.0.32",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Patch release bumping desktop app version from `0.0.31` to `0.0.32`
- Updates `apps/desktop/package.json` version field
- Updates `.github/release-plan.json` with new tag and release name

## Release Summary
- Release type: patch
- Base version: 0.0.31 (apps/desktop/package.json)
- Next version: 0.0.32
- Tag: v0.0.32
- Release title: Open Recorder v0.0.32
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

## Test plan
- [x] Build passes (`pnpm run build` succeeds)
- [x] Version correctly bumped in `apps/desktop/package.json`
- [x] Release plan updated in `.github/release-plan.json`

https://claude.ai/code/session_01A9aTtDDhRB5HtJjzxSsMkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9aTtDDhRB5HtJjzxSsMkr)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
