### PR TITLE
[codex] Fix HUD source label visibility

### DIFF
--- a/apps/desktop/src/components/launch/LaunchWindow.test.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.test.tsx
@@ -393,4 +393,25 @@ describe("LaunchWindow event listener cleanup", () => {
 
 		await harness.unmount();
 	});
+
+	it("renders the selected source name in full in the recording HUD", async () => {
+		setupDefaultMocks();
+		const harness = await mountLaunchWindow();
+
+		const recordButton = Array.from(document.querySelectorAll("button")).find((button) =>
+			button.textContent?.includes("Record Video"),
+		);
+
+		expect(recordButton).toBeDefined();
+
+		await act(async () => {
+			recordButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+		await flushEffects();
+
+		expect(document.body.textContent).toContain("Main Display");
+		expect(document.body.textContent).not.toContain("Main D...");
+
+		await harness.unmount();
+	});
 });

--- a/apps/desktop/src/components/launch/LaunchWindow.tsx
+++ b/apps/desktop/src/components/launch/LaunchWindow.tsx
@@ -35,7 +35,6 @@ import { useScreenRecorder } from "../../hooks/useScreenRecorder";
 import { microphoneMachine } from "../../machines/microphoneMachine";
 import { PermissionOnboarding } from "../onboarding/PermissionOnboarding";
 import { Button } from "../ui/button";
-import { ContentClamp } from "../ui/content-clamp";
 import { Popover, PopoverAnchor, PopoverContent } from "../ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
@@ -679,12 +678,12 @@ export function LaunchWindow() {
 								<Button
 									variant="link"
 									size="sm"
-									className="hud-no-drag gap-1 bg-transparent px-0 text-xs text-white/60 hover:bg-transparent"
+									className="hud-no-drag min-w-fit shrink-0 gap-1 bg-transparent px-0 text-xs text-white/60 hover:bg-transparent"
 									onClick={() => openSourceSelector()}
 									title={selectedSource}
 								>
 									<MdMonitor size={14} className="text-white/60" />
-									<ContentClamp truncateLength={10}>{selectedSource}</ContentClamp>
+									<span>{selectedSource}</span>
 								</Button>
 
 								<div className={dividerClass} />
@@ -742,13 +741,13 @@ export function LaunchWindow() {
 						<Button
 							variant="link"
 							size="sm"
-							className="hud-no-drag gap-1 bg-transparent px-0 text-xs text-white/80 hover:bg-transparent"
+							className="hud-no-drag min-w-fit shrink-0 gap-1 bg-transparent px-0 text-xs text-white/80 hover:bg-transparent"
 							onClick={() => openSourceSelector()}
 							disabled={recording}
 							title={selectedSource}
 						>
 							<MdMonitor size={14} className="text-white/80" />
-							<ContentClamp truncateLength={6}>{selectedSource}</ContentClamp>
+							<span>{selectedSource}</span>
 						</Button>
 
 						<div className={dividerClass} />


### PR DESCRIPTION
## Summary

Fixes the HUD source label so the selected display name is shown in full instead of being manually truncated to an ellipsis.

## Root Cause

The recording and screenshot HUD source buttons wrapped the selected source in `ContentClamp` with very short limits, so even the default `Main Display` label rendered as `Main D...` before layout could size naturally.

## Changes

- Removed `ContentClamp` from the selected source labels in the HUD.
- Let the source buttons size to their label with `min-w-fit` and `shrink-0`.
- Added a regression test asserting that the recording HUD renders `Main Display` and not `Main D...`.

## Validation

- `pnpm --filter @open-recorder/desktop exec vitest --run src/components/launch/LaunchWindow.test.tsx`
- `pnpm --filter @open-recorder/desktop typecheck`
- `pnpm --filter @open-recorder/desktop exec biome check src/components/launch/LaunchWindow.tsx src/components/launch/LaunchWindow.test.tsx`
- Computer Use visual verification in `OpenRecorderDev` confirmed `Main Display` is fully visible in the HUD.