### PR TITLE
Prepare release v0.0.34

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.33",
-  "releaseName": "Open Recorder v0.0.33",
+  "tagName": "v0.0.34",
+  "releaseName": "Open Recorder v0.0.34",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.33",
+	"version": "0.0.34",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Patch version bump from `0.0.33` to `0.0.34` in `apps/desktop/package.json`
- Updated `.github/release-plan.json` with new tag `v0.0.34`
- Build verified passing before version bump

## Release Summary
- Release type: patch
- Base version: 0.0.33 (apps/desktop/package.json)
- Next version: 0.0.34
- Tag: v0.0.34
- Release title: Open Recorder v0.0.34
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release.

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Version bumped correctly in `apps/desktop/package.json`
- [x] `.github/release-plan.json` updated with correct tag and release name

https://claude.ai/code/session_01XL2YfaNJJRJNQxRH7bNi18

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL2YfaNJJRJNQxRH7bNi18)_