### PR TITLE
Prepare release v0.0.33

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.32",
-  "releaseName": "Open Recorder v0.0.32",
+  "tagName": "v0.0.33",
+  "releaseName": "Open Recorder v0.0.33",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.32",
+	"version": "0.0.33",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Bump desktop app version from `0.0.32` to `0.0.33` (patch release)
- Update `apps/desktop/package.json` and `.github/release-plan.json` with new version

## Test plan
- [x] Verified `pnpm run build` passes successfully with the new version
- [ ] Confirm release workflow triggers correctly after merge

https://claude.ai/code/session_01XpeWE9hytrFi7b8oQWjadm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpeWE9hytrFi7b8oQWjadm)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/imbhargav5/open-recorder/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->