### PR TITLE
Fix display capture and cursor overlay defaults

### DIFF
--- a/apps/desktop/electron/display-media-source.test.ts
+++ b/apps/desktop/electron/display-media-source.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveDisplayMediaSource } from "./display-media-source";
+import type { SelectedSource } from "./state";
+
+type TestCapturerSource = Parameters<typeof resolveDisplayMediaSource>[1][number];
+
+function screenSource(id: string, displayId: string, name = "Screen"): TestCapturerSource {
+	return { id, display_id: displayId, name };
+}
+
+function windowSource(id: string, name = "Window"): TestCapturerSource {
+	return { id, display_id: "", name };
+}
+
+describe("resolveDisplayMediaSource", () => {
+	it("prefers the stable display id over a stale sequential screen id", () => {
+		const selectedSource: SelectedSource = {
+			id: "screen:1:0",
+			name: "External Display",
+			sourceType: "screen",
+			display_id: "200",
+		};
+		const sources = [
+			screenSource("screen:1:0", "100", "Built-in Display"),
+			screenSource("screen:2:0", "200", "External Display"),
+		];
+
+		expect(resolveDisplayMediaSource(selectedSource, sources)).toBe(sources[1]);
+	});
+
+	it("matches windows by exact source id", () => {
+		const selectedSource: SelectedSource = {
+			id: "window:123:0",
+			name: "Demo Window",
+			sourceType: "window",
+		};
+		const sources = [screenSource("screen:1:0", "100"), windowSource("window:123:0")];
+
+		expect(resolveDisplayMediaSource(selectedSource, sources)).toBe(sources[1]);
+	});
+
+	it("falls back to the first screen when no selected source matches", () => {
+		const sources = [windowSource("window:123:0"), screenSource("screen:1:0", "100")];
+
+		expect(resolveDisplayMediaSource(null, sources)).toBe(sources[1]);
+	});
+});

--- a/apps/desktop/electron/display-media-source.ts
+++ b/apps/desktop/electron/display-media-source.ts
@@ -1,0 +1,56 @@
+import type { SelectedSource } from "./state.js";
+
+type CapturerSource = Pick<Electron.DesktopCapturerSource, "display_id" | "id" | "name">;
+
+function isScreenSource(source: Pick<CapturerSource, "id">): boolean {
+	return source.id.startsWith("screen:");
+}
+
+function isWindowSource(source: Pick<CapturerSource, "id">): boolean {
+	return source.id.startsWith("window:");
+}
+
+function selectedSourceType(source: SelectedSource): "screen" | "window" {
+	if (source.sourceType === "window" || source.id.startsWith("window:")) {
+		return "window";
+	}
+	return "screen";
+}
+
+function selectedDisplayId(source: SelectedSource): string | undefined {
+	const displayId = source.displayId ?? source.display_id;
+	if (typeof displayId !== "string") return undefined;
+
+	const trimmed = displayId.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function resolveDisplayMediaSource(
+	selectedSource: SelectedSource | null | undefined,
+	sources: CapturerSource[],
+): CapturerSource | undefined {
+	if (selectedSource) {
+		if (selectedSourceType(selectedSource) === "screen") {
+			const displayId = selectedDisplayId(selectedSource);
+			if (displayId) {
+				const displayMatch = sources.find(
+					(source) => isScreenSource(source) && source.display_id === displayId,
+				);
+				if (displayMatch) return displayMatch;
+			}
+		}
+
+		const idMatch = sources.find((source) => source.id === selectedSource.id);
+		if (idMatch) return idMatch;
+
+		if (selectedSourceType(selectedSource) === "window" && selectedSource.windowId !== undefined) {
+			const windowPrefix = `window:${selectedSource.windowId}:`;
+			const windowMatch = sources.find(
+				(source) => isWindowSource(source) && source.id.startsWith(windowPrefix),
+			);
+			if (windowMatch) return windowMatch;
+		}
+	}
+
+	return sources.find(isScreenSource) ?? sources[0];
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,6 +31,7 @@ import { registerScreenshotHandlers } from "./handlers/screenshot.js";
 import { registerWindowMgmtHandlers } from "./handlers/window-mgmt.js";
 import { isEditorWindowLabel } from "./window-routing.js";
 import { AppUpdaterService } from "./updater.js";
+import { resolveDisplayMediaSource } from "./display-media-source.js";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -226,16 +227,12 @@ app.whenReady().then(() => {
 	// to the WebRTC pipeline. If nothing is selected, fall back to the first screen.
 	session.defaultSession.setDisplayMediaRequestHandler(
 		async (_request, callback) => {
-			const wantedId = appState.selectedSource?.id;
 			try {
 				const sources = await desktopCapturer.getSources({
 					types: ["screen", "window"],
 					thumbnailSize: { width: 0, height: 0 },
 				});
-				const match =
-					(wantedId && sources.find((s) => s.id === wantedId)) ??
-					sources.find((s) => s.id.startsWith("screen:")) ??
-					sources[0];
+				const match = resolveDisplayMediaSource(appState.selectedSource, sources);
 				if (!match) {
 					callback({});
 					return;

--- a/apps/desktop/electron/state.ts
+++ b/apps/desktop/electron/state.ts
@@ -36,6 +36,7 @@ export interface RecordingSession {
 	facecamOffsetMs?: number;
 	facecamSettings?: FacecamSettings;
 	sourceName?: string;
+	showCursorOverlay?: boolean;
 }
 
 export interface CursorTelemetryPoint {

--- a/apps/desktop/src/__tests__/types/backend-types.typecheck.ts
+++ b/apps/desktop/src/__tests__/types/backend-types.typecheck.ts
@@ -15,10 +15,10 @@
  * Run: pnpm typecheck
  */
 
-import type { RecordingSession, FacecamSettings } from "@/lib/recordingSession";
-import type { ShortcutsConfig, ShortcutBinding } from "@/lib/shortcuts";
 import type { DesktopSource } from "@/components/launch/sourceSelectorState";
-import type { SourceListOptions, NativeRecordingOptions } from "@/lib/backend";
+import type { NativeRecordingOptions, SourceListOptions } from "@/lib/backend";
+import type { FacecamSettings, RecordingSession } from "@/lib/recordingSession";
+import type { ShortcutBinding, ShortcutsConfig } from "@/lib/shortcuts";
 
 // ─── RecordingSession ────────────────────────────────────────────────────────
 
@@ -32,6 +32,7 @@ void (session.facecamVideoPath satisfies string | undefined);
 void (session.facecamOffsetMs satisfies number | undefined);
 void (session.facecamSettings satisfies FacecamSettings | undefined);
 void (session.sourceName satisfies string | undefined);
+void (session.showCursorOverlay satisfies boolean | undefined);
 
 // @ts-expect-error: 'nonExistentField' does not exist on RecordingSession
 void session.nonExistentField;

--- a/apps/desktop/src/atoms/stateDefaults.test.ts
+++ b/apps/desktop/src/atoms/stateDefaults.test.ts
@@ -226,7 +226,7 @@ describe("atom defaults", () => {
 			"video cursor settings",
 			cursorSettingsAtom,
 			{
-				showCursor: true,
+				showCursor: false,
 				loopCursor: false,
 				cursorSize: 3,
 				cursorSmoothing: 0.67,

--- a/apps/desktop/src/atoms/videoEditor.jotai.test.ts
+++ b/apps/desktop/src/atoms/videoEditor.jotai.test.ts
@@ -209,8 +209,8 @@ describe("videoEditor atoms – cursor defaults", () => {
 		store = createStore();
 	});
 
-	it("cursorSettingsAtom.showCursor defaults to true", () => {
-		expect(store.get(cursorSettingsAtom).showCursor).toBe(true);
+	it("cursorSettingsAtom.showCursor defaults to false", () => {
+		expect(store.get(cursorSettingsAtom).showCursor).toBe(false);
 	});
 
 	it("cursorSettingsAtom.loopCursor defaults to false", () => {

--- a/apps/desktop/src/atoms/videoEditor.ts
+++ b/apps/desktop/src/atoms/videoEditor.ts
@@ -85,7 +85,7 @@ export const paddingAtom = atom<number>(50);
 
 // --- Cursor settings (composite) ---
 export const cursorSettingsAtom = atom<CursorSettings>({
-	showCursor: true,
+	showCursor: false,
 	loopCursor: false,
 	cursorSize: DEFAULT_CURSOR_SIZE,
 	cursorSmoothing: DEFAULT_CURSOR_SMOOTHING,

--- a/apps/desktop/src/components/video-editor/VideoEditor.tsx
+++ b/apps/desktop/src/components/video-editor/VideoEditor.tsx
@@ -514,7 +514,7 @@ export default function VideoEditor() {
 	const setFacecamVideoPath = useSetAtom(facecamVideoPathAtom);
 	const [facecamPlaybackPath, setFacecamPlaybackPath] = useAtom(facecamPlaybackPathAtom);
 	const [facecamOffsetMs, setFacecamOffsetMs] = useAtom(facecamOffsetMsAtom);
-	const setCurrentProjectPath = useSetAtom(currentProjectPathAtom);
+	const [currentProjectPath, setCurrentProjectPath] = useAtom(currentProjectPathAtom);
 	const [loading, setLoading] = useAtom(videoLoadingAtom);
 	const [playbackReady, setPlaybackReady] = useAtom(playbackReadyAtom);
 	const [error, setError] = useAtom(videoErrorAtom);
@@ -592,6 +592,19 @@ export default function VideoEditor() {
 	const autoSuggestedVideoPathRef = useRef<string | null>(null);
 	const pendingExportSaveRef = useRef<PendingExportSave | null>(null);
 	const playbackOverlayWasVisibleRef = useRef(false);
+	const sessionCursorOverlayDefaultAppliedRef = useRef<string | null>(null);
+
+	const applyCursorOverlayDefaultForSession = useCallback(
+		(sourcePath: string, showCursorOverlay: boolean) => {
+			sessionCursorOverlayDefaultAppliedRef.current = sourcePath;
+			setCursorSettings((current) =>
+				current.showCursor === showCursorOverlay
+					? current
+					: { ...current, showCursor: showCursorOverlay },
+			);
+		},
+		[setCursorSettings],
+	);
 
 	const { handleUndo, handleRedo } = useVideoEditorHistory({
 		zoomRegions,
@@ -800,6 +813,10 @@ export default function VideoEditor() {
 							defaultEnabled: Boolean(nextFacecamPath),
 						}),
 					);
+					applyCursorOverlayDefaultForSession(
+						initialState.sourcePath,
+						initialState.showCursorOverlay,
+					);
 					setCurrentProjectPath(null);
 					setLastSavedSnapshot(null);
 				} else if (initialState.kind === "video") {
@@ -828,7 +845,30 @@ export default function VideoEditor() {
 		}
 
 		loadInitialData();
-	}, [applyLoadedProject, resetPlaybackStateForSourceChange, resolvePlaybackPaths]);
+	}, [
+		applyLoadedProject,
+		applyCursorOverlayDefaultForSession,
+		resetPlaybackStateForSourceChange,
+		resolvePlaybackPaths,
+	]);
+
+	useEffect(() => {
+		if (
+			!videoSourcePath ||
+			currentProjectPath ||
+			sessionCursorOverlayDefaultAppliedRef.current === videoSourcePath
+		) {
+			return;
+		}
+
+		const searchParams = new URLSearchParams(window.location.search);
+		if (
+			searchParams.get("editorMode") === "session" &&
+			searchParams.get("showCursorOverlay") !== "true"
+		) {
+			applyCursorOverlayDefaultForSession(videoSourcePath, false);
+		}
+	}, [applyCursorOverlayDefaultForSession, currentProjectPath, videoSourcePath]);
 
 	const saveProject = useCallback(
 		async (forceSaveAs: boolean) => {

--- a/apps/desktop/src/components/video-editor/VideoPlayback.test.tsx
+++ b/apps/desktop/src/components/video-editor/VideoPlayback.test.tsx
@@ -415,6 +415,25 @@ describe("VideoPlayback", () => {
 		await harness.unmount();
 	});
 
+	it("reports ready when a local video is already decoded before media events are observed", async () => {
+		const onReadyChange = vi.fn();
+		const harness = await renderPlayback({ onReadyChange });
+		const video = getPrimaryVideo(harness.container);
+
+		defineMediaProperty(video, "videoWidth", 1920);
+		defineMediaProperty(video, "videoHeight", 1080);
+		defineMediaProperty(video, "duration", 12);
+		defineMediaProperty(video, "readyState", HTMLMediaElement.HAVE_CURRENT_DATA);
+
+		await harness.rerender({
+			videoPath: "asset://localhost/video-fast-local.webm",
+		});
+		await flushEffects();
+
+		expect(onReadyChange).toHaveBeenLastCalledWith(true);
+		await harness.unmount();
+	});
+
 	it("does not block first paint if cursor asset preloading fails", async () => {
 		mockState.preloadCursorAssets.mockRejectedValue(new Error("cursor assets unavailable"));
 		vi.spyOn(console, "warn").mockImplementation(() => undefined);

--- a/apps/desktop/src/components/video-editor/VideoPlayback.tsx
+++ b/apps/desktop/src/components/video-editor/VideoPlayback.tsx
@@ -637,6 +637,40 @@ const VideoPlayback = memo(
 				}
 			}, []);
 
+			const scheduleFirstFrameTimeout = useCallback(
+				(video: HTMLVideoElement) => {
+					clearFirstFrameTimeout();
+					firstFrameTimeoutRef.current = window.setTimeout(() => {
+						if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+							onError("Timed out while loading the first video frame");
+						}
+					}, FIRST_FRAME_TIMEOUT_MS);
+				},
+				[clearFirstFrameTimeout, onError],
+			);
+
+			const syncPrimaryVideoReadiness = useCallback(
+				(video: HTMLVideoElement) => {
+					const hasDimensions = video.videoWidth > 0 && video.videoHeight > 0;
+					if (!hasDimensions) {
+						return;
+					}
+
+					setMetadataReady(true);
+
+					if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+						clearFirstFrameTimeout();
+						setFirstFrameReady(true);
+						return;
+					}
+
+					if (video.readyState >= HTMLMediaElement.HAVE_METADATA) {
+						scheduleFirstFrameTimeout(video);
+					}
+				},
+				[clearFirstFrameTimeout, scheduleFirstFrameTimeout, setFirstFrameReady, setMetadataReady],
+			);
+
 			useEffect(() => {
 				zoomRegionsRef.current = zoomRegions;
 			}, [zoomRegions]);
@@ -988,7 +1022,39 @@ const VideoPlayback = memo(
 				setFirstFrameReady(false);
 				clearFirstFrameTimeout();
 				cursorOverlayRef.current?.reset();
-			}, [clearFirstFrameTimeout, videoPath]);
+				syncPrimaryVideoReadiness(video);
+			}, [
+				clearFirstFrameTimeout,
+				setFirstFrameReady,
+				setMetadataReady,
+				syncPrimaryVideoReadiness,
+				videoPath,
+			]);
+
+			useEffect(() => {
+				if (firstFrameReady) {
+					return;
+				}
+
+				const video = videoRef.current;
+				if (!video) {
+					return;
+				}
+
+				syncPrimaryVideoReadiness(video);
+
+				if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+					return;
+				}
+
+				const intervalId = window.setInterval(() => {
+					syncPrimaryVideoReadiness(video);
+				}, 250);
+
+				return () => {
+					window.clearInterval(intervalId);
+				};
+			}, [firstFrameReady, syncPrimaryVideoReadiness, videoPath]);
 
 			useEffect(() => {
 				void facecamVideoPath;
@@ -1525,11 +1591,7 @@ const VideoPlayback = memo(
 					return;
 				}
 
-				firstFrameTimeoutRef.current = window.setTimeout(() => {
-					if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-						onError("Timed out while loading the first video frame");
-					}
-				}, FIRST_FRAME_TIMEOUT_MS);
+				scheduleFirstFrameTimeout(video);
 			};
 
 			const handleLoadedData = (e: React.SyntheticEvent<HTMLVideoElement, Event>) => {

--- a/apps/desktop/src/components/video-editor/editorWindowParams.test.ts
+++ b/apps/desktop/src/components/video-editor/editorWindowParams.test.ts
@@ -14,6 +14,7 @@ describe("editorWindowParams", () => {
 			facecamOffsetMs: 240,
 			facecamSettings: { enabled: true, shape: "circle" },
 			sourceName: "Browser Window",
+			showCursorOverlay: true,
 		});
 
 		expect(parseEditorWindowLaunchParams(query)).toEqual({
@@ -23,6 +24,23 @@ describe("editorWindowParams", () => {
 			facecamOffsetMs: 240,
 			facecamSettings: { enabled: true, shape: "circle" },
 			sourceName: "Browser Window",
+			showCursorOverlay: true,
+		});
+	});
+
+	it("defaults legacy recording session queries to the non-doubled cursor behavior", () => {
+		expect(
+			parseEditorWindowLaunchParams(
+				"?windowType=editor&editorMode=session&videoPath=file%3A%2F%2F%2FUsers%2Fdemo%2Fsession.mov",
+			),
+		).toEqual({
+			mode: "session",
+			videoPath: "/Users/demo/session.mov",
+			facecamVideoPath: null,
+			facecamOffsetMs: 0,
+			facecamSettings: undefined,
+			sourceName: null,
+			showCursorOverlay: false,
 		});
 	});
 

--- a/apps/desktop/src/components/video-editor/editorWindowParams.ts
+++ b/apps/desktop/src/components/video-editor/editorWindowParams.ts
@@ -18,6 +18,7 @@ export type EditorWindowLaunchParams =
 			facecamOffsetMs?: number;
 			facecamSettings?: Partial<FacecamSettings> | null;
 			sourceName?: string | null;
+			showCursorOverlay?: boolean;
 	  };
 
 function normalizeSourceName(value: string | null | undefined) {
@@ -47,6 +48,16 @@ function parseJson<T>(value: string | null): T | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+function parseBoolean(value: string | null): boolean | undefined {
+	if (value === "true") {
+		return true;
+	}
+	if (value === "false") {
+		return false;
+	}
+	return undefined;
 }
 
 function basenameWithoutExtension(filePath: string) {
@@ -81,6 +92,9 @@ export function buildEditorWindowQuery(params: EditorWindowLaunchParams) {
 		}
 		if (params.facecamSettings) {
 			searchParams.set("facecamSettings", JSON.stringify(params.facecamSettings));
+		}
+		if (typeof params.showCursorOverlay === "boolean") {
+			searchParams.set("showCursorOverlay", String(params.showCursorOverlay));
 		}
 	}
 
@@ -126,6 +140,7 @@ export function parseEditorWindowLaunchParams(
 			facecamOffsetMs: Number.isFinite(rawOffset) ? rawOffset : undefined,
 			facecamSettings: parseJson<Partial<FacecamSettings>>(searchParams.get("facecamSettings")),
 			sourceName: normalizeSourceName(searchParams.get("sourceName")) ?? null,
+			showCursorOverlay: parseBoolean(searchParams.get("showCursorOverlay")) ?? false,
 		};
 	}
 

--- a/apps/desktop/src/components/video-editor/projectPersistence.ts
+++ b/apps/desktop/src/components/video-editor/projectPersistence.ts
@@ -283,7 +283,7 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 		backgroundBlur: normalizedBackgroundBlur,
 		zoomMotionBlur: normalizedZoomMotionBlur,
 		connectZooms: typeof editor.connectZooms === "boolean" ? editor.connectZooms : true,
-		showCursor: typeof editor.showCursor === "boolean" ? editor.showCursor : true,
+		showCursor: typeof editor.showCursor === "boolean" ? editor.showCursor : false,
 		loopCursor: typeof editor.loopCursor === "boolean" ? editor.loopCursor : false,
 		cursorSize: isFiniteNumber(editor.cursorSize)
 			? clamp(editor.cursorSize, 0.5, 10)

--- a/apps/desktop/src/components/video-editor/videoEditorLoadState.test.ts
+++ b/apps/desktop/src/components/video-editor/videoEditorLoadState.test.ts
@@ -97,6 +97,7 @@ describe("loadInitialVideoEditorState", () => {
 			facecamOffsetMs: 240,
 			facecamSettings: undefined,
 			sourceName: "Display 1",
+			showCursorOverlay: false,
 		});
 
 		expect(loadCurrentProjectFile).not.toHaveBeenCalled();
@@ -161,6 +162,7 @@ describe("loadInitialVideoEditorState", () => {
 			facecamOffsetMs: 240,
 			facecamSettings: { enabled: true },
 			sourceName: null,
+			showCursorOverlay: false,
 		});
 	});
 

--- a/apps/desktop/src/components/video-editor/videoEditorLoadState.ts
+++ b/apps/desktop/src/components/video-editor/videoEditorLoadState.ts
@@ -13,6 +13,7 @@ type RecordingSessionLike = {
 	facecamOffsetMs?: number | null;
 	facecamSettings?: Partial<FacecamSettings> | null;
 	sourceName?: string | null;
+	showCursorOverlay?: boolean | null;
 } | null;
 
 export type InitialVideoEditorLoadResult =
@@ -28,6 +29,7 @@ export type InitialVideoEditorLoadResult =
 			facecamOffsetMs: number;
 			facecamSettings: Partial<FacecamSettings> | null | undefined;
 			sourceName: string | null;
+			showCursorOverlay: boolean;
 	  }
 	| {
 			kind: "video";
@@ -95,6 +97,7 @@ export async function loadInitialVideoEditorState({
 			facecamOffsetMs: launchParams.facecamOffsetMs ?? 0,
 			facecamSettings: launchParams.facecamSettings,
 			sourceName: launchParams.sourceName ?? null,
+			showCursorOverlay: launchParams.showCursorOverlay ?? false,
 		};
 	}
 
@@ -128,6 +131,7 @@ export async function loadInitialVideoEditorState({
 			facecamOffsetMs: session.facecamOffsetMs ?? 0,
 			facecamSettings: session.facecamSettings,
 			sourceName: typeof session.sourceName === "string" ? session.sourceName : null,
+			showCursorOverlay: session.showCursorOverlay === true,
 		};
 	}
 

--- a/apps/desktop/src/hooks/useScreenRecorder.ts
+++ b/apps/desktop/src/hooks/useScreenRecorder.ts
@@ -336,12 +336,17 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	}, []);
 
 	const buildRecordingSession = useCallback(
-		(screenVideoPath: string, facecamResult: FacecamCaptureResult): RecordingSession => ({
+		(
+			screenVideoPath: string,
+			facecamResult: FacecamCaptureResult,
+			showCursorOverlay: boolean,
+		): RecordingSession => ({
 			screenVideoPath,
 			...(facecamResult?.path ? { facecamVideoPath: facecamResult.path } : {}),
 			...(facecamResult?.offsetMs !== undefined ? { facecamOffsetMs: facecamResult.offsetMs } : {}),
 			facecamSettings: createDefaultFacecamSettings(Boolean(facecamResult?.path)),
 			...(selectedSourceName.current ? { sourceName: selectedSourceName.current } : {}),
+			showCursorOverlay,
 		}),
 		[],
 	);
@@ -527,7 +532,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				const facecamResult = await facecamResultPromise.catch(() => null);
 				if (!mountedRef.current) return;
 
-				const recordingSession = buildRecordingSession(finalPath, facecamResult);
+				const recordingSession = buildRecordingSession(finalPath, facecamResult, true);
 				await backend.setCurrentVideoPath(finalPath).catch(() => null);
 				if (!mountedRef.current) return;
 
@@ -542,6 +547,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						facecamOffsetMs: recordingSession.facecamOffsetMs,
 						facecamSettings: recordingSession.facecamSettings,
 						sourceName: recordingSession.sourceName,
+						showCursorOverlay: recordingSession.showCursorOverlay,
 					}),
 				);
 			})();
@@ -948,7 +954,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						? await pendingFacecamResult.current
 						: null;
 					pendingFacecamResult.current = null;
-					const recordingSession = buildRecordingSession(storedPath, facecamResult);
+					const recordingSession = buildRecordingSession(
+						storedPath,
+						facecamResult,
+						platform !== "darwin",
+					);
 
 					await backend.setCurrentRecordingSession(recordingSession);
 					await backend.switchToEditor(
@@ -959,6 +969,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 							facecamOffsetMs: recordingSession.facecamOffsetMs,
 							facecamSettings: recordingSession.facecamSettings,
 							sourceName: recordingSession.sourceName,
+							showCursorOverlay: recordingSession.showCursorOverlay,
 						}),
 					);
 				} catch (error) {

--- a/apps/desktop/src/lib/recordingSession.ts
+++ b/apps/desktop/src/lib/recordingSession.ts
@@ -20,6 +20,7 @@ export interface RecordingSession {
 	facecamOffsetMs?: number;
 	facecamSettings?: FacecamSettings;
 	sourceName?: string;
+	showCursorOverlay?: boolean;
 }
 
 export interface PersistedRecordingSession extends RecordingSession {
@@ -154,6 +155,8 @@ export function normalizeRecordingSession(
 			typeof candidate.sourceName === "string" && candidate.sourceName.trim()
 				? candidate.sourceName
 				: undefined,
+		showCursorOverlay:
+			typeof candidate.showCursorOverlay === "boolean" ? candidate.showCursorOverlay : undefined,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Resolve Electron display media sources by stable display id so multi-display captures use the selected screen
- Recover video readiness when local files are already decoded before load events are observed
- Default cursor overlays off for Electron/macOS recordings to avoid double cursors

## Tests
- pnpm --filter @open-recorder/desktop exec vitest --run src/atoms/videoEditor.jotai.test.ts src/atoms/stateDefaults.test.ts src/components/video-editor/projectPersistence.test.ts src/components/video-editor/editorWindowParams.test.ts src/components/video-editor/videoEditorLoadState.test.ts src/hooks/useScreenRecorder.test.tsx src/hooks/useScreenRecorder.facecamPendingWrites.test.tsx src/components/video-editor/VideoPlayback.test.tsx electron/display-media-source.test.ts
- pnpm --filter @open-recorder/desktop typecheck
- pnpm --filter @open-recorder/desktop exec biome check src/atoms/videoEditor.ts src/atoms/videoEditor.jotai.test.ts src/atoms/stateDefaults.test.ts src/components/video-editor/projectPersistence.ts src/components/video-editor/projectPersistence.test.ts src/components/video-editor/editorWindowParams.ts src/components/video-editor/editorWindowParams.test.ts src/components/video-editor/videoEditorLoadState.ts src/components/video-editor/videoEditorLoadState.test.ts src/lib/recordingSession.ts src/hooks/useScreenRecorder.ts src/__tests__/types/backend-types.typecheck.ts electron/state.ts