### PR TITLE
Release v0.0.36 (patch)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.35",
+	"version": "0.0.36",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Bump desktop app version from 0.0.35 to 0.0.36 (patch release)
- Build verified passing before and after the version bump

## Test plan
- [x] `pnpm build` passes successfully with new version
- [ ] Verify CI passes on this PR

https://claude.ai/code/session_01FVv2oAsPXeZ7STGCZHW2kc

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVv2oAsPXeZ7STGCZHW2kc)_