### PR TITLE
[codex] Improve desktop editor UI

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -71,6 +71,7 @@
 		"mp4box": "^2.2.0",
 		"pixi-filters": "^6.1.5",
 		"pixi.js": "^8.14.0",
+		"radix-ui": "^1.4.3",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5",
 		"react-icons": "^5.5.0",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,16 +1,17 @@
-import { invoke } from "@/lib/electronBridge";
 import { useAtom } from "jotai";
-import { useEffect, type ReactElement } from "react";
+import { type ReactElement, useEffect } from "react";
+import { invoke } from "@/lib/electronBridge";
+import { appNameAtom, windowTypeAtom } from "./atoms/app";
 import { AppUpdaterDialog } from "./components/AppUpdaterDialog";
 import ImageEditor from "./components/image-editor/ImageEditor";
 import { LaunchWindow } from "./components/launch/LaunchWindow";
 import { SourceSelector } from "./components/launch/SourceSelector";
+import { TooltipProvider } from "./components/ui/tooltip";
 import { ShortcutsConfigDialog } from "./components/video-editor/ShortcutsConfigDialog";
 import VideoEditor from "./components/video-editor/VideoEditor";
 import { useI18n } from "./contexts/I18nContext";
 import { ShortcutsProvider } from "./contexts/ShortcutsContext";
 import { loadAllCustomFonts } from "./lib/customFonts";
-import { appNameAtom, windowTypeAtom } from "./atoms/app";
 
 export default function App() {
 	const [windowType, setWindowType] = useAtom(windowTypeAtom);
@@ -26,8 +27,14 @@ export default function App() {
 			document.body.style.background = "transparent";
 			document.documentElement.style.background = "transparent";
 			document.getElementById("root")?.style.setProperty("background", "transparent");
-			document.documentElement.classList.add("dark");
 		}
+		document.documentElement.classList.toggle(
+			"dark",
+			type === "hud-overlay" ||
+				type === "source-selector" ||
+				type === "editor" ||
+				type === "image-editor",
+		);
 
 		// Load custom fonts on app initialization
 		loadAllCustomFonts().catch((error) => {
@@ -93,11 +100,11 @@ export default function App() {
 		windowType === "editor" || windowType === "image-editor" || windowType === "";
 
 	return (
-		<>
+		<TooltipProvider delayDuration={350}>
 			{content}
 			{shouldRenderUpdater ? (
 				<AppUpdaterDialog enableAutoCheck={windowType !== "image-editor"} />
 			) : null}
-		</>
+		</TooltipProvider>
 	);
 }

--- a/apps/desktop/src/__tests__/integration/multi-window-isolation.test.ts
+++ b/apps/desktop/src/__tests__/integration/multi-window-isolation.test.ts
@@ -9,6 +9,7 @@
 import { createStore } from "jotai/vanilla";
 import { describe, expect, it } from "vitest";
 import { appNameAtom, isMacOSAtom, windowTypeAtom } from "@/atoms/app";
+import { createDefaultZoomEasing } from "@/components/video-editor/types";
 import {
 	imageBackgroundTypeAtom,
 	imageBorderRadiusAtom,
@@ -208,7 +209,14 @@ describe("multi-window isolation – video editor atoms", () => {
 	it("zoomRegionsAtom is independent per store", () => {
 		const { storeA, storeB } = makeTwoStores();
 		storeA.set(zoomRegionsAtom, [
-			{ id: "z1", startMs: 0, endMs: 2000, depth: 2, focus: { cx: 0.5, cy: 0.5 } },
+			{
+				id: "z1",
+				startMs: 0,
+				endMs: 2000,
+				depth: 2,
+				focus: { cx: 0.5, cy: 0.5 },
+				...createDefaultZoomEasing(),
+			},
 		]);
 		expect(storeB.get(zoomRegionsAtom)).toHaveLength(0);
 	});

--- a/apps/desktop/src/__tests__/integration/video-editor-workflow.test.ts
+++ b/apps/desktop/src/__tests__/integration/video-editor-workflow.test.ts
@@ -7,6 +7,7 @@
 
 import { createStore } from "jotai/vanilla";
 import { describe, expect, it } from "vitest";
+import { createDefaultZoomEasing } from "@/components/video-editor/types";
 import {
 	annotationRegionsAtom,
 	aspectRatioAtom,
@@ -265,7 +266,14 @@ describe("video editor – zoom regions", () => {
 	it("adding zoom region updates zoomRegionsAtom", () => {
 		const store = makeFreshStore();
 		store.set(zoomRegionsAtom, [
-			{ id: "zoom-1", startMs: 0, endMs: 3000, depth: 3, focus: { cx: 0.5, cy: 0.5 } },
+			{
+				id: "zoom-1",
+				startMs: 0,
+				endMs: 3000,
+				depth: 3,
+				focus: { cx: 0.5, cy: 0.5 },
+				...createDefaultZoomEasing(),
+			},
 		]);
 		expect(store.get(zoomRegionsAtom)).toHaveLength(1);
 	});

--- a/apps/desktop/src/atoms/videoEditor.jotai.test.ts
+++ b/apps/desktop/src/atoms/videoEditor.jotai.test.ts
@@ -10,6 +10,7 @@
 
 import { createStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultZoomEasing } from "@/components/video-editor/types";
 import {
 	addCustomFontDialogOpenAtom,
 	addCustomFontImportUrlAtom,
@@ -427,7 +428,14 @@ describe("videoEditor atoms – mutations", () => {
 
 	it("can add a zoom region", () => {
 		store.set(zoomRegionsAtom, [
-			{ id: "z1", startMs: 0, endMs: 2000, depth: 2, focus: { cx: 0.5, cy: 0.5 } },
+			{
+				id: "z1",
+				startMs: 0,
+				endMs: 2000,
+				depth: 2,
+				focus: { cx: 0.5, cy: 0.5 },
+				...createDefaultZoomEasing(),
+			},
 		]);
 		expect(store.get(zoomRegionsAtom)).toHaveLength(1);
 		expect(store.get(zoomRegionsAtom)[0].id).toBe("z1");
@@ -481,7 +489,14 @@ describe("videoEditor atoms – store isolation", () => {
 		const storeA = createStore();
 		const storeB = createStore();
 		storeA.set(zoomRegionsAtom, [
-			{ id: "z1", startMs: 0, endMs: 1000, depth: 1, focus: { cx: 0.5, cy: 0.5 } },
+			{
+				id: "z1",
+				startMs: 0,
+				endMs: 1000,
+				depth: 1,
+				focus: { cx: 0.5, cy: 0.5 },
+				...createDefaultZoomEasing(),
+			},
 		]);
 		expect(storeB.get(zoomRegionsAtom)).toHaveLength(0);
 	});
@@ -522,7 +537,14 @@ describe("videoEditor atoms – subscriptions", () => {
 
 		store.set(zoomRegionsAtom, []);
 		store.set(zoomRegionsAtom, [
-			{ id: "z1", startMs: 0, endMs: 500, depth: 1, focus: { cx: 0.5, cy: 0.5 } },
+			{
+				id: "z1",
+				startMs: 0,
+				endMs: 500,
+				depth: 1,
+				focus: { cx: 0.5, cy: 0.5 },
+				...createDefaultZoomEasing(),
+			},
 		]);
 
 		expect(listener).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/atoms/videoEditor.test.ts
+++ b/apps/desktop/src/atoms/videoEditor.test.ts
@@ -1,11 +1,12 @@
 import { createStore } from "jotai/vanilla";
 import { describe, expect, it } from "vitest";
-import type {
-	AnnotationRegion,
-	CropRegion,
-	SpeedRegion,
-	TrimRegion,
-	ZoomRegion,
+import {
+	createDefaultZoomEasing,
+	type AnnotationRegion,
+	type CropRegion,
+	type SpeedRegion,
+	type TrimRegion,
+	type ZoomRegion,
 } from "@/components/video-editor/types";
 import type { ExportProgress } from "@/lib/exporter";
 import type { AspectRatio } from "@/utils/aspectRatioUtils";
@@ -318,6 +319,7 @@ describe("videoEditor atoms – regions and selections", () => {
 			endMs: 1000,
 			depth: 2,
 			focus: { cx: 0.5, cy: 0.5 },
+			...createDefaultZoomEasing(),
 		};
 		store.set(zoomRegionsAtom, [region]);
 		expect(store.get(zoomRegionsAtom)).toHaveLength(1);

--- a/apps/desktop/src/components/launch/SourceSelector.tsx
+++ b/apps/desktop/src/components/launch/SourceSelector.tsx
@@ -11,7 +11,11 @@ import {
 } from "@/atoms/sourceSelector";
 import { flashSelectedScreen, getSources, selectSource } from "@/lib/backend";
 import { cn } from "@/lib/utils";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../ui/card";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
+import { Separator } from "../ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { getSourceGridColumnClass } from "./sourceGridLayout";
 import { type DesktopSource, mapSources, mergeSources } from "./sourceSelectorState";
@@ -27,14 +31,15 @@ interface SourceGridProps {
 function SourceGrid({ sources, selectedSource, onSelect, type, emptyMessage }: SourceGridProps) {
 	if (sources.length === 0) {
 		return (
-			<div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-border bg-muted/50 py-12">
-				{type === "screen" ? (
-					<Monitor className="h-5 w-5 text-muted-foreground" />
-				) : (
-					<AppWindow className="h-5 w-5 text-muted-foreground" />
-				)}
-				<p className="text-sm text-muted-foreground">{emptyMessage}</p>
-			</div>
+			<Empty className="min-h-48 border-dashed bg-muted/30">
+				<EmptyHeader>
+					<EmptyMedia>{type === "screen" ? <Monitor /> : <AppWindow />}</EmptyMedia>
+					<EmptyTitle>{emptyMessage}</EmptyTitle>
+					<EmptyDescription>
+						Try a different tab or make sure the source is visible.
+					</EmptyDescription>
+				</EmptyHeader>
+			</Empty>
 		);
 	}
 
@@ -54,10 +59,11 @@ function SourceGrid({ sources, selectedSource, onSelect, type, emptyMessage }: S
 					<button
 						type="button"
 						key={source.id}
+						aria-pressed={isSelected}
 						className={cn(
-							"rounded-lg border bg-card text-left transition-colors hover:bg-accent",
+							"group rounded-lg border bg-card/80 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:bg-accent/60 hover:shadow-md",
 							isWindow ? "p-1.5" : "p-2",
-							isSelected ? "border-primary ring-2 ring-primary/30" : "border-border",
+							isSelected ? "border-primary ring-2 ring-primary/25" : "border-border/70",
 						)}
 						onClick={() => onSelect(source)}
 					>
@@ -89,14 +95,21 @@ function SourceGrid({ sources, selectedSource, onSelect, type, emptyMessage }: S
 								</div>
 							)}
 							{isSelected && (
-								<div className="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
+								<div className="absolute top-1 right-1 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm">
 									<MdCheck className="h-2.5 w-2.5" />
 								</div>
 							)}
 						</div>
-						<p className={cn("truncate font-medium", isWindow ? "text-xs" : "text-sm")}>
-							{source.name}
-						</p>
+						<div className="flex items-center gap-2">
+							<p className={cn("truncate font-medium", isWindow ? "text-xs" : "text-sm")}>
+								{source.name}
+							</p>
+							{isSelected ? (
+								<Badge variant="secondary" className="ml-auto text-[10px]">
+									Selected
+								</Badge>
+							) : null}
+						</div>
 					</button>
 				);
 			})}
@@ -234,70 +247,89 @@ export function SourceSelector() {
 
 	if (loading) {
 		return (
-			<div className="rounded-2xl border border-border bg-background p-6 shadow-xl">
-				<div className="flex flex-col items-center gap-3">
-					<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-					<p className="text-sm text-muted-foreground">Finding sources...</p>
-				</div>
-			</div>
+			<Card className="w-[520px] border-border/70 bg-background/95 shadow-2xl">
+				<CardContent className="p-6">
+					<Empty className="border-0 p-0">
+						<EmptyHeader>
+							<EmptyMedia>
+								<Loader2 className="animate-spin" />
+							</EmptyMedia>
+							<EmptyTitle>Finding sources</EmptyTitle>
+							<EmptyDescription>Collecting screens and open windows.</EmptyDescription>
+						</EmptyHeader>
+					</Empty>
+				</CardContent>
+			</Card>
 		);
 	}
 
 	return (
-		<div className="rounded-2xl border border-border bg-background p-4 shadow-xl">
-			<h1 className="mb-4 text-lg font-semibold">Choose what to share</h1>
+		<Card className="w-[min(860px,calc(100vw-32px))] border-border/70 bg-background/95 shadow-2xl">
+			<CardHeader className="p-4 pb-3">
+				<div className="flex items-center justify-between gap-4">
+					<div>
+						<CardTitle className="text-lg">Choose what to share</CardTitle>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Pick a screen or a single app window for the next recording.
+						</p>
+					</div>
+					<Badge variant="outline">{screenSources.length + windowSources.length} sources</Badge>
+				</div>
+			</CardHeader>
+			<CardContent className="p-4 pt-0">
+				<Tabs
+					value={activeTab}
+					onValueChange={(value) => setActiveTab(value as "screens" | "windows")}
+				>
+					<TabsList className="grid w-full grid-cols-2">
+						<TabsTrigger value="screens" className="gap-1.5">
+							<Monitor data-icon="inline-start" />
+							Screens
+							<Badge variant="secondary" className="ml-1 text-[10px]">
+								{screenSources.length}
+							</Badge>
+						</TabsTrigger>
+						<TabsTrigger value="windows" className="gap-1.5">
+							<AppWindow data-icon="inline-start" />
+							Windows
+							<Badge variant="secondary" className="ml-1 text-[10px]">
+								{windowSources.length}
+								{windowsLoading ? "..." : ""}
+							</Badge>
+						</TabsTrigger>
+					</TabsList>
 
-			<Tabs
-				value={activeTab}
-				onValueChange={(value) => setActiveTab(value as "screens" | "windows")}
-			>
-				<TabsList>
-					<TabsTrigger value="screens" className="gap-1.5">
-						<Monitor className="h-3.5 w-3.5" />
-						Screens
-						<span className="ml-0.5 rounded-full bg-foreground/10 px-1.5 py-0.5 text-xs leading-none">
-							{screenSources.length}
-						</span>
-					</TabsTrigger>
-					<TabsTrigger value="windows" className="gap-1.5">
-						<AppWindow className="h-3.5 w-3.5" />
-						Windows
-						<span className="ml-0.5 rounded-full bg-foreground/10 px-1.5 py-0.5 text-xs leading-none">
-							{windowSources.length}
-							{windowsLoading ? "..." : ""}
-						</span>
-					</TabsTrigger>
-				</TabsList>
+					<TabsContent value="screens" className="mt-3">
+						<SourceGrid
+							sources={screenSources}
+							selectedSource={selectedSource}
+							onSelect={handleSourceSelect}
+							type="screen"
+							emptyMessage="No screens available"
+						/>
+					</TabsContent>
 
-				<TabsContent value="screens" className="mt-3">
-					<SourceGrid
-						sources={screenSources}
-						selectedSource={selectedSource}
-						onSelect={handleSourceSelect}
-						type="screen"
-						emptyMessage="No screens available"
-					/>
-				</TabsContent>
+					<TabsContent value="windows" className="mt-3">
+						<SourceGrid
+							sources={windowSources}
+							selectedSource={selectedSource}
+							onSelect={handleSourceSelect}
+							type="window"
+							emptyMessage="No windows available"
+						/>
+					</TabsContent>
+				</Tabs>
+			</CardContent>
 
-				<TabsContent value="windows" className="mt-3">
-					<SourceGrid
-						sources={windowSources}
-						selectedSource={selectedSource}
-						onSelect={handleSourceSelect}
-						type="window"
-						emptyMessage="No windows available"
-					/>
-				</TabsContent>
-			</Tabs>
-
-			<div className="mt-4 flex justify-end gap-2 border-t border-border pt-4">
+			<Separator />
+			<CardFooter className="flex justify-end gap-2 p-4">
 				<Button variant="outline" onClick={() => window.close()}>
 					Cancel
 				</Button>
 				<Button onClick={() => void handleShare()} disabled={!selectedSource}>
 					Share Source
 				</Button>
-			</div>
-		</div>
+			</CardFooter>
+		</Card>
 	);
 }

--- a/apps/desktop/src/components/projects/ProjectsPage.tsx
+++ b/apps/desktop/src/components/projects/ProjectsPage.tsx
@@ -1,7 +1,9 @@
 import { FolderOpen, Plus } from "lucide-react";
 import { useCallback } from "react";
 import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
 	Empty,
 	EmptyDescription,
@@ -9,6 +11,7 @@ import {
 	EmptyMedia,
 	EmptyTitle,
 } from "@/components/ui/empty";
+import { Separator } from "@/components/ui/separator";
 import * as backend from "@/lib/backend";
 
 interface ProjectsPageProps {
@@ -33,56 +36,84 @@ export function ProjectsPage({ onOpenProject }: ProjectsPageProps) {
 	}, []);
 
 	return (
-		<div className="flex-1 min-h-0 overflow-auto bg-[#09090b] text-slate-200">
-			<div className="mx-auto w-full max-w-4xl px-8 py-10">
-				<div className="flex items-end justify-between gap-4 mb-8">
+		<div className="min-h-0 flex-1 overflow-auto bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-8 py-8">
+				<div className="flex items-end justify-between gap-4">
 					<div>
-						<h1 className="text-2xl font-semibold tracking-tight text-white">Projects</h1>
-						<p className="mt-1 text-sm text-white/60">
-							Open a saved project or jump back into the editor.
+						<div className="flex items-center gap-2">
+							<h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
+							<Badge variant="secondary">Local</Badge>
+						</div>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Open a saved project or browse recordings from this device.
 						</p>
 					</div>
 					<Button
 						type="button"
 						size="sm"
 						onClick={handleOpenProject}
-						className="h-8 gap-1.5 bg-[#2563EB] text-white text-xs font-medium hover:bg-[#2563EB]/90"
+						className="h-8 gap-1.5 text-xs font-medium"
 					>
-						<Plus className="h-3.5 w-3.5" />
+						<Plus data-icon="inline-start" />
 						Open project file
 					</Button>
 				</div>
 
-				<Empty className="max-w-none border-white/10 bg-white/[0.02]">
+				<div className="grid gap-4 md:grid-cols-2">
+					<Card className="border-border/70 bg-card/80 shadow-xl shadow-black/10">
+						<CardHeader className="p-5">
+							<CardTitle className="flex items-center gap-2 text-base">
+								<Plus className="size-4 text-primary" />
+								Open project
+							</CardTitle>
+							<CardDescription>Load an Open Recorder editing session.</CardDescription>
+						</CardHeader>
+						<CardContent className="p-5 pt-0">
+							<Button type="button" className="w-full" onClick={handleOpenProject}>
+								<Plus data-icon="inline-start" />
+								Choose file
+							</Button>
+						</CardContent>
+					</Card>
+
+					<Card className="border-border/70 bg-card/80 shadow-xl shadow-black/10">
+						<CardHeader className="p-5">
+							<CardTitle className="flex items-center gap-2 text-base">
+								<FolderOpen className="size-4 text-primary" />
+								Recordings folder
+							</CardTitle>
+							<CardDescription>Jump to saved captures and exported videos.</CardDescription>
+						</CardHeader>
+						<CardContent className="p-5 pt-0">
+							<Button
+								type="button"
+								variant="outline"
+								className="w-full"
+								onClick={handleOpenRecordingsFolder}
+							>
+								<FolderOpen data-icon="inline-start" />
+								Browse recordings
+							</Button>
+						</CardContent>
+					</Card>
+				</div>
+
+				<Separator />
+
+				<Empty className="max-w-none border-dashed bg-card/40">
 					<EmptyHeader>
-						<EmptyMedia className="size-16 border-[#2563EB]/20 bg-[#2563EB]/10 text-[#93c5fd]">
+						<EmptyMedia className="size-16 border-primary/20 bg-primary/10 text-primary">
 							<FolderOpen className="size-7" />
 						</EmptyMedia>
 						<EmptyTitle>No recent projects yet</EmptyTitle>
 						<EmptyDescription>
-							Load a saved project file, or open your recordings folder to browse existing captures.
+							Recent project shortcuts will appear here after you save or open one.
 						</EmptyDescription>
 					</EmptyHeader>
 					<div className="flex items-center justify-center gap-2">
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={handleOpenProject}
-							className="h-8 gap-1.5 border-white/10 bg-white/5 text-xs text-white hover:bg-white/10"
-						>
-							<Plus className="h-3.5 w-3.5" />
+						<Button type="button" variant="outline" size="sm" onClick={handleOpenProject}>
+							<Plus data-icon="inline-start" />
 							Open project
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={handleOpenRecordingsFolder}
-							className="h-8 gap-1.5 border-white/10 bg-white/5 text-xs text-white hover:bg-white/10"
-						>
-							<FolderOpen className="h-3.5 w-3.5" />
-							Browse recordings
 						</Button>
 					</div>
 				</Empty>

--- a/apps/desktop/src/components/shell/AppSidebar.tsx
+++ b/apps/desktop/src/components/shell/AppSidebar.tsx
@@ -2,6 +2,10 @@ import { useAtom, useSetAtom } from "jotai";
 import { FolderGit2, HelpCircle, Video } from "lucide-react";
 import { type InternalView, internalViewAtom, sidebarExpandedAtom } from "@/atoms/navigation";
 import { showShortcutsDialogAtom } from "@/atoms/videoEditor";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 type NavItem = {
@@ -20,64 +24,102 @@ export function AppSidebar() {
 	const [activeView, setActiveView] = useAtom(internalViewAtom);
 	const setShowShortcutsDialog = useSetAtom(showShortcutsDialogAtom);
 
+	const renderNavButton = ({
+		label,
+		icon: Icon,
+		isActive,
+		onClick,
+	}: {
+		label: string;
+		icon: typeof Video;
+		isActive?: boolean;
+		onClick: () => void;
+	}) => {
+		const button = (
+			<Button
+				type="button"
+				variant={isActive ? "secondary" : "ghost"}
+				size={expanded ? "sm" : "icon"}
+				onClick={onClick}
+				aria-label={label}
+				aria-current={isActive ? "page" : undefined}
+				className={cn(
+					"h-9 justify-start rounded-lg text-xs",
+					expanded ? "w-full px-2.5" : "size-9 px-0",
+					isActive
+						? "bg-primary/15 text-primary hover:bg-primary/20"
+						: "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
+				)}
+			>
+				<Icon data-icon="inline-start" />
+				<span className={cn("truncate", !expanded && "sr-only")}>{label}</span>
+			</Button>
+		);
+
+		if (expanded) {
+			return button;
+		}
+
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>{button}</TooltipTrigger>
+				<TooltipContent side="right">{label}</TooltipContent>
+			</Tooltip>
+		);
+	};
+
 	return (
 		<aside
 			data-testid="app-sidebar"
 			aria-label="Primary navigation"
 			className={cn(
-				"flex-shrink-0 h-full bg-[#09090b] border-r border-white/5 flex flex-col py-3 transition-[width] duration-200 ease-out overflow-hidden",
-				expanded ? "w-52" : "w-12",
+				"flex h-full flex-shrink-0 flex-col overflow-hidden border-r border-border/60 bg-card/95 py-3 shadow-xl shadow-black/20 transition-[width] duration-200 ease-out",
+				expanded ? "w-56" : "w-14",
 			)}
 		>
-			<nav className="flex flex-col gap-1 px-2 mt-2">
+			<div className="flex items-center gap-2 px-2.5">
+				<div className="flex size-9 flex-shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-primary/10 text-primary">
+					<Video className="size-4" />
+				</div>
+				<div
+					className={cn(
+						"min-w-0 transition-opacity duration-150",
+						expanded ? "opacity-100" : "pointer-events-none opacity-0",
+					)}
+				>
+					<div className="truncate text-sm font-semibold text-foreground">Open Recorder</div>
+					<Badge variant="secondary" className="mt-1 text-[10px]">
+						Studio
+					</Badge>
+				</div>
+			</div>
+
+			<Separator className="my-3 bg-border/70" />
+
+			<nav className="flex flex-col gap-1 px-2">
 				{NAV_ITEMS.map(({ view, label, icon: Icon }) => {
 					const isActive = activeView === view;
 					return (
-						<button
-							key={view}
-							type="button"
-							onClick={() => setActiveView(view)}
-							title={expanded ? undefined : label}
-							aria-label={label}
-							aria-current={isActive ? "page" : undefined}
-							className={cn(
-								"group flex items-center gap-3 rounded-md h-8 px-2 text-xs font-medium transition-colors cursor-pointer",
-								isActive
-									? "bg-white/10 text-white"
-									: "text-white/60 hover:bg-white/5 hover:text-white",
-							)}
-						>
-							<Icon className="h-4 w-4 flex-shrink-0" />
-							<span
-								className={cn(
-									"truncate transition-opacity duration-150",
-									expanded ? "opacity-100" : "opacity-0 pointer-events-none",
-								)}
-							>
-								{label}
-							</span>
-						</button>
+						<div key={view}>
+							{renderNavButton({
+								label,
+								icon: Icon,
+								isActive,
+								onClick: () => setActiveView(view),
+							})}
+						</div>
 					);
 				})}
-				<button
-					type="button"
-					onClick={() => setShowShortcutsDialog(true)}
-					title={expanded ? undefined : "Help"}
-					aria-label="Help"
-					aria-haspopup="dialog"
-					className="group flex h-8 cursor-pointer items-center gap-3 rounded-md px-2 text-xs font-medium text-white/60 transition-colors hover:bg-white/5 hover:text-white"
-				>
-					<HelpCircle className="h-4 w-4 flex-shrink-0" />
-					<span
-						className={cn(
-							"truncate transition-opacity duration-150",
-							expanded ? "opacity-100" : "opacity-0 pointer-events-none",
-						)}
-					>
-						Help
-					</span>
-				</button>
 			</nav>
+
+			<div className="mt-auto px-2">
+				<Separator className="mb-3 bg-border/70" />
+				{renderNavButton({
+					label: "Help",
+					icon: HelpCircle,
+					onClick: () => setShowShortcutsDialog(true),
+				})}
+			</div>
 		</aside>
 	);
 }

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+	"inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+	{
+		variants: {
+			variant: {
+				default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+				secondary: "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+				destructive:
+					"bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+				outline:
+					"border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+				ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+				link: "text-primary underline-offset-4 [a&]:hover:underline",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+function Badge({
+	className,
+	variant = "default",
+	asChild = false,
+	...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+	const Comp = asChild ? Slot.Root : "span";
+
+	return (
+		<Comp
+			data-slot="badge"
+			data-variant={variant}
+			className={cn(badgeVariants({ variant }), className)}
+			{...props}
+		/>
+	);
+}
+
+export { Badge };

--- a/apps/desktop/src/components/ui/separator.tsx
+++ b/apps/desktop/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+	className,
+	orientation = "horizontal",
+	decorative = true,
+	...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+	return (
+		<SeparatorPrimitive.Root
+			data-slot="separator"
+			decorative={decorative}
+			orientation={orientation}
+			className={cn(
+				"shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Separator };

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+	delayDuration = 0,
+	...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+	return (
+		<TooltipPrimitive.Provider
+			data-slot="tooltip-provider"
+			delayDuration={delayDuration}
+			{...props}
+		/>
+	);
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+	return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+	return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+	className,
+	sideOffset = 0,
+	children,
+	...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+	return (
+		<TooltipPrimitive.Portal>
+			<TooltipPrimitive.Content
+				data-slot="tooltip-content"
+				sideOffset={sideOffset}
+				className={cn(
+					"z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				<TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+			</TooltipPrimitive.Content>
+		</TooltipPrimitive.Portal>
+	);
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/desktop/src/components/video-editor/SettingsPanel.test.tsx
+++ b/apps/desktop/src/components/video-editor/SettingsPanel.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { Provider } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { act, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -36,14 +38,22 @@ async function click(element: Element | null) {
 	await flushEffects();
 }
 
-async function renderPanel() {
+async function renderPanel(props: Partial<ComponentProps<typeof SettingsPanel>> = {}) {
 	const container = document.createElement("div");
 	document.body.appendChild(container);
 	const root: Root = createRoot(container);
+	const store = createStore();
 
 	await act(async () => {
 		root.render(
-			<SettingsPanel selected="#000000" onWallpaperChange={vi.fn()} aspectRatio="16:9" />,
+			<Provider store={store}>
+				<SettingsPanel
+					selected="#000000"
+					onWallpaperChange={vi.fn()}
+					aspectRatio="16:9"
+					{...props}
+				/>
+			</Provider>,
 		);
 	});
 	await flushEffects();
@@ -92,11 +102,11 @@ describe("SettingsPanel", () => {
 		await harness.unmount();
 	});
 
-	it("switches background sub-tabs inside the selected background panel", async () => {
+	it("shows background controls inside the appearance panel", async () => {
 		const harness = await renderPanel();
 
-		await click(harness.container.querySelector('[aria-label="Background"]'));
-
+		expect(harness.container.querySelector('[aria-label="Background"]')).toBeNull();
+		expect(harness.container.textContent).toContain("Background");
 		expect(harness.container.textContent).toContain("Upload Custom");
 		expect(harness.container.querySelector('img[alt="Wallpaper 1"]')?.getAttribute("src")).toBe(
 			"/wallpapers/thumbs/wallpaper1.jpg",
@@ -109,6 +119,83 @@ describe("SettingsPanel", () => {
 
 		expect(harness.container.querySelector('[aria-label="Gradient 1"]')).not.toBeNull();
 		expect(harness.container.textContent).not.toContain("Upload Custom");
+
+		await harness.unmount();
+	});
+
+	it("shows a focused zoom editor without the main editor controls", async () => {
+		const onZoomEaseChange = vi.fn();
+		const harness = await renderPanel({
+			selectedZoomId: "zoom-1",
+			selectedZoomDepth: 2,
+			selectedZoomEaseIn: { durationMs: 1200, type: "linear" },
+			selectedZoomEaseOut: { durationMs: 800, type: "smooth" },
+			onZoomDepthChange: vi.fn(),
+			onZoomEaseChange,
+			onZoomDelete: vi.fn(),
+		});
+
+		expect(harness.container.textContent).toContain("Zoom Settings");
+		expect(harness.container.textContent).toContain("Ease In");
+		expect(harness.container.textContent).toContain("Ease Out");
+		expect(harness.container.textContent).toContain("Linear");
+		expect(harness.container.textContent).toContain("Smooth");
+		expect(harness.container.textContent).toContain("Delete Zoom");
+		expect(harness.container.textContent).not.toContain("Shadow");
+		expect(harness.container.textContent).not.toContain("Report Bug");
+		expect(harness.container.querySelector('[aria-label="Appearance"]')).toBeNull();
+
+		const easeInDurationInput = harness.container.querySelector(
+			'input[aria-label="Ease In duration"]',
+		) as HTMLInputElement | null;
+		expect(easeInDurationInput?.value).toBe("1.2");
+
+		await act(async () => {
+			if (!easeInDurationInput) throw new Error("Expected ease-in duration input");
+			const valueSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLInputElement.prototype,
+				"value",
+			)?.set;
+			valueSetter?.call(easeInDurationInput, "0.75");
+			easeInDurationInput.dispatchEvent(new Event("input", { bubbles: true }));
+			easeInDurationInput.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		await flushEffects();
+
+		expect(onZoomEaseChange).toHaveBeenCalledWith("easeIn", { durationMs: 750 });
+
+		await harness.unmount();
+	});
+
+	it("shows a focused trim editor without the main editor controls", async () => {
+		const harness = await renderPanel({
+			selectedTrimId: "trim-1",
+			onTrimDelete: vi.fn(),
+		});
+
+		expect(harness.container.textContent).toContain("Trim Settings");
+		expect(harness.container.textContent).toContain("Delete Trim Region");
+		expect(harness.container.textContent).not.toContain("Shadow");
+		expect(harness.container.textContent).not.toContain("Report Bug");
+		expect(harness.container.querySelector('[aria-label="Appearance"]')).toBeNull();
+
+		await harness.unmount();
+	});
+
+	it("shows a focused speed editor without the main editor controls", async () => {
+		const harness = await renderPanel({
+			selectedSpeedId: "speed-1",
+			selectedSpeedValue: 1.5,
+			onSpeedChange: vi.fn(),
+			onSpeedDelete: vi.fn(),
+		});
+
+		expect(harness.container.textContent).toContain("Speed Settings");
+		expect(harness.container.textContent).toContain("Delete Speed Region");
+		expect(harness.container.textContent).toContain("1.5×");
+		expect(harness.container.textContent).not.toContain("Shadow");
+		expect(harness.container.textContent).not.toContain("Report Bug");
+		expect(harness.container.querySelector('[aria-label="Appearance"]')).toBeNull();
 
 		await harness.unmount();
 	});

--- a/apps/desktop/src/components/video-editor/SettingsPanel.test.tsx
+++ b/apps/desktop/src/components/video-editor/SettingsPanel.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@uiw/react-color-block", () => ({
 	default: () => <div data-testid="color-block" />,
 }));
 
+const { TooltipProvider } = await import("@/components/ui/tooltip");
 const { SettingsPanel } = await import("./SettingsPanel");
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -47,12 +48,14 @@ async function renderPanel(props: Partial<ComponentProps<typeof SettingsPanel>> 
 	await act(async () => {
 		root.render(
 			<Provider store={store}>
-				<SettingsPanel
-					selected="#000000"
-					onWallpaperChange={vi.fn()}
-					aspectRatio="16:9"
-					{...props}
-				/>
+				<TooltipProvider>
+					<SettingsPanel
+						selected="#000000"
+						onWallpaperChange={vi.fn()}
+						aspectRatio="16:9"
+						{...props}
+					/>
+				</TooltipProvider>
 			</Provider>,
 		);
 	});

--- a/apps/desktop/src/components/video-editor/SettingsPanel.tsx
+++ b/apps/desktop/src/components/video-editor/SettingsPanel.tsx
@@ -4,15 +4,18 @@ import {
 	Bug,
 	Camera,
 	Crop,
+	Gauge,
 	type LucideIcon,
 	MousePointer2,
 	Palette,
+	Scissors,
 	SlidersHorizontal,
 	Star,
 	Trash2,
 	Upload,
 	Volume2,
 	X,
+	ZoomIn,
 } from "lucide-react";
 import { memo, type ReactNode, useMemo, useRef } from "react";
 import { toast } from "sonner";
@@ -25,14 +28,27 @@ import {
 	settingsSelectedColorAtom,
 	settingsShowCropModalAtom,
 } from "@/atoms/settingsPanel";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { openExternalUrl } from "@/lib/backend";
 import {
 	createDefaultFacecamSettings,
 	FACECAM_ANCHORS,
+	type FacecamAnchor,
 	type FacecamSettings,
 } from "@/lib/recordingSession";
 import { cn } from "@/lib/utils";
@@ -40,7 +56,6 @@ import { BUILT_IN_WALLPAPERS, type BuiltInWallpaper, WALLPAPER_PATHS } from "@/l
 import { type AspectRatio } from "@/utils/aspectRatioUtils";
 import { AnnotationSettingsPanel } from "./AnnotationSettingsPanel";
 import { CropControl } from "./CropControl";
-import { KeyboardShortcutsHelp } from "./KeyboardShortcutsHelp";
 import type {
 	AnnotationRegion,
 	AnnotationType,
@@ -48,8 +63,10 @@ import type {
 	FigureData,
 	PlaybackSpeed,
 	ZoomDepth,
+	ZoomEaseType,
+	ZoomEasing,
 } from "./types";
-import { SPEED_OPTIONS } from "./types";
+import { DEFAULT_ZOOM_EASE_IN, DEFAULT_ZOOM_EASE_OUT, SPEED_OPTIONS } from "./types";
 
 const GRADIENTS = [
 	"linear-gradient( 111.6deg,  rgba(114,167,232,1) 9.4%, rgba(253,129,82,1) 43.9%, rgba(253,129,82,1) 54.8%, rgba(249,202,86,1) 86.3% )",
@@ -108,7 +125,7 @@ const SETTINGS_SIDEBAR_TABS: SettingsTabDefinition[] = [
 	{
 		id: "appearance",
 		label: "Appearance",
-		description: "Frame styling, crop, and composition.",
+		description: "Frame styling, background, crop, and composition.",
 		icon: SlidersHorizontal,
 	},
 	{
@@ -122,12 +139,6 @@ const SETTINGS_SIDEBAR_TABS: SettingsTabDefinition[] = [
 		label: "Camera",
 		description: "Facecam overlay settings.",
 		icon: Camera,
-	},
-	{
-		id: "background",
-		label: "Background",
-		description: "Wallpaper, colors, and gradients.",
-		icon: Palette,
 	},
 	{
 		id: "audio",
@@ -146,6 +157,9 @@ interface SettingsPanelProps {
 	onAudioVolumeChange?: (volume: number) => void;
 	selectedZoomDepth?: ZoomDepth | null;
 	onZoomDepthChange?: (depth: ZoomDepth) => void;
+	selectedZoomEaseIn?: ZoomEasing | null;
+	selectedZoomEaseOut?: ZoomEasing | null;
+	onZoomEaseChange?: (side: "easeIn" | "easeOut", patch: Partial<ZoomEasing>) => void;
 	selectedZoomId?: string | null;
 	onZoomDelete?: (id: string) => void;
 	selectedTrimId?: string | null;
@@ -202,6 +216,27 @@ const ZOOM_DEPTH_OPTIONS: Array<{ depth: ZoomDepth; label: string }> = [
 	{ depth: 5, label: "3.5×" },
 	{ depth: 6, label: "5×" },
 ];
+
+const ZOOM_EASE_OPTIONS: Array<{ type: ZoomEaseType; label: string }> = [
+	{ type: "smooth", label: "Smooth" },
+	{ type: "linear", label: "Linear" },
+	{ type: "ease-in", label: "Ease In" },
+	{ type: "ease-out", label: "Ease Out" },
+	{ type: "ease-in-out", label: "Ease In-Out" },
+];
+
+function formatZoomEaseDurationSeconds(durationMs: number) {
+	return (durationMs / 1000).toFixed(3).replace(/\.?0+$/, "");
+}
+
+function parseZoomEaseDurationMs(value: string) {
+	const seconds = Number.parseFloat(value);
+	if (!Number.isFinite(seconds)) {
+		return null;
+	}
+
+	return Math.round(Math.max(0, Math.min(5, seconds)) * 1000);
+}
 
 const normalizeWallpaperValue = (value: string) =>
 	value.replace(/^file:\/\//, "").replace(/^\//, "");
@@ -271,6 +306,9 @@ function SettingsPanelInner({
 	onAudioVolumeChange,
 	selectedZoomDepth,
 	onZoomDepthChange,
+	selectedZoomEaseIn,
+	selectedZoomEaseOut,
+	onZoomEaseChange,
 	selectedZoomId,
 	onZoomDelete,
 	selectedTrimId,
@@ -353,6 +391,54 @@ function SettingsPanelInner({
 			onTrimDelete(selectedTrimId);
 		}
 	};
+
+	const renderZoomEaseControl = (label: string, side: "easeIn" | "easeOut", easing: ZoomEasing) => (
+		<div className="rounded-lg border border-white/5 bg-white/5 p-2">
+			<div className="mb-2 text-[10px] font-medium text-slate-300">{label}</div>
+			<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.3fr)] gap-2">
+				<div>
+					<div className="mb-1 text-[9px] uppercase tracking-wide text-slate-500">Duration</div>
+					<Input
+						aria-label={`${label} duration`}
+						type="number"
+						inputMode="decimal"
+						min={0}
+						max={5}
+						step={0.05}
+						value={formatZoomEaseDurationSeconds(easing.durationMs)}
+						onChange={(event) => {
+							const durationMs = parseZoomEaseDurationMs(event.target.value);
+							if (durationMs !== null) {
+								onZoomEaseChange?.(side, { durationMs });
+							}
+						}}
+						className="h-8 rounded-md border-white/10 bg-black/20 px-2 text-xs text-slate-100 ring-offset-0 focus-visible:ring-1 focus-visible:ring-[#2563EB] focus-visible:ring-offset-0"
+					/>
+				</div>
+				<div>
+					<div className="mb-1 text-[9px] uppercase tracking-wide text-slate-500">Ease Type</div>
+					<Select
+						value={easing.type}
+						onValueChange={(value) => onZoomEaseChange?.(side, { type: value as ZoomEaseType })}
+					>
+						<SelectTrigger
+							aria-label={`${label} type`}
+							className="h-8 rounded-md border-white/10 bg-black/20 px-2 text-xs text-slate-100 ring-offset-0 focus:ring-1 focus:ring-[#2563EB] focus:ring-offset-0"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent className="z-[10000] border-white/10 bg-[#1a1a1c] text-slate-200">
+							{ZOOM_EASE_OPTIONS.map((option) => (
+								<SelectItem key={option.type} value={option.type}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+		</div>
+	);
 
 	const handleCropToggle = () => {
 		if (!showCropModal && cropRegion) {
@@ -444,10 +530,294 @@ function SettingsPanelInner({
 		);
 	}
 
+	if (zoomEnabled) {
+		return (
+			<div className="flex-[2] min-w-0 bg-[#09090b] border border-white/5 rounded-2xl p-4 flex flex-col shadow-xl h-full overflow-y-auto custom-scrollbar">
+				<div className="mb-6">
+					<div className="flex items-center justify-between mb-4">
+						<div className="flex items-center gap-2">
+							<ZoomIn className="h-4 w-4 text-[#2563EB]" />
+							<span className="text-sm font-medium text-slate-200">Zoom Settings</span>
+						</div>
+						{selectedZoomDepth && (
+							<span className="text-[10px] uppercase tracking-wider font-medium text-[#2563EB] bg-[#2563EB]/10 px-2 py-1 rounded-full">
+								{ZOOM_DEPTH_OPTIONS.find((option) => option.depth === selectedZoomDepth)?.label}
+							</span>
+						)}
+					</div>
+					<ToggleGroup
+						type="single"
+						value={String(selectedZoomDepth)}
+						onValueChange={(value) => {
+							const nextDepth = Number(value) as ZoomDepth;
+							if (ZOOM_DEPTH_OPTIONS.some((option) => option.depth === nextDepth)) {
+								onZoomDepthChange?.(nextDepth);
+							}
+						}}
+						className="mb-3 grid grid-cols-6 rounded-lg border border-white/5 bg-white/5 p-1"
+					>
+						{ZOOM_DEPTH_OPTIONS.map((option) => (
+							<ToggleGroupItem
+								key={option.depth}
+								value={String(option.depth)}
+								className="h-8 text-xs"
+							>
+								{option.label}
+							</ToggleGroupItem>
+						))}
+					</ToggleGroup>
+					<div className="mb-3 grid grid-cols-1 gap-2">
+						{renderZoomEaseControl("Ease In", "easeIn", selectedZoomEaseIn ?? DEFAULT_ZOOM_EASE_IN)}
+						{renderZoomEaseControl(
+							"Ease Out",
+							"easeOut",
+							selectedZoomEaseOut ?? DEFAULT_ZOOM_EASE_OUT,
+						)}
+					</div>
+					<div className="grid grid-cols-2 gap-2 mb-3">
+						<div className="p-2 rounded-lg bg-white/5 border border-white/5">
+							<div className="flex items-center justify-between mb-1">
+								<div className="text-[10px] font-medium text-slate-300">Motion Blur</div>
+								<span className="text-[10px] text-slate-500 font-mono">
+									{zoomMotionBlur.toFixed(2)}×
+								</span>
+							</div>
+							<Slider
+								value={[zoomMotionBlur]}
+								onValueChange={(values) => onZoomMotionBlurChange?.(values[0])}
+								min={0}
+								max={2}
+								step={0.05}
+								className="w-full"
+							/>
+						</div>
+						<div className="flex items-center justify-between p-2 rounded-lg bg-white/5 border border-white/5">
+							<div className="text-[10px] font-medium text-slate-300">Connect Zooms</div>
+							<Switch
+								checked={connectZooms}
+								onCheckedChange={onConnectZoomsChange}
+								className="data-[state=checked]:bg-[#2563EB] scale-90"
+							/>
+						</div>
+					</div>
+					<Button
+						onClick={handleDeleteClick}
+						variant="destructive"
+						size="sm"
+						className="mt-3 w-full gap-2 bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 hover:border-red-500/30 transition-all h-8 text-xs"
+					>
+						<Trash2 className="w-3 h-3" />
+						Delete Zoom
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (trimEnabled) {
+		return (
+			<div className="flex-[2] min-w-0 bg-[#09090b] border border-white/5 rounded-2xl p-4 flex flex-col shadow-xl h-full overflow-y-auto custom-scrollbar">
+				<div className="mb-6">
+					<div className="flex items-center justify-between mb-4">
+						<div className="flex items-center gap-2">
+							<Scissors className="h-4 w-4 text-red-400" />
+							<span className="text-sm font-medium text-slate-200">Trim Settings</span>
+						</div>
+						<span className="text-[10px] uppercase tracking-wider font-medium text-red-400 bg-red-500/10 px-2 py-1 rounded-full">
+							Active
+						</span>
+					</div>
+					<Button
+						onClick={handleTrimDeleteClick}
+						variant="destructive"
+						size="sm"
+						className="w-full gap-2 bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 hover:border-red-500/30 transition-all h-8 text-xs"
+					>
+						<Trash2 className="w-3 h-3" />
+						Delete Trim Region
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (selectedSpeedId) {
+		return (
+			<div className="flex-[2] min-w-0 bg-[#09090b] border border-white/5 rounded-2xl p-4 flex flex-col shadow-xl h-full overflow-y-auto custom-scrollbar">
+				<div className="mb-6">
+					<div className="flex items-center justify-between mb-4">
+						<div className="flex items-center gap-2">
+							<Gauge className="h-4 w-4 text-[#d97706]" />
+							<span className="text-sm font-medium text-slate-200">Speed Settings</span>
+						</div>
+						{selectedSpeedValue && (
+							<span className="text-[10px] uppercase tracking-wider font-medium text-[#d97706] bg-[#d97706]/10 px-2 py-1 rounded-full">
+								{SPEED_OPTIONS.find((option) => option.speed === selectedSpeedValue)?.label ??
+									`${selectedSpeedValue}×`}
+							</span>
+						)}
+					</div>
+					<ToggleGroup
+						type="single"
+						value={selectedSpeedValue ? String(selectedSpeedValue) : undefined}
+						onValueChange={(value) => {
+							const nextSpeed = Number(value) as PlaybackSpeed;
+							if (SPEED_OPTIONS.some((option) => option.speed === nextSpeed)) {
+								onSpeedChange?.(nextSpeed);
+							}
+						}}
+						className="mb-3 grid grid-cols-7 rounded-lg border border-white/5 bg-white/5 p-1"
+					>
+						{SPEED_OPTIONS.map((option) => (
+							<ToggleGroupItem
+								key={option.speed}
+								value={String(option.speed)}
+								className="h-8 text-xs"
+							>
+								{option.label}
+							</ToggleGroupItem>
+						))}
+					</ToggleGroup>
+					<Button
+						onClick={() => onSpeedDelete?.(selectedSpeedId)}
+						variant="destructive"
+						size="sm"
+						className="mt-3 w-full gap-2 bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 hover:border-red-500/30 transition-all h-8 text-xs"
+					>
+						<Trash2 className="w-3 h-3" />
+						Delete Speed Region
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
 	const ActiveTabIcon = activeTabDefinition.icon;
 
+	const renderBackgroundControls = () => (
+		<Tabs
+			value={backgroundTab}
+			onValueChange={(value) => setBackgroundTab(value as typeof backgroundTab)}
+			className="w-full"
+		>
+			<TabsList className="mb-2 bg-white/5 border border-white/5 p-0.5 w-full grid grid-cols-3 h-7 rounded-lg">
+				<TabsTrigger
+					value="image"
+					className="data-[state=active]:bg-[#2563EB] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all"
+				>
+					Image
+				</TabsTrigger>
+				<TabsTrigger
+					value="color"
+					className="data-[state=active]:bg-[#2563EB] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all"
+				>
+					Color
+				</TabsTrigger>
+				<TabsTrigger
+					value="gradient"
+					className="data-[state=active]:bg-[#2563EB] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all"
+				>
+					Gradient
+				</TabsTrigger>
+			</TabsList>
+
+			<div className="max-h-[min(200px,25vh)] overflow-y-auto custom-scrollbar">
+				<TabsContent value="image" className="mt-0 space-y-2">
+					<input
+						type="file"
+						ref={fileInputRef}
+						onChange={handleImageUpload}
+						accept=".jpg,.jpeg,image/jpeg"
+						className="hidden"
+					/>
+					<Button
+						onClick={() => fileInputRef.current?.click()}
+						variant="outline"
+						className="w-full gap-2 bg-white/5 text-slate-200 border-white/10 hover:bg-[#2563EB] hover:text-white hover:border-[#2563EB] transition-all h-7 text-[10px]"
+					>
+						<Upload className="w-3 h-3" />
+						Upload Custom
+					</Button>
+
+					<div className="grid grid-cols-7 gap-1.5">
+						{customImages.map((imageUrl, idx) => {
+							const isSelected = selected === imageUrl;
+							return (
+								<WallpaperPreviewTile
+									key={`custom-${idx}`}
+									label={`Custom wallpaper ${idx + 1}`}
+									previewSrc={imageUrl}
+									isSelected={isSelected}
+									onSelect={() => onWallpaperChange(imageUrl)}
+								>
+									<button
+										type="button"
+										onClick={(e) => handleRemoveCustomImage(imageUrl, e)}
+										className="absolute top-0.5 right-0.5 w-3 h-3 bg-red-500/90 hover:bg-red-500 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10"
+									>
+										<X className="w-2 h-2 text-white" />
+									</button>
+								</WallpaperPreviewTile>
+							);
+						})}
+
+						{BUILT_IN_WALLPAPERS.map((wallpaper) => (
+							<WallpaperPreviewTile
+								key={wallpaper.id}
+								label={wallpaper.label}
+								previewSrc={wallpaper.thumbnailPublicPath}
+								isSelected={Boolean(selected) && isBuiltInWallpaperSelected(selected, wallpaper)}
+								onSelect={() => onWallpaperChange(wallpaper.publicPath)}
+							/>
+						))}
+					</div>
+				</TabsContent>
+
+				<TabsContent value="color" className="mt-0">
+					<div className="p-1">
+						<Block
+							color={selectedColor}
+							colors={COLOR_PALETTE}
+							onChange={(color) => {
+								setSelectedColor(color.hex);
+								onWallpaperChange(color.hex);
+							}}
+							style={{
+								width: "100%",
+								borderRadius: "8px",
+							}}
+						/>
+					</div>
+				</TabsContent>
+
+				<TabsContent value="gradient" className="mt-0">
+					<div className="grid grid-cols-7 gap-1.5">
+						{GRADIENTS.map((currentGradient, idx) => (
+							<div
+								key={currentGradient}
+								className={cn(
+									"aspect-square w-9 h-9 rounded-md border-2 overflow-hidden cursor-pointer transition-all duration-200 shadow-sm",
+									gradient === currentGradient
+										? "border-[#2563EB] ring-1 ring-[#2563EB]/30"
+										: "border-white/10 hover:border-[#2563EB]/40 opacity-80 hover:opacity-100 bg-white/5",
+								)}
+								style={{ background: currentGradient }}
+								aria-label={`Gradient ${idx + 1}`}
+								onClick={() => {
+									setGradient(currentGradient);
+									onWallpaperChange(currentGradient);
+								}}
+								role="button"
+							/>
+						))}
+					</div>
+				</TabsContent>
+			</div>
+		</Tabs>
+	);
+
 	const renderSelectedTabContent = () => {
-		switch (activeTab) {
+		switch (activeTabDefinition.id) {
 			case "appearance":
 				return (
 					<div className="space-y-3">
@@ -524,6 +894,14 @@ function SettingsPanelInner({
 							<Crop className="w-3 h-3" />
 							Crop Video
 						</Button>
+
+						<div className="space-y-2 border-t border-white/5 pt-3">
+							<div className="flex items-center gap-2">
+								<Palette className="h-3.5 w-3.5 text-[#2563EB]" />
+								<div className="text-[10px] font-medium text-slate-300">Background</div>
+							</div>
+							{renderBackgroundControls()}
+						</div>
 					</div>
 				);
 			case "cursor":
@@ -640,32 +1018,23 @@ function SettingsPanelInner({
 
 						{facecamAvailable && (
 							<div className="space-y-3">
-								<div className="grid grid-cols-2 gap-2">
-									<Button
-										type="button"
-										variant="outline"
-										onClick={() => updateFacecamSettings({ shape: "circle" })}
-										className={cn(
-											"h-8 text-[10px] border-white/10 bg-white/5 text-slate-300 hover:bg-white/10",
-											facecamSettings.shape === "circle" &&
-												"border-[#2563EB]/60 bg-[#2563EB]/15 text-white",
-										)}
-									>
+								<ToggleGroup
+									type="single"
+									value={facecamSettings.shape}
+									onValueChange={(value) => {
+										if (value === "circle" || value === "square") {
+											updateFacecamSettings({ shape: value });
+										}
+									}}
+									className="grid grid-cols-2 rounded-lg border border-white/5 bg-white/5 p-1"
+								>
+									<ToggleGroupItem value="circle" className="h-8 text-[10px]">
 										Circle
-									</Button>
-									<Button
-										type="button"
-										variant="outline"
-										onClick={() => updateFacecamSettings({ shape: "square" })}
-										className={cn(
-											"h-8 text-[10px] border-white/10 bg-white/5 text-slate-300 hover:bg-white/10",
-											facecamSettings.shape === "square" &&
-												"border-[#2563EB]/60 bg-[#2563EB]/15 text-white",
-										)}
-									>
+									</ToggleGroupItem>
+									<ToggleGroupItem value="square" className="h-8 text-[10px]">
 										Square
-									</Button>
-								</div>
+									</ToggleGroupItem>
+								</ToggleGroup>
 
 								<div className="p-2 rounded-lg bg-white/5 border border-white/5">
 									<div className="flex items-center justify-between mb-1">
@@ -747,7 +1116,20 @@ function SettingsPanelInner({
 
 								<div className="p-2 rounded-lg bg-white/5 border border-white/5">
 									<div className="text-[10px] font-medium text-slate-300 mb-1.5">Position</div>
-									<div className="grid grid-cols-2 gap-1.5">
+									<ToggleGroup
+										type="single"
+										value={facecamSettings.anchor ?? "bottom-right"}
+										onValueChange={(value) => {
+											if (FACECAM_ANCHORS.includes(value as FacecamAnchor)) {
+												updateFacecamSettings({
+													anchor: value as FacecamAnchor,
+													customX: undefined,
+													customY: undefined,
+												});
+											}
+										}}
+										className="grid grid-cols-2 rounded-lg border border-white/5 bg-white/5 p-1"
+									>
 										{FACECAM_ANCHORS.map((anchorOption) => {
 											const labels: Record<string, string> = {
 												"top-left": "Top Left",
@@ -759,27 +1141,16 @@ function SettingsPanelInner({
 												facecamSettings.anchor === anchorOption ||
 												(!facecamSettings.anchor && anchorOption === "bottom-right");
 											return (
-												<Button
+												<ToggleGroupItem
 													key={anchorOption}
-													type="button"
-													variant="outline"
-													onClick={() =>
-														updateFacecamSettings({
-															anchor: anchorOption,
-															customX: undefined,
-															customY: undefined,
-														})
-													}
-													className={cn(
-														"h-7 text-[9px] border-white/10 bg-white/5 text-slate-300 hover:bg-white/10",
-														isActive && "border-[#2563EB]/60 bg-[#2563EB]/15 text-white",
-													)}
+													value={anchorOption}
+													className={cn("h-7 text-[9px]", isActive && "text-white")}
 												>
 													{labels[anchorOption] ?? anchorOption}
-												</Button>
+												</ToggleGroupItem>
 											);
 										})}
-									</div>
+									</ToggleGroup>
 									{facecamSettings.anchor === "custom" && (
 										<div className="mt-1.5 text-[9px] text-slate-500">
 											Drag the bubble in the preview to reposition.
@@ -789,130 +1160,6 @@ function SettingsPanelInner({
 							</div>
 						)}
 					</div>
-				);
-			case "background":
-				return (
-					<Tabs
-						value={backgroundTab}
-						onValueChange={(value) => setBackgroundTab(value as typeof backgroundTab)}
-						className="w-full"
-					>
-						<TabsList className="mb-2 bg-white/5 border border-white/5 p-0.5 w-full grid grid-cols-3 h-7 rounded-lg">
-							<TabsTrigger
-								value="image"
-								className="data-[state=active]:bg-[#2563EB] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all"
-							>
-								Image
-							</TabsTrigger>
-							<TabsTrigger
-								value="color"
-								className="data-[state=active]:bg-[#2563EB] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all"
-							>
-								Color
-							</TabsTrigger>
-							<TabsTrigger
-								value="gradient"
-								className="data-[state=active]:bg-[#2563EB] data-[state=active]:text-white text-slate-400 text-[10px] py-1 rounded-md transition-all"
-							>
-								Gradient
-							</TabsTrigger>
-						</TabsList>
-
-						<div className="max-h-[min(200px,25vh)] overflow-y-auto custom-scrollbar">
-							<TabsContent value="image" className="mt-0 space-y-2">
-								<input
-									type="file"
-									ref={fileInputRef}
-									onChange={handleImageUpload}
-									accept=".jpg,.jpeg,image/jpeg"
-									className="hidden"
-								/>
-								<Button
-									onClick={() => fileInputRef.current?.click()}
-									variant="outline"
-									className="w-full gap-2 bg-white/5 text-slate-200 border-white/10 hover:bg-[#2563EB] hover:text-white hover:border-[#2563EB] transition-all h-7 text-[10px]"
-								>
-									<Upload className="w-3 h-3" />
-									Upload Custom
-								</Button>
-
-								<div className="grid grid-cols-7 gap-1.5">
-									{customImages.map((imageUrl, idx) => {
-										const isSelected = selected === imageUrl;
-										return (
-											<WallpaperPreviewTile
-												key={`custom-${idx}`}
-												label={`Custom wallpaper ${idx + 1}`}
-												previewSrc={imageUrl}
-												isSelected={isSelected}
-												onSelect={() => onWallpaperChange(imageUrl)}
-											>
-												<button
-													type="button"
-													onClick={(e) => handleRemoveCustomImage(imageUrl, e)}
-													className="absolute top-0.5 right-0.5 w-3 h-3 bg-red-500/90 hover:bg-red-500 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-10"
-												>
-													<X className="w-2 h-2 text-white" />
-												</button>
-											</WallpaperPreviewTile>
-										);
-									})}
-
-									{BUILT_IN_WALLPAPERS.map((wallpaper) => (
-										<WallpaperPreviewTile
-											key={wallpaper.id}
-											label={wallpaper.label}
-											previewSrc={wallpaper.thumbnailPublicPath}
-											isSelected={
-												Boolean(selected) && isBuiltInWallpaperSelected(selected, wallpaper)
-											}
-											onSelect={() => onWallpaperChange(wallpaper.publicPath)}
-										/>
-									))}
-								</div>
-							</TabsContent>
-
-							<TabsContent value="color" className="mt-0">
-								<div className="p-1">
-									<Block
-										color={selectedColor}
-										colors={COLOR_PALETTE}
-										onChange={(color) => {
-											setSelectedColor(color.hex);
-											onWallpaperChange(color.hex);
-										}}
-										style={{
-											width: "100%",
-											borderRadius: "8px",
-										}}
-									/>
-								</div>
-							</TabsContent>
-
-							<TabsContent value="gradient" className="mt-0">
-								<div className="grid grid-cols-7 gap-1.5">
-									{GRADIENTS.map((currentGradient, idx) => (
-										<div
-											key={currentGradient}
-											className={cn(
-												"aspect-square w-9 h-9 rounded-md border-2 overflow-hidden cursor-pointer transition-all duration-200 shadow-sm",
-												gradient === currentGradient
-													? "border-[#2563EB] ring-1 ring-[#2563EB]/30"
-													: "border-white/10 hover:border-[#2563EB]/40 opacity-80 hover:opacity-100 bg-white/5",
-											)}
-											style={{ background: currentGradient }}
-											aria-label={`Gradient ${idx + 1}`}
-											onClick={() => {
-												setGradient(currentGradient);
-												onWallpaperChange(currentGradient);
-											}}
-											role="button"
-										/>
-									))}
-								</div>
-							</TabsContent>
-						</div>
-					</Tabs>
 				);
 			case "audio":
 				return (
@@ -957,220 +1204,106 @@ function SettingsPanelInner({
 	};
 
 	return (
-		<div className="flex-[2] min-w-0 bg-[#09090b] border border-white/5 rounded-2xl flex flex-col shadow-xl h-full overflow-hidden">
-			<div className="flex flex-1 min-h-0 overflow-hidden">
-				<div
-					className="flex flex-col items-center gap-2 border-r border-white/5 bg-white/[0.02] px-2 py-3"
-					role="tablist"
-					aria-orientation="vertical"
-				>
-					{SETTINGS_SIDEBAR_TABS.map((tab) => {
-						const TabIcon = tab.icon;
-						const isActive = tab.id === activeTab;
+		<Card className="flex h-full min-w-0 flex-[2] flex-col overflow-hidden border-border/70 bg-card/90 shadow-2xl shadow-black/20">
+			<CardContent className="flex min-h-0 flex-1 p-0">
+				<div className="flex flex-1 min-h-0 overflow-hidden">
+					<div
+						className="flex flex-col items-center gap-2 border-r border-border/60 bg-muted/30 px-2 py-3"
+						role="tablist"
+						aria-orientation="vertical"
+					>
+						{SETTINGS_SIDEBAR_TABS.map((tab) => {
+							const TabIcon = tab.icon;
+							const isActive = tab.id === activeTabDefinition.id;
 
-						return (
-							<button
-								key={tab.id}
-								type="button"
-								role="tab"
-								id={`settings-tab-${tab.id}`}
-								aria-selected={isActive}
-								aria-controls={`settings-panel-${tab.id}`}
-								aria-label={tab.label}
-								title={tab.label}
-								onClick={() => setActiveTab(tab.id)}
-								className={cn(
-									"flex h-11 w-11 items-center justify-center rounded-xl border transition-all duration-200",
-									isActive
-										? "border-[#2563EB]/60 bg-[#2563EB]/15 text-white shadow-[0_0_18px_rgba(37,99,235,0.18)]"
-										: "border-transparent bg-white/[0.03] text-slate-500 hover:border-white/10 hover:bg-white/[0.07] hover:text-slate-200",
-								)}
+							return (
+								<Tooltip key={tab.id}>
+									<TooltipTrigger asChild>
+										<Button
+											type="button"
+											role="tab"
+											id={`settings-tab-${tab.id}`}
+											aria-selected={isActive}
+											aria-controls={`settings-panel-${tab.id}`}
+											aria-label={tab.label}
+											onClick={() => setActiveTab(tab.id)}
+											variant={isActive ? "secondary" : "ghost"}
+											size="icon"
+											className={cn(
+												"size-10 rounded-lg",
+												isActive
+													? "bg-primary/15 text-primary hover:bg-primary/20"
+													: "text-muted-foreground hover:bg-muted hover:text-foreground",
+											)}
+										>
+											<TabIcon />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent side="left">{tab.label}</TooltipContent>
+								</Tooltip>
+							);
+						})}
+					</div>
+
+					<div className="flex flex-1 min-h-0 flex-col">
+						<div className="flex-1 overflow-y-auto custom-scrollbar p-4 pb-0">
+							<div
+								role="tabpanel"
+								id={`settings-panel-${activeTabDefinition.id}`}
+								aria-labelledby={`settings-tab-${activeTabDefinition.id}`}
+								className="rounded-lg border border-border/70 bg-background/60 p-4"
 							>
-								<TabIcon className="h-4 w-4" />
-							</button>
-						);
-					})}
-				</div>
-
-				<div className="flex flex-1 min-h-0 flex-col">
-					<div className="flex-1 overflow-y-auto custom-scrollbar p-4 pb-0">
-						{zoomEnabled && (
-							<div className="mb-3 rounded-xl border border-[#2563EB]/20 border-l-2 border-l-[#2563EB] bg-[#2563EB]/5 p-3">
-								<div className="flex items-center justify-between mb-3">
-									<span className="text-sm font-medium text-slate-200">Zoom Settings</span>
+								<div className="mb-4">
 									<div className="flex items-center gap-2">
-										{selectedZoomDepth && (
-											<span className="text-[10px] uppercase tracking-wider font-medium text-[#2563EB] bg-[#2563EB]/10 px-2 py-0.5 rounded-full">
-												{ZOOM_DEPTH_OPTIONS.find((o) => o.depth === selectedZoomDepth)?.label}
-											</span>
-										)}
-										<KeyboardShortcutsHelp />
+										<ActiveTabIcon className="size-4 text-primary" />
+										<h3 className="text-sm font-medium text-foreground">
+											{activeTabDefinition.label}
+										</h3>
+										<Badge variant="secondary" className="ml-auto text-[10px]">
+											{activeTabDefinition.id}
+										</Badge>
 									</div>
+									<p className="mt-1 text-[10px] text-muted-foreground">
+										{activeTabDefinition.description}
+									</p>
 								</div>
-								<div className="grid grid-cols-6 gap-1.5 mb-3">
-									{ZOOM_DEPTH_OPTIONS.map((option) => {
-										const isActive = selectedZoomDepth === option.depth;
-										return (
-											<Button
-												key={option.depth}
-												type="button"
-												onClick={() => onZoomDepthChange?.(option.depth)}
-												className={cn(
-													"h-auto w-full rounded-lg border px-1 py-2 text-center shadow-sm transition-all",
-													"duration-200 ease-out",
-													"opacity-100 cursor-pointer",
-													isActive
-														? "border-[#2563EB] bg-[#2563EB] text-white shadow-[#2563EB]/20"
-														: "border-white/5 bg-white/5 text-slate-400 hover:bg-white/10 hover:border-white/10 hover:text-slate-200",
-												)}
-											>
-												<span className="text-xs font-semibold">{option.label}</span>
-											</Button>
-										);
-									})}
-								</div>
-								<div className="grid grid-cols-2 gap-2 mb-3">
-									<div className="p-2 rounded-lg bg-white/5 border border-white/5">
-										<div className="flex items-center justify-between mb-1">
-											<div className="text-[10px] font-medium text-slate-300">Motion Blur</div>
-											<span className="text-[10px] text-slate-500 font-mono">
-												{zoomMotionBlur.toFixed(2)}×
-											</span>
-										</div>
-										<Slider
-											value={[zoomMotionBlur]}
-											onValueChange={(values) => onZoomMotionBlurChange?.(values[0])}
-											min={0}
-											max={2}
-											step={0.05}
-											className="w-full"
-										/>
-									</div>
-									<div className="flex items-center justify-between p-2 rounded-lg bg-white/5 border border-white/5">
-										<div className="text-[10px] font-medium text-slate-300">Connect Zooms</div>
-										<Switch
-											checked={connectZooms}
-											onCheckedChange={onConnectZoomsChange}
-											className="data-[state=checked]:bg-[#2563EB] scale-90"
-										/>
-									</div>
-								</div>
-								<Button
-									onClick={handleDeleteClick}
-									variant="destructive"
-									size="sm"
-									className="mt-3 w-full gap-2 bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 hover:border-red-500/30 transition-all h-8 text-xs"
-								>
-									<Trash2 className="w-3 h-3" />
-									Delete Zoom
-								</Button>
+								{renderSelectedTabContent()}
 							</div>
-						)}
-
-						{trimEnabled && (
-							<div className="mb-3 rounded-xl border border-red-500/20 border-l-2 border-l-red-500 bg-red-500/5 p-3">
-								<Button
-									onClick={handleTrimDeleteClick}
-									variant="destructive"
-									size="sm"
-									className="w-full gap-2 bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 hover:border-red-500/30 transition-all h-8 text-xs"
-								>
-									<Trash2 className="w-3 h-3" />
-									Delete Trim Region
-								</Button>
-							</div>
-						)}
-
-						{selectedSpeedId && (
-							<div className="mb-3 rounded-xl border border-[#d97706]/20 border-l-2 border-l-[#d97706] bg-[#d97706]/5 p-3">
-								<div className="flex items-center justify-between mb-3">
-									<span className="text-sm font-medium text-slate-200">Speed Settings</span>
-									{selectedSpeedValue && (
-										<span className="text-[10px] uppercase tracking-wider font-medium text-[#d97706] bg-[#d97706]/10 px-2 py-0.5 rounded-full">
-											{SPEED_OPTIONS.find((o) => o.speed === selectedSpeedValue)?.label ??
-												`${selectedSpeedValue}×`}
-										</span>
-									)}
-								</div>
-								<div className="grid grid-cols-7 gap-1.5 mb-3">
-									{SPEED_OPTIONS.map((option) => {
-										const isActive = selectedSpeedValue === option.speed;
-										return (
-											<Button
-												key={option.speed}
-												type="button"
-												onClick={() => onSpeedChange?.(option.speed)}
-												className={cn(
-													"h-auto w-full rounded-lg border px-1 py-2 text-center shadow-sm transition-all",
-													"duration-200 ease-out",
-													"opacity-100 cursor-pointer",
-													isActive
-														? "border-[#d97706] bg-[#d97706] text-white shadow-[#d97706]/20"
-														: "border-white/5 bg-white/5 text-slate-400 hover:bg-white/10 hover:border-white/10 hover:text-slate-200",
-												)}
-											>
-												<span className="text-xs font-semibold">{option.label}</span>
-											</Button>
-										);
-									})}
-								</div>
-								<Button
-									onClick={() => selectedSpeedId && onSpeedDelete?.(selectedSpeedId)}
-									variant="destructive"
-									size="sm"
-									className="mt-3 w-full gap-2 bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 hover:border-red-500/30 transition-all h-8 text-xs"
-								>
-									<Trash2 className="w-3 h-3" />
-									Delete Speed Region
-								</Button>
-							</div>
-						)}
-
-						<div
-							role="tabpanel"
-							id={`settings-panel-${activeTabDefinition.id}`}
-							aria-labelledby={`settings-tab-${activeTabDefinition.id}`}
-							className="rounded-xl border border-white/5 bg-white/[0.02] p-4"
-						>
-							<div className="mb-4">
-								<div className="flex items-center gap-2">
-									<ActiveTabIcon className="h-4 w-4 text-[#2563EB]" />
-									<h3 className="text-sm font-medium text-slate-200">
-										{activeTabDefinition.label}
-									</h3>
-								</div>
-								<p className="mt-1 text-[10px] text-slate-500">{activeTabDefinition.description}</p>
-							</div>
-							{renderSelectedTabContent()}
 						</div>
-					</div>
 
-					<div className="flex-shrink-0 p-4 pt-3 border-t border-white/5 bg-[#09090b]">
-						<div className="flex gap-2">
-							<button
-								type="button"
-								onClick={() => {
-									openExternalUrl("https://github.com/imbhargav5/open-recorder/issues/new/choose");
-								}}
-								className="flex-1 flex items-center justify-center gap-1.5 text-[10px] text-slate-500 hover:text-slate-300 py-1.5 transition-colors"
-							>
-								<Bug className="w-3 h-3 text-[#2563EB]" />
-								Report Bug
-							</button>
-							<button
-								type="button"
-								onClick={() => {
-									openExternalUrl("https://github.com/imbhargav5/open-recorder");
-								}}
-								className="flex-1 flex items-center justify-center gap-1.5 text-[10px] text-slate-500 hover:text-slate-300 py-1.5 transition-colors"
-							>
-								<Star className="w-3 h-3 text-yellow-400" />
-								Star on GitHub
-							</button>
+						<div className="flex-shrink-0 border-t border-border/60 bg-muted/20 p-4 pt-3">
+							<div className="flex gap-2">
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									onClick={() => {
+										openExternalUrl(
+											"https://github.com/imbhargav5/open-recorder/issues/new/choose",
+										);
+									}}
+									className="flex-1 text-[10px] text-muted-foreground"
+								>
+									<Bug data-icon="inline-start" />
+									Report Bug
+								</Button>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									onClick={() => {
+										openExternalUrl("https://github.com/imbhargav5/open-recorder");
+									}}
+									className="flex-1 text-[10px] text-muted-foreground"
+								>
+									<Star data-icon="inline-start" />
+									Star on GitHub
+								</Button>
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
+			</CardContent>
 			{showCropModal && cropRegion && onCropChange && (
 				<>
 					<div
@@ -1212,7 +1345,7 @@ function SettingsPanelInner({
 					</div>
 				</>
 			)}
-		</div>
+		</Card>
 	);
 }
 

--- a/apps/desktop/src/components/video-editor/VideoEditor.tsx
+++ b/apps/desktop/src/components/video-editor/VideoEditor.tsx
@@ -56,7 +56,9 @@ import {
 } from "@/atoms/videoEditor";
 import { ProjectsPage } from "@/components/projects/ProjectsPage";
 import { AppSidebar } from "@/components/shell/AppSidebar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
 	Empty,
 	EmptyDescription,
@@ -65,8 +67,10 @@ import {
 	EmptyTitle,
 } from "@/components/ui/empty";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
 import { Toaster } from "@/components/ui/sonner";
 import { Switch } from "@/components/ui/switch";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useShortcuts } from "@/contexts/ShortcutsContext";
 import { useWaveformData } from "@/hooks/useWaveformData";
 import { getAssetPath } from "@/lib/assetPath";
@@ -91,7 +95,6 @@ import {
 	normalizeFacecamSettings,
 } from "@/lib/recordingSession";
 import { matchesShortcut } from "@/lib/shortcuts";
-import { cn } from "@/lib/utils";
 import { DEFAULT_WALLPAPER_RELATIVE_PATH, WALLPAPER_PATHS } from "@/lib/wallpapers";
 import { getAspectRatioValue } from "@/utils/aspectRatioUtils";
 import { AllShortcutsDialog } from "./AllShortcutsDialog";
@@ -114,6 +117,7 @@ import {
 	type AnnotationRegion,
 	type CursorTelemetryPoint,
 	clampFocusToDepth,
+	createDefaultZoomEasing,
 	DEFAULT_ANNOTATION_POSITION,
 	DEFAULT_ANNOTATION_SIZE,
 	DEFAULT_ANNOTATION_STYLE,
@@ -125,6 +129,7 @@ import {
 	type SpeedRegion,
 	type TrimRegion,
 	type ZoomDepth,
+	type ZoomEasing,
 	type ZoomFocus,
 	type ZoomRegion,
 } from "./types";
@@ -324,27 +329,36 @@ function EditorTitleBar({
 
 	return (
 		<div
-			className="relative h-10 flex-shrink-0 bg-[#09090b]/80 backdrop-blur-md border-b border-white/5 flex items-center justify-center px-6 z-50"
+			className="relative z-50 flex h-12 flex-shrink-0 items-center justify-center border-b border-border/60 bg-card/95 px-4 shadow-sm backdrop-blur-md"
 			style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
 		>
 			<div
-				className="absolute left-2 flex items-center"
+				className="absolute left-2 flex items-center gap-2"
 				style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
 			>
-				<button
+				<Button
 					type="button"
 					onClick={() => setSidebarExpanded(!sidebarExpanded)}
 					aria-label={sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"}
 					aria-expanded={sidebarExpanded}
 					title={sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"}
-					className="inline-flex h-7 w-7 items-center justify-center rounded-md text-white/60 transition hover:bg-white/8 hover:text-white cursor-pointer"
+					variant="ghost"
+					size="icon"
+					className="size-8"
 				>
-					<PanelLeft className="h-4 w-4" />
-				</button>
+					<PanelLeft />
+				</Button>
 			</div>
-			<span className="text-sm font-semibold tracking-tight text-white/90">
-				{internalView === "projects" ? "Projects" : editorNavbarTitle}
-			</span>
+			<div className="flex min-w-0 items-center gap-2">
+				<span className="max-w-[46vw] truncate text-sm font-semibold tracking-tight text-foreground">
+					{internalView === "projects" ? "Projects" : editorNavbarTitle}
+				</span>
+				{internalView === "editor" ? (
+					<Badge variant="secondary" className="text-[10px]">
+						{exportFormat.toUpperCase()}
+					</Badge>
+				) : null}
+			</div>
 			{internalView === "editor" && (
 				<div
 					className="absolute right-4 flex items-center gap-2"
@@ -356,18 +370,19 @@ function EditorTitleBar({
 								type="button"
 								size="sm"
 								onClick={onOpenExportDialog}
-								className="h-7 rounded-r-none gap-1.5 bg-[#2563EB] text-white text-xs font-medium hover:bg-[#2563EB]/90 active:scale-[0.98] transition-all"
+								className="h-8 rounded-r-none text-xs font-medium"
 							>
-								<Download className="w-3.5 h-3.5" />
+								<Download data-icon="inline-start" />
 								Export {exportFormat === "gif" ? "GIF" : "Video"}
 							</Button>
 							<PopoverTrigger asChild>
 								<Button
 									type="button"
 									size="sm"
-									className="h-7 w-7 p-0 rounded-l-none border-l border-[#2563EB]/50 bg-[#2563EB] text-white hover:bg-[#2563EB]/90 active:scale-[0.98] transition-all"
+									className="h-8 w-8 rounded-l-none border-l border-primary-foreground/20 px-0"
+									aria-label="Export settings"
 								>
-									<ChevronDown className="w-3.5 h-3.5" />
+									<ChevronDown />
 								</Button>
 							</PopoverTrigger>
 						</div>
@@ -375,128 +390,124 @@ function EditorTitleBar({
 							side="bottom"
 							align="end"
 							sideOffset={8}
-							className="w-[280px] bg-[#09090b] border-white/10 p-3 rounded-xl"
+							className="w-[320px] border-border/70 bg-popover p-0 shadow-2xl"
 						>
-							<div className="space-y-3">
-								<div className="flex items-center gap-2">
-									<button
-										onClick={() => setExportFormat("mp4")}
-										className={cn(
-											"flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border transition-all text-xs font-medium",
-											exportFormat === "mp4"
-												? "bg-[#2563EB]/10 border-[#2563EB]/50 text-white"
-												: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-slate-200",
-										)}
-									>
-										<Film className="w-3.5 h-3.5" />
-										MP4
-									</button>
-									<button
-										onClick={() => setExportFormat("gif")}
-										className={cn(
-											"flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border transition-all text-xs font-medium",
-											exportFormat === "gif"
-												? "bg-[#2563EB]/10 border-[#2563EB]/50 text-white"
-												: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10 hover:text-slate-200",
-										)}
-									>
-										<Image className="w-3.5 h-3.5" />
-										GIF
-									</button>
-								</div>
-
-								{exportFormat === "mp4" && (
-									<div className="bg-white/5 border border-white/5 p-0.5 w-full grid grid-cols-3 h-7 rounded-lg">
-										<button
-											onClick={() => setExportQuality("medium")}
-											className={cn(
-												"rounded-md transition-all text-[10px] font-medium",
-												exportQuality === "medium"
-													? "bg-white text-black"
-													: "text-slate-400 hover:text-slate-200",
-											)}
-										>
-											Low
-										</button>
-										<button
-											onClick={() => setExportQuality("good")}
-											className={cn(
-												"rounded-md transition-all text-[10px] font-medium",
-												exportQuality === "good"
-													? "bg-white text-black"
-													: "text-slate-400 hover:text-slate-200",
-											)}
-										>
-											Medium
-										</button>
-										<button
-											onClick={() => setExportQuality("source")}
-											className={cn(
-												"rounded-md transition-all text-[10px] font-medium",
-												exportQuality === "source"
-													? "bg-white text-black"
-													: "text-slate-400 hover:text-slate-200",
-											)}
-										>
-											High
-										</button>
+							<Card className="border-0 bg-transparent shadow-none">
+								<CardHeader className="p-3 pb-2">
+									<div className="flex items-center justify-between gap-3">
+										<CardTitle className="text-sm">Export</CardTitle>
+										<Badge variant="outline" className="text-[10px]">
+											Quick settings
+										</Badge>
 									</div>
-								)}
+								</CardHeader>
+								<CardContent className="flex flex-col gap-3 p-3 pt-0">
+									<ToggleGroup
+										type="single"
+										value={exportFormat}
+										onValueChange={(value) => {
+											if (value === "mp4" || value === "gif") {
+												setExportFormat(value);
+											}
+										}}
+										className="grid grid-cols-2 rounded-lg border border-border bg-muted/30 p-1"
+									>
+										<ToggleGroupItem value="mp4" className="h-8 gap-1.5 text-xs">
+											<Film data-icon="inline-start" />
+											MP4
+										</ToggleGroupItem>
+										<ToggleGroupItem value="gif" className="h-8 gap-1.5 text-xs">
+											<Image data-icon="inline-start" />
+											GIF
+										</ToggleGroupItem>
+									</ToggleGroup>
 
-								{exportFormat === "gif" && (
-									<div className="space-y-2">
-										<div className="flex items-center gap-2">
-											<div className="flex-1 bg-white/5 border border-white/5 p-0.5 grid grid-cols-4 h-7 rounded-lg">
-												{GIF_FRAME_RATES.map((rate) => (
-													<button
-														key={rate.value}
-														onClick={() => setGifFrameRate(rate.value)}
-														className={cn(
-															"rounded-md transition-all text-[10px] font-medium",
-															gifFrameRate === rate.value
-																? "bg-white text-black"
-																: "text-slate-400 hover:text-slate-200",
-														)}
-													>
-														{rate.value}
-													</button>
-												))}
+									{exportFormat === "mp4" && (
+										<ToggleGroup
+											type="single"
+											value={exportQuality}
+											onValueChange={(value) => {
+												if (value === "medium" || value === "good" || value === "source") {
+													setExportQuality(value);
+												}
+											}}
+											className="grid grid-cols-3 rounded-lg border border-border bg-muted/30 p-1"
+										>
+											<ToggleGroupItem value="medium" className="h-7 text-[10px]">
+												Low
+											</ToggleGroupItem>
+											<ToggleGroupItem value="good" className="h-7 text-[10px]">
+												Medium
+											</ToggleGroupItem>
+											<ToggleGroupItem value="source" className="h-7 text-[10px]">
+												High
+											</ToggleGroupItem>
+										</ToggleGroup>
+									)}
+
+									{exportFormat === "gif" && (
+										<div className="flex flex-col gap-2">
+											<div className="grid grid-cols-[1.2fr_1fr] gap-2">
+												<ToggleGroup
+													type="single"
+													value={String(gifFrameRate)}
+													onValueChange={(value) => {
+														const nextRate = GIF_FRAME_RATES.find(
+															(rate) => String(rate.value) === value,
+														)?.value;
+														if (nextRate !== undefined) {
+															setGifFrameRate(nextRate);
+														}
+													}}
+													className="grid grid-cols-4 rounded-lg border border-border bg-muted/30 p-1"
+												>
+													{GIF_FRAME_RATES.map((rate) => (
+														<ToggleGroupItem
+															key={rate.value}
+															value={String(rate.value)}
+															className="h-7 text-[10px]"
+														>
+															{rate.value}
+														</ToggleGroupItem>
+													))}
+												</ToggleGroup>
+												<ToggleGroup
+													type="single"
+													value={gifSizePreset}
+													onValueChange={(value) => {
+														if (value in GIF_SIZE_PRESETS) {
+															setGifSizePreset(value as GifSizePreset);
+														}
+													}}
+													className="grid grid-cols-3 rounded-lg border border-border bg-muted/30 p-1"
+												>
+													{Object.entries(GIF_SIZE_PRESETS).map(([key]) => (
+														<ToggleGroupItem key={key} value={key} className="h-7 text-[10px]">
+															{key === "original"
+																? "Orig"
+																: key.charAt(0).toUpperCase() + key.slice(1, 3)}
+														</ToggleGroupItem>
+													))}
+												</ToggleGroup>
 											</div>
-											<div className="flex-1 bg-white/5 border border-white/5 p-0.5 grid grid-cols-3 h-7 rounded-lg">
-												{Object.entries(GIF_SIZE_PRESETS).map(([key]) => (
-													<button
-														key={key}
-														onClick={() => setGifSizePreset(key as GifSizePreset)}
-														className={cn(
-															"rounded-md transition-all text-[10px] font-medium",
-															gifSizePreset === key
-																? "bg-white text-black"
-																: "text-slate-400 hover:text-slate-200",
-														)}
-													>
-														{key === "original"
-															? "Orig"
-															: key.charAt(0).toUpperCase() + key.slice(1, 3)}
-													</button>
-												))}
+											<Separator />
+											<div className="flex items-center justify-between text-[10px] text-muted-foreground">
+												<span>
+													{gifOutputDimensions.width} × {gifOutputDimensions.height}px
+												</span>
+												<div className="flex items-center gap-2">
+													<span>Loop</span>
+													<Switch
+														checked={gifLoop}
+														onCheckedChange={setGifLoop}
+														className="scale-75 data-[state=checked]:bg-primary"
+													/>
+												</div>
 											</div>
 										</div>
-										<div className="flex items-center justify-between">
-											<span className="text-[10px] text-slate-500">
-												{gifOutputDimensions.width} × {gifOutputDimensions.height}px
-											</span>
-											<div className="flex items-center gap-2">
-												<span className="text-[10px] text-slate-400">Loop</span>
-												<Switch
-													checked={gifLoop}
-													onCheckedChange={setGifLoop}
-													className="data-[state=checked]:bg-[#2563EB] scale-75"
-												/>
-											</div>
-										</div>
-									</div>
-								)}
-							</div>
+									)}
+								</CardContent>
+							</Card>
 						</PopoverContent>
 					</Popover>
 				</div>
@@ -1160,6 +1171,8 @@ export default function VideoEditor() {
 				cx: dominantAtStart.focus.cx,
 				cy: dominantAtStart.focus.cy,
 			},
+			easeIn: { ...dominantAtStart.easeIn },
+			easeOut: { ...dominantAtStart.easeOut },
 		};
 
 		return [...zoomRegions.filter((region) => region.id !== loopEndRegion.id), loopEndRegion];
@@ -1227,6 +1240,7 @@ export default function VideoEditor() {
 					endMs,
 					depth: DEFAULT_ZOOM_DEPTH,
 					focus: clampFocusToDepth(candidate.focus, DEFAULT_ZOOM_DEPTH),
+					...createDefaultZoomEasing(),
 				});
 				reservedSpans.push({ start: startMs, end: endMs });
 				acceptedCenters.push(candidate.centerTimeMs);
@@ -1324,6 +1338,17 @@ export default function VideoEditor() {
 		return zoomRegions.find((z) => z.id === selectedZoomId)?.depth ?? null;
 	}, [selectedZoomId, zoomRegions]);
 
+	const selectedZoomEasing = useMemo(() => {
+		if (!selectedZoomId) return null;
+		const selectedZoom = zoomRegions.find((z) => z.id === selectedZoomId);
+		if (!selectedZoom) return null;
+
+		return {
+			easeIn: selectedZoom.easeIn,
+			easeOut: selectedZoom.easeOut,
+		};
+	}, [selectedZoomId, zoomRegions]);
+
 	const selectedSpeedValue = useMemo(() => {
 		if (!selectedSpeedId) return null;
 		return speedRegions.find((r) => r.id === selectedSpeedId)?.speed ?? null;
@@ -1331,13 +1356,18 @@ export default function VideoEditor() {
 
 	const handleSelectZoom = useCallback((id: string | null) => {
 		setSelectedZoomId(id);
-		if (id) setSelectedTrimId(null);
+		if (id) {
+			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
+			setSelectedAnnotationId(null);
+		}
 	}, []);
 
 	const handleSelectTrim = useCallback((id: string | null) => {
 		setSelectedTrimId(id);
 		if (id) {
 			setSelectedZoomId(null);
+			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 		}
 	}, []);
@@ -1347,6 +1377,7 @@ export default function VideoEditor() {
 		if (id) {
 			setSelectedZoomId(null);
 			setSelectedTrimId(null);
+			setSelectedSpeedId(null);
 		}
 	}, []);
 
@@ -1358,10 +1389,12 @@ export default function VideoEditor() {
 			endMs: Math.round(span.end),
 			depth: DEFAULT_ZOOM_DEPTH,
 			focus: { cx: 0.5, cy: 0.5 },
+			...createDefaultZoomEasing(),
 		};
 		setZoomRegions((prev) => [...prev, newRegion]);
 		setSelectedZoomId(id);
 		setSelectedTrimId(null);
+		setSelectedSpeedId(null);
 		setSelectedAnnotationId(null);
 	}, []);
 
@@ -1373,10 +1406,12 @@ export default function VideoEditor() {
 			endMs: Math.round(span.end),
 			depth: DEFAULT_ZOOM_DEPTH,
 			focus: clampFocusToDepth(focus, DEFAULT_ZOOM_DEPTH),
+			...createDefaultZoomEasing(),
 		};
 		setZoomRegions((prev) => [...prev, newRegion]);
 		setSelectedZoomId(id);
 		setSelectedTrimId(null);
+		setSelectedSpeedId(null);
 		setSelectedAnnotationId(null);
 	}, []);
 
@@ -1390,6 +1425,7 @@ export default function VideoEditor() {
 		setTrimRegions((prev) => [...prev, newRegion]);
 		setSelectedTrimId(id);
 		setSelectedZoomId(null);
+		setSelectedSpeedId(null);
 		setSelectedAnnotationId(null);
 	}, []);
 
@@ -1444,6 +1480,26 @@ export default function VideoEditor() {
 								...region,
 								depth,
 								focus: clampFocusToDepth(region.focus, depth),
+							}
+						: region,
+				),
+			);
+		},
+		[selectedZoomId],
+	);
+
+	const handleZoomEaseChange = useCallback(
+		(side: "easeIn" | "easeOut", patch: Partial<ZoomEasing>) => {
+			if (!selectedZoomId) return;
+			setZoomRegions((prev) =>
+				prev.map((region) =>
+					region.id === selectedZoomId
+						? {
+								...region,
+								[side]: {
+									...region[side],
+									...patch,
+								},
 							}
 						: region,
 				),
@@ -1548,6 +1604,7 @@ export default function VideoEditor() {
 		setSelectedAnnotationId(id);
 		setSelectedZoomId(null);
 		setSelectedTrimId(null);
+		setSelectedSpeedId(null);
 	}, []);
 
 	const handleAnnotationSpanChange = useCallback((id: string, span: Span) => {
@@ -2229,7 +2286,7 @@ export default function VideoEditor() {
 	}
 
 	return (
-		<div className="flex h-screen bg-[#09090b] text-slate-200 overflow-hidden selection:bg-[#2563EB]/30">
+		<div className="flex h-screen overflow-hidden bg-background text-foreground selection:bg-primary/30">
 			{showPlaybackLoadingOverlay && (
 				<div className="fixed inset-0 z-[120] flex items-center justify-center bg-[#09090b]/92 px-6 backdrop-blur-sm">
 					<Empty className="border-white/10 bg-white/[0.02]">
@@ -2256,156 +2313,160 @@ export default function VideoEditor() {
 				{internalView === "projects" ? (
 					<ProjectsPage onOpenProject={handleLoadProject} />
 				) : (
-					<div className="flex-1 p-5 gap-4 flex min-h-0 relative">
+					<div className="relative flex min-h-0 flex-1 gap-4 bg-muted/20 p-4">
 						{/* Left Column - Video & Timeline */}
 						<div className="flex-[7] flex flex-col gap-3 min-w-0 h-full">
 							<PanelGroup direction="vertical" className="gap-3">
 								{/* Top section: video preview and controls */}
 								<Panel defaultSize={70} minSize={40}>
-									<div className="w-full h-full flex flex-col items-center justify-center bg-black/40 rounded-2xl border border-white/5 shadow-2xl overflow-hidden">
-										{/* Video preview */}
-										<div
-											className="w-full flex justify-center items-center"
-											style={{ flex: "1 1 auto", margin: "6px 0 0" }}
-										>
+									<Card className="h-full overflow-hidden border-border/70 bg-card/80 shadow-2xl shadow-black/20">
+										<CardContent className="flex h-full flex-col items-center justify-center p-0">
+											{/* Video preview */}
 											<div
-												className="relative"
+												className="w-full flex justify-center items-center"
+												style={{ flex: "1 1 auto", margin: "6px 0 0" }}
+											>
+												<div
+													className="relative"
+													style={{
+														width: "auto",
+														height: "100%",
+														aspectRatio: getAspectRatioValue(
+															aspectRatio,
+															(() => {
+																const previewVideo = videoPlaybackRef.current?.video;
+																if (previewVideo && previewVideo.videoHeight > 0) {
+																	return previewVideo.videoWidth / previewVideo.videoHeight;
+																}
+																return 16 / 9;
+															})(),
+														),
+														maxWidth: "100%",
+														margin: "0 auto",
+														boxSizing: "border-box",
+													}}
+												>
+													<Profiler id="VideoPlayback" onRender={onRenderProfiler}>
+														<VideoPlayback
+															aspectRatio={aspectRatio}
+															ref={videoPlaybackRef}
+															videoPath={videoPath || ""}
+															facecamVideoPath={facecamPlaybackPath || undefined}
+															facecamOffsetMs={facecamOffsetMs}
+															facecamSettings={facecamSettings}
+															onDurationChange={setDuration}
+															onTimeUpdate={timeStore.setTime}
+															onPlayStateChange={setIsPlaying}
+															onError={setError}
+															wallpaper={wallpaper}
+															audioMuted={audioMuted}
+															audioVolume={audioVolume}
+															zoomRegions={effectiveZoomRegions}
+															selectedZoomId={selectedZoomId}
+															onSelectZoom={handleSelectZoom}
+															onZoomFocusChange={handleZoomFocusChange}
+															isPlaying={isPlaying}
+															showShadow={shadowIntensity > 0}
+															shadowIntensity={shadowIntensity}
+															backgroundBlur={backgroundBlur}
+															zoomMotionBlur={zoomMotionBlur}
+															connectZooms={connectZooms}
+															borderRadius={borderRadius}
+															padding={padding}
+															cropRegion={cropRegion}
+															trimRegions={trimRegions}
+															speedRegions={speedRegions}
+															annotationRegions={annotationRegions}
+															selectedAnnotationId={selectedAnnotationId}
+															onSelectAnnotation={handleSelectAnnotation}
+															onAnnotationPositionChange={handleAnnotationPositionChange}
+															onAnnotationSizeChange={handleAnnotationSizeChange}
+															cursorTelemetry={effectiveCursorTelemetry}
+															showCursor={showCursor}
+															cursorSize={cursorSize}
+															cursorSmoothing={cursorSmoothing}
+															cursorMotionBlur={cursorMotionBlur}
+															cursorClickBounce={cursorClickBounce}
+															onReadyChange={setPlaybackReady}
+															onFacecamPositionChange={handleFacecamPositionChange}
+														/>
+													</Profiler>
+												</div>
+											</div>
+											{/* Playback controls */}
+											<div
+												className="w-full flex justify-center items-center"
 												style={{
-													width: "auto",
-													height: "100%",
-													aspectRatio: getAspectRatioValue(
-														aspectRatio,
-														(() => {
-															const previewVideo = videoPlaybackRef.current?.video;
-															if (previewVideo && previewVideo.videoHeight > 0) {
-																return previewVideo.videoWidth / previewVideo.videoHeight;
-															}
-															return 16 / 9;
-														})(),
-													),
-													maxWidth: "100%",
-													margin: "0 auto",
-													boxSizing: "border-box",
+													height: "48px",
+													flexShrink: 0,
+													padding: "6px 12px",
+													margin: "6px 0 6px 0",
 												}}
 											>
-												<Profiler id="VideoPlayback" onRender={onRenderProfiler}>
-													<VideoPlayback
-														aspectRatio={aspectRatio}
-														ref={videoPlaybackRef}
-														videoPath={videoPath || ""}
-														facecamVideoPath={facecamPlaybackPath || undefined}
-														facecamOffsetMs={facecamOffsetMs}
-														facecamSettings={facecamSettings}
-														onDurationChange={setDuration}
-														onTimeUpdate={timeStore.setTime}
-														onPlayStateChange={setIsPlaying}
-														onError={setError}
-														wallpaper={wallpaper}
-														audioMuted={audioMuted}
-														audioVolume={audioVolume}
-														zoomRegions={effectiveZoomRegions}
-														selectedZoomId={selectedZoomId}
-														onSelectZoom={handleSelectZoom}
-														onZoomFocusChange={handleZoomFocusChange}
-														isPlaying={isPlaying}
-														showShadow={shadowIntensity > 0}
-														shadowIntensity={shadowIntensity}
-														backgroundBlur={backgroundBlur}
-														zoomMotionBlur={zoomMotionBlur}
-														connectZooms={connectZooms}
-														borderRadius={borderRadius}
-														padding={padding}
-														cropRegion={cropRegion}
-														trimRegions={trimRegions}
-														speedRegions={speedRegions}
-														annotationRegions={annotationRegions}
-														selectedAnnotationId={selectedAnnotationId}
-														onSelectAnnotation={handleSelectAnnotation}
-														onAnnotationPositionChange={handleAnnotationPositionChange}
-														onAnnotationSizeChange={handleAnnotationSizeChange}
-														cursorTelemetry={effectiveCursorTelemetry}
-														showCursor={showCursor}
-														cursorSize={cursorSize}
-														cursorSmoothing={cursorSmoothing}
-														cursorMotionBlur={cursorMotionBlur}
-														cursorClickBounce={cursorClickBounce}
-														onReadyChange={setPlaybackReady}
-														onFacecamPositionChange={handleFacecamPositionChange}
-													/>
-												</Profiler>
+												<div style={{ width: "100%", maxWidth: "700px" }}>
+													<Profiler id="PlaybackControls" onRender={onRenderProfiler}>
+														<PlaybackControls
+															isPlaying={isPlaying}
+															timeStore={timeStore}
+															duration={duration}
+															onTogglePlayPause={togglePlayPause}
+															onSeek={handleSeek}
+														/>
+													</Profiler>
+												</div>
 											</div>
-										</div>
-										{/* Playback controls */}
-										<div
-											className="w-full flex justify-center items-center"
-											style={{
-												height: "48px",
-												flexShrink: 0,
-												padding: "6px 12px",
-												margin: "6px 0 6px 0",
-											}}
-										>
-											<div style={{ width: "100%", maxWidth: "700px" }}>
-												<Profiler id="PlaybackControls" onRender={onRenderProfiler}>
-													<PlaybackControls
-														isPlaying={isPlaying}
-														timeStore={timeStore}
-														duration={duration}
-														onTogglePlayPause={togglePlayPause}
-														onSeek={handleSeek}
-													/>
-												</Profiler>
-											</div>
-										</div>
-									</div>
+										</CardContent>
+									</Card>
 								</Panel>
 
-								<PanelResizeHandle className="h-3 bg-[#09090b]/80 hover:bg-[#09090b] transition-colors rounded-full mx-4 flex items-center justify-center">
-									<div className="w-8 h-1 bg-white/20 rounded-full"></div>
+								<PanelResizeHandle className="mx-4 flex h-3 items-center justify-center rounded-full bg-background/80 transition-colors hover:bg-background">
+									<div className="h-1 w-8 rounded-full bg-border"></div>
 								</PanelResizeHandle>
 
 								{/* Timeline section */}
 								<Panel defaultSize={30} minSize={20}>
-									<div className="h-full min-h-0 bg-[#09090b] rounded-2xl border border-white/5 shadow-lg overflow-auto flex flex-col">
-										<Profiler id="TimelineEditor" onRender={onRenderProfiler}>
-											<TimelineEditor
-												videoDuration={duration}
-												timeStore={timeStore}
-												onSeek={handleSeek}
-												cursorTelemetry={effectiveCursorTelemetry}
-												zoomRegions={effectiveZoomRegions}
-												onZoomAdded={handleZoomAdded}
-												onZoomSuggested={handleZoomSuggested}
-												onZoomSpanChange={handleZoomSpanChange}
-												onZoomDelete={handleZoomDelete}
-												selectedZoomId={selectedZoomId}
-												onSelectZoom={handleSelectZoom}
-												trimRegions={trimRegions}
-												onTrimAdded={handleTrimAdded}
-												onTrimSpanChange={handleTrimSpanChange}
-												onTrimDelete={handleTrimDelete}
-												selectedTrimId={selectedTrimId}
-												onSelectTrim={handleSelectTrim}
-												speedRegions={speedRegions}
-												onSpeedAdded={handleSpeedAdded}
-												onSpeedSpanChange={handleSpeedSpanChange}
-												onSpeedDelete={handleSpeedDelete}
-												selectedSpeedId={selectedSpeedId}
-												onSelectSpeed={handleSelectSpeed}
-												annotationRegions={annotationRegions}
-												onAnnotationAdded={handleAnnotationAdded}
-												onAnnotationSpanChange={handleAnnotationSpanChange}
-												onAnnotationDelete={handleAnnotationDelete}
-												selectedAnnotationId={selectedAnnotationId}
-												onSelectAnnotation={handleSelectAnnotation}
-												aspectRatio={aspectRatio}
-												onAspectRatioChange={setAspectRatio}
-												waveformData={waveformData}
-												waveformLoading={waveformLoading}
-												audioMuted={audioMuted}
-											/>
-										</Profiler>
-									</div>
+									<Card className="flex h-full min-h-0 flex-col overflow-auto border-border/70 bg-card/80 shadow-xl shadow-black/10">
+										<CardContent className="flex min-h-0 flex-1 flex-col p-0">
+											<Profiler id="TimelineEditor" onRender={onRenderProfiler}>
+												<TimelineEditor
+													videoDuration={duration}
+													timeStore={timeStore}
+													onSeek={handleSeek}
+													cursorTelemetry={effectiveCursorTelemetry}
+													zoomRegions={effectiveZoomRegions}
+													onZoomAdded={handleZoomAdded}
+													onZoomSuggested={handleZoomSuggested}
+													onZoomSpanChange={handleZoomSpanChange}
+													onZoomDelete={handleZoomDelete}
+													selectedZoomId={selectedZoomId}
+													onSelectZoom={handleSelectZoom}
+													trimRegions={trimRegions}
+													onTrimAdded={handleTrimAdded}
+													onTrimSpanChange={handleTrimSpanChange}
+													onTrimDelete={handleTrimDelete}
+													selectedTrimId={selectedTrimId}
+													onSelectTrim={handleSelectTrim}
+													speedRegions={speedRegions}
+													onSpeedAdded={handleSpeedAdded}
+													onSpeedSpanChange={handleSpeedSpanChange}
+													onSpeedDelete={handleSpeedDelete}
+													selectedSpeedId={selectedSpeedId}
+													onSelectSpeed={handleSelectSpeed}
+													annotationRegions={annotationRegions}
+													onAnnotationAdded={handleAnnotationAdded}
+													onAnnotationSpanChange={handleAnnotationSpanChange}
+													onAnnotationDelete={handleAnnotationDelete}
+													selectedAnnotationId={selectedAnnotationId}
+													onSelectAnnotation={handleSelectAnnotation}
+													aspectRatio={aspectRatio}
+													onAspectRatioChange={setAspectRatio}
+													waveformData={waveformData}
+													waveformLoading={waveformLoading}
+													audioMuted={audioMuted}
+												/>
+											</Profiler>
+										</CardContent>
+									</Card>
 								</Panel>
 							</PanelGroup>
 						</div>
@@ -2421,6 +2482,9 @@ export default function VideoEditor() {
 								onAudioVolumeChange={setAudioVolume}
 								selectedZoomDepth={selectedZoomDepth}
 								onZoomDepthChange={handleZoomDepthChange}
+								selectedZoomEaseIn={selectedZoomEasing?.easeIn ?? null}
+								selectedZoomEaseOut={selectedZoomEasing?.easeOut ?? null}
+								onZoomEaseChange={handleZoomEaseChange}
 								selectedZoomId={selectedZoomId}
 								onZoomDelete={handleZoomDelete}
 								selectedTrimId={selectedTrimId}

--- a/apps/desktop/src/components/video-editor/projectPersistence.test.ts
+++ b/apps/desktop/src/components/video-editor/projectPersistence.test.ts
@@ -16,6 +16,8 @@ import {
 	DEFAULT_CURSOR_MOTION_BLUR,
 	DEFAULT_CURSOR_SIZE,
 	DEFAULT_CURSOR_SMOOTHING,
+	DEFAULT_ZOOM_EASE_IN,
+	DEFAULT_ZOOM_EASE_OUT,
 	DEFAULT_ZOOM_MOTION_BLUR,
 } from "./types";
 
@@ -98,7 +100,7 @@ describe("projectPersistence", () => {
 					depth: 9 as never,
 					focus: { cx: -3, cy: 4 },
 				},
-			],
+			] as never,
 			trimRegions: [
 				{
 					id: "trim-1",
@@ -177,6 +179,8 @@ describe("projectPersistence", () => {
 				endMs: 1001,
 				depth: 3,
 				focus: { cx: 0, cy: 1 },
+				easeIn: DEFAULT_ZOOM_EASE_IN,
+				easeOut: DEFAULT_ZOOM_EASE_OUT,
 			},
 		]);
 		expect(normalized.trimRegions).toEqual([
@@ -237,6 +241,33 @@ describe("projectPersistence", () => {
 		});
 
 		expect(normalized.annotationRegions[0]?.style.color).toBe("#000");
+	});
+
+	it("sanitizes persisted zoom easing values", () => {
+		const normalized = normalizeProjectEditor({
+			zoomRegions: [
+				{
+					id: "zoom-1",
+					startMs: 0,
+					endMs: 1000,
+					depth: 3,
+					focus: { cx: 0.5, cy: 0.5 },
+					easeIn: { durationMs: -250, type: "broken" },
+					easeOut: { durationMs: 7000, type: "ease-in-out" },
+				},
+			] as never,
+		});
+
+		expect(normalized.zoomRegions[0]).toMatchObject({
+			easeIn: {
+				durationMs: 0,
+				type: DEFAULT_ZOOM_EASE_IN.type,
+			},
+			easeOut: {
+				durationMs: 5000,
+				type: "ease-in-out",
+			},
+		});
 	});
 
 	it("keeps numeric editor state within bounds for a wide range of inputs", () => {

--- a/apps/desktop/src/components/video-editor/projectPersistence.ts
+++ b/apps/desktop/src/components/video-editor/projectPersistence.ts
@@ -19,13 +19,19 @@ import {
 	DEFAULT_FIGURE_DATA,
 	DEFAULT_PLAYBACK_SPEED,
 	DEFAULT_ZOOM_DEPTH,
+	DEFAULT_ZOOM_EASE_IN,
+	DEFAULT_ZOOM_EASE_OUT,
 	DEFAULT_ZOOM_MOTION_BLUR,
 	type SpeedRegion,
 	type TrimRegion,
+	ZOOM_EASE_TYPES,
+	type ZoomDepth,
+	type ZoomEaseType,
+	type ZoomEasing,
 	type ZoomRegion,
 } from "./types";
 
-export const PROJECT_VERSION = 3;
+export const PROJECT_VERSION = 4;
 
 export interface ProjectEditorState {
 	wallpaper: string;
@@ -74,6 +80,26 @@ function clamp(value: number, min: number, max: number) {
 	return Math.min(max, Math.max(min, value));
 }
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object");
+}
+
+function isZoomEaseType(value: unknown): value is ZoomEaseType {
+	return typeof value === "string" && ZOOM_EASE_TYPES.includes(value as ZoomEaseType);
+}
+
+function normalizeZoomEasing(value: unknown, fallback: ZoomEasing): ZoomEasing {
+	const candidate = isObjectRecord(value) ? value : {};
+	const rawDuration = candidate.durationMs;
+
+	return {
+		durationMs: isFiniteNumber(rawDuration)
+			? Math.round(clamp(rawDuration, 0, 5000))
+			: fallback.durationMs,
+		type: isZoomEaseType(candidate.type) ? candidate.type : fallback.type,
+	};
+}
+
 export { fromFileUrl, toFileUrl };
 
 export function deriveNextId(prefix: string, ids: string[]): number {
@@ -115,24 +141,35 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 			? 2
 			: 0;
 
-	const normalizedZoomRegions: ZoomRegion[] = Array.isArray(editor.zoomRegions)
-		? editor.zoomRegions
-				.filter((region): region is ZoomRegion => Boolean(region && typeof region.id === "string"))
+	const rawZoomRegions = (editor as Partial<{ zoomRegions: unknown }>).zoomRegions;
+	const normalizedZoomRegions: ZoomRegion[] = Array.isArray(rawZoomRegions)
+		? rawZoomRegions
+				.filter(
+					(region): region is Record<string, unknown> & { id: string } =>
+						isObjectRecord(region) && typeof region.id === "string",
+				)
 				.map((region) => {
 					const rawStart = isFiniteNumber(region.startMs) ? Math.round(region.startMs) : 0;
 					const rawEnd = isFiniteNumber(region.endMs) ? Math.round(region.endMs) : rawStart + 1000;
 					const startMs = Math.max(0, Math.min(rawStart, rawEnd));
 					const endMs = Math.max(startMs + 1, rawEnd);
+					const rawFocus = isObjectRecord(region.focus) ? region.focus : {};
+					const depth =
+						typeof region.depth === "number" && [1, 2, 3, 4, 5, 6].includes(region.depth)
+							? (region.depth as ZoomDepth)
+							: DEFAULT_ZOOM_DEPTH;
 
 					return {
 						id: region.id,
 						startMs,
 						endMs,
-						depth: [1, 2, 3, 4, 5, 6].includes(region.depth) ? region.depth : DEFAULT_ZOOM_DEPTH,
+						depth,
 						focus: {
-							cx: clamp(isFiniteNumber(region.focus?.cx) ? region.focus.cx : 0.5, 0, 1),
-							cy: clamp(isFiniteNumber(region.focus?.cy) ? region.focus.cy : 0.5, 0, 1),
+							cx: clamp(isFiniteNumber(rawFocus.cx) ? rawFocus.cx : 0.5, 0, 1),
+							cy: clamp(isFiniteNumber(rawFocus.cy) ? rawFocus.cy : 0.5, 0, 1),
 						},
+						easeIn: normalizeZoomEasing(region.easeIn, DEFAULT_ZOOM_EASE_IN),
+						easeOut: normalizeZoomEasing(region.easeOut, DEFAULT_ZOOM_EASE_OUT),
 					};
 				})
 		: [];

--- a/apps/desktop/src/components/video-editor/types.ts
+++ b/apps/desktop/src/components/video-editor/types.ts
@@ -5,12 +5,46 @@ export interface ZoomFocus {
 	cy: number; // normalized vertical center (0-1)
 }
 
+export type ZoomEaseType = "smooth" | "linear" | "ease-in" | "ease-out" | "ease-in-out";
+
+export interface ZoomEasing {
+	durationMs: number;
+	type: ZoomEaseType;
+}
+
 export interface ZoomRegion {
 	id: string;
 	startMs: number;
 	endMs: number;
 	depth: ZoomDepth;
 	focus: ZoomFocus;
+	easeIn: ZoomEasing;
+	easeOut: ZoomEasing;
+}
+
+export const ZOOM_EASE_TYPES: ZoomEaseType[] = [
+	"smooth",
+	"linear",
+	"ease-in",
+	"ease-out",
+	"ease-in-out",
+];
+
+export const DEFAULT_ZOOM_EASE_IN: ZoomEasing = {
+	durationMs: 1523,
+	type: "smooth",
+};
+
+export const DEFAULT_ZOOM_EASE_OUT: ZoomEasing = {
+	durationMs: 1015,
+	type: "smooth",
+};
+
+export function createDefaultZoomEasing() {
+	return {
+		easeIn: { ...DEFAULT_ZOOM_EASE_IN },
+		easeOut: { ...DEFAULT_ZOOM_EASE_OUT },
+	};
 }
 
 export interface CursorTelemetryPoint {

--- a/apps/desktop/src/components/video-editor/videoEditorHistory.test.ts
+++ b/apps/desktop/src/components/video-editor/videoEditorHistory.test.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_ANNOTATION_SIZE,
 	DEFAULT_ANNOTATION_STYLE,
 	DEFAULT_FIGURE_DATA,
+	createDefaultZoomEasing,
 } from "./types";
 import {
 	cloneEditorHistorySnapshot,
@@ -56,7 +57,14 @@ describe("videoEditorHistory", () => {
 	it("clones region arrays so history snapshots are not structurally shared", () => {
 		const original = createEditorHistorySnapshot({
 			zoomRegions: [
-				{ id: "zoom-1", startMs: 0, endMs: 500, depth: 3, focus: { cx: 0.5, cy: 0.5 } },
+				{
+					id: "zoom-1",
+					startMs: 0,
+					endMs: 500,
+					depth: 3,
+					focus: { cx: 0.5, cy: 0.5 },
+					...createDefaultZoomEasing(),
+				},
 			],
 			trimRegions: [{ id: "trim-1", startMs: 0, endMs: 500 }],
 			speedRegions: [{ id: "speed-1", startMs: 0, endMs: 500, speed: 1.5 }],
@@ -76,12 +84,63 @@ describe("videoEditorHistory", () => {
 		expect(cloned.annotationRegions).not.toBe(original.annotationRegions);
 	});
 
+	it("changes the signature when zoom easing changes", () => {
+		const baseSnapshot = createEditorHistorySnapshot({
+			zoomRegions: [
+				{
+					id: "zoom-1",
+					startMs: 0,
+					endMs: 500,
+					depth: 3,
+					focus: { cx: 0.5, cy: 0.5 },
+					...createDefaultZoomEasing(),
+				},
+			],
+			trimRegions: [],
+			speedRegions: [],
+			annotationRegions: [],
+			selectedZoomId: "zoom-1",
+			selectedTrimId: null,
+			selectedSpeedId: null,
+			selectedAnnotationId: null,
+		});
+
+		const changedSnapshot = createEditorHistorySnapshot({
+			...baseSnapshot,
+			zoomRegions: [
+				{
+					...baseSnapshot.zoomRegions[0],
+					easeOut: {
+						durationMs: 250,
+						type: "linear",
+					},
+				},
+			],
+		});
+
+		expect(changedSnapshot.signature).not.toBe(baseSnapshot.signature);
+	});
+
 	it("derives the next region ids and annotation z-index from restored history", () => {
 		expect(
 			deriveEditorHistoryCounters({
 				zoomRegions: [
-					{ id: "zoom-2", startMs: 0, endMs: 500, depth: 3, focus: { cx: 0.5, cy: 0.5 } },
-					{ id: "zoom-9", startMs: 600, endMs: 900, depth: 4, focus: { cx: 0.4, cy: 0.4 } },
+					{
+						id: "zoom-2",
+						startMs: 0,
+						endMs: 500,
+						depth: 3,
+						focus: { cx: 0.5, cy: 0.5 },
+						...createDefaultZoomEasing(),
+					},
+					{
+						id: "zoom-9",
+						startMs: 600,
+						endMs: 900,
+						depth: 4,
+						focus: { cx: 0.4, cy: 0.4 },
+						...createDefaultZoomEasing(),
+					},
 				],
 				trimRegions: [{ id: "trim-4", startMs: 0, endMs: 900 }],
 				speedRegions: [{ id: "speed-5", startMs: 0, endMs: 900, speed: 2 }],

--- a/apps/desktop/src/components/video-editor/videoEditorHistory.ts
+++ b/apps/desktop/src/components/video-editor/videoEditorHistory.ts
@@ -24,7 +24,18 @@ export type EditorHistoryCounters = {
 };
 
 function getZoomRegionSignature(region: ZoomRegion) {
-	return `${region.id}:${region.startMs}:${region.endMs}:${region.depth}:${region.focus.cx}:${region.focus.cy}`;
+	return [
+		region.id,
+		region.startMs,
+		region.endMs,
+		region.depth,
+		region.focus.cx,
+		region.focus.cy,
+		region.easeIn.durationMs,
+		region.easeIn.type,
+		region.easeOut.durationMs,
+		region.easeOut.type,
+	].join(":");
 }
 
 function getTrimRegionSignature(region: TrimRegion) {

--- a/apps/desktop/src/components/video-editor/videoPlayback/zoomRegionUtils.test.ts
+++ b/apps/desktop/src/components/video-editor/videoPlayback/zoomRegionUtils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { ZoomEaseType, ZoomRegion } from "../types";
+import { createDefaultZoomEasing } from "../types";
+import { easeOutScreenStudio } from "./mathUtils";
+import { computeRegionStrength } from "./zoomRegionUtils";
+
+function makeZoomRegion(overrides: Partial<ZoomRegion> = {}): ZoomRegion {
+	return {
+		id: "zoom-1",
+		startMs: 1000,
+		endMs: 2000,
+		depth: 3,
+		focus: { cx: 0.5, cy: 0.5 },
+		...createDefaultZoomEasing(),
+		...overrides,
+	};
+}
+
+describe("zoomRegionUtils", () => {
+	it("uses per-region ease-in and ease-out durations", () => {
+		const region = makeZoomRegion({
+			easeIn: { durationMs: 1000, type: "linear" },
+			easeOut: { durationMs: 500, type: "linear" },
+		});
+
+		expect(computeRegionStrength(region, 500)).toBe(0);
+		expect(computeRegionStrength(region, 1000)).toBeCloseTo(0.5);
+		expect(computeRegionStrength(region, 1500)).toBe(1);
+		expect(computeRegionStrength(region, 2250)).toBeCloseTo(0.5);
+		expect(computeRegionStrength(region, 2501)).toBe(0);
+	});
+
+	it.each([
+		["linear", 0.5],
+		["ease-in", 0.125],
+		["ease-out", 0.875],
+		["ease-in-out", 0.5],
+		["smooth", easeOutScreenStudio(0.5)],
+	] satisfies Array<[ZoomEaseType, number]>)("applies %s easing to zoom-in strength", (type, expected) => {
+		const region = makeZoomRegion({
+			easeIn: { durationMs: 1000, type },
+		});
+
+		expect(computeRegionStrength(region, 1000)).toBeCloseTo(expected);
+	});
+
+	it.each([
+		["linear", 0.5],
+		["ease-in", 0.875],
+		["ease-out", 0.125],
+		["ease-in-out", 0.5],
+		["smooth", 1 - easeOutScreenStudio(0.5)],
+	] satisfies Array<[ZoomEaseType, number]>)("applies %s easing to zoom-out strength", (type, expected) => {
+		const region = makeZoomRegion({
+			easeOut: { durationMs: 1000, type },
+		});
+
+		expect(computeRegionStrength(region, 2500)).toBeCloseTo(expected);
+	});
+});

--- a/apps/desktop/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
+++ b/apps/desktop/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
@@ -1,8 +1,12 @@
-import type { ZoomFocus, ZoomRegion } from "../types";
-import { ZOOM_DEPTH_SCALES } from "../types";
-import { TRANSITION_WINDOW_MS, ZOOM_IN_TRANSITION_WINDOW_MS } from "./constants";
+import type { ZoomEasing, ZoomEaseType, ZoomFocus, ZoomRegion } from "../types";
+import {
+	DEFAULT_ZOOM_EASE_IN,
+	DEFAULT_ZOOM_EASE_OUT,
+	ZOOM_DEPTH_SCALES,
+	ZOOM_EASE_TYPES,
+} from "../types";
 import { clampFocusToScale } from "./focusUtils";
-import { clamp01, cubicBezier, easeOutScreenStudio } from "./mathUtils";
+import { clamp01, cubicBezier, easeInOutCubic, easeOutCubic, easeOutScreenStudio } from "./mathUtils";
 
 const CHAINED_ZOOM_PAN_GAP_MS = 1500;
 const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
@@ -35,26 +39,65 @@ function easeConnectedPan(value: number) {
   return cubicBezier(0.1, 0.0, 0.2, 1.0, value);
 }
 
+function resolveZoomEasing(easing: ZoomEasing | undefined, fallback: ZoomEasing): ZoomEasing {
+  const durationMs = easing?.durationMs;
+  const type = easing?.type;
+  const rawDuration =
+    typeof durationMs === "number" && Number.isFinite(durationMs) ? durationMs : fallback.durationMs;
+
+  return {
+    durationMs: Math.round(Math.max(0, Math.min(5000, rawDuration))),
+    type: ZOOM_EASE_TYPES.includes(type as ZoomEaseType) ? (type as ZoomEaseType) : fallback.type,
+  };
+}
+
+function applyZoomEase(type: ZoomEaseType, value: number) {
+  const clamped = clamp01(value);
+
+  switch (type) {
+    case "linear":
+      return clamped;
+    case "ease-in":
+      return clamped * clamped * clamped;
+    case "ease-out":
+      return easeOutCubic(clamped);
+    case "ease-in-out":
+      return easeInOutCubic(clamped);
+    case "smooth":
+      return easeOutScreenStudio(clamped);
+  }
+}
+
 export function computeRegionStrength(region: ZoomRegion, timeMs: number) {
-  const zoomInEnd = region.startMs + ZOOM_IN_OVERLAP_MS;
-  const leadInStart = zoomInEnd - ZOOM_IN_TRANSITION_WINDOW_MS;
-  const leadOutEnd = region.endMs + TRANSITION_WINDOW_MS;
+  const easeIn = resolveZoomEasing(region.easeIn, DEFAULT_ZOOM_EASE_IN);
+  const easeOut = resolveZoomEasing(region.easeOut, DEFAULT_ZOOM_EASE_OUT);
+  const zoomInEnd = region.startMs + Math.min(ZOOM_IN_OVERLAP_MS, easeIn.durationMs);
+  const leadInStart = zoomInEnd - easeIn.durationMs;
+  const leadOutEnd = region.endMs + easeOut.durationMs;
 
   if (timeMs < leadInStart || timeMs > leadOutEnd) {
     return 0;
   }
 
   if (timeMs < zoomInEnd) {
-    const progress = (timeMs - leadInStart) / ZOOM_IN_TRANSITION_WINDOW_MS;
-    return easeOutScreenStudio(progress);
+    if (easeIn.durationMs <= 0) {
+      return 1;
+    }
+
+    const progress = (timeMs - leadInStart) / easeIn.durationMs;
+    return applyZoomEase(easeIn.type, progress);
   }
 
   if (timeMs <= region.endMs) {
     return 1;
   }
 
-  const progress = clamp01((timeMs - region.endMs) / TRANSITION_WINDOW_MS);
-  return 1 - easeOutScreenStudio(progress);
+  if (easeOut.durationMs <= 0) {
+    return 0;
+  }
+
+  const progress = clamp01((timeMs - region.endMs) / easeOut.durationMs);
+  return 1 - applyZoomEase(easeOut.type, progress);
 }
 
 function getLinearFocus(start: ZoomFocus, end: ZoomFocus, amount: number): ZoomFocus {
@@ -217,4 +260,3 @@ export function findDominantRegion(regions: ZoomRegion[], timeMs: number, option
     ? { ...activeRegion, transition: null }
     : { region: null, strength: 0, blendedScale: null, transition: null };
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       pixi.js:
         specifier: ^8.14.0
         version: 8.17.1
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -786,6 +789,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
     peerDependencies:
@@ -799,8 +815,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -845,6 +913,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -926,6 +1007,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -935,8 +1042,73 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1013,6 +1185,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1026,8 +1224,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1096,6 +1320,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-toggle-group@1.1.11':
     resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
     peerDependencies:
@@ -1111,6 +1348,32 @@ packages:
 
   '@radix-ui/react-toggle@1.1.10':
     resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1151,6 +1414,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2974,6 +3246,19 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   re-resizable@6.11.2:
     resolution: {integrity: sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==}
     peerDependencies:
@@ -4209,6 +4494,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4226,9 +4520,61 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -4268,6 +4614,20 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
@@ -4348,12 +4708,52 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -4377,6 +4777,82 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4451,6 +4927,34 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4462,6 +4966,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -4493,6 +5014,15 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4561,6 +5091,26 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4581,6 +5131,41 @@ snapshots:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -4612,6 +5197,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -6427,6 +7019,69 @@ snapshots:
       side-channel: 1.1.0
 
   quick-lru@5.1.1: {}
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   re-resizable@6.11.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary
- Improves the desktop editor shell, source selector, sidebar, projects view, settings panel, and export controls with stronger shadcn/ui composition.
- Adds shadcn badge, separator, and tooltip primitives plus the radix-ui dependency required by those components.
- Preserves the existing smooth slider implementation.
- Carries forward the editor state, zoom/cursor history, and persistence updates already present in the working tree so the branch remains buildable.

## Validation
- pnpm --filter @open-recorder/desktop typecheck
- pnpm --filter @open-recorder/desktop build
- Live Electron smoke check with Computer Use for editor, export popover, and projects view

## Notes
- Generated apps/desktop/test-results artifacts were intentionally left uncommitted.