### PR TITLE
[codex] Fix electron-builder signing identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,15 @@ jobs:
       - name: Build desktop app
         run: pnpm --filter @open-recorder/desktop build
 
+      - name: Normalize macOS signing identity
+        shell: bash
+        run: |
+          if [[ "${CSC_NAME:-}" == "Developer ID Application:"* ]]; then
+            normalized_name="${CSC_NAME#Developer ID Application:}"
+            normalized_name="${normalized_name#"${normalized_name%%[![:space:]]*}"}"
+            echo "CSC_NAME=$normalized_name" >> "$GITHUB_ENV"
+          fi
+
       - name: Package macOS arm64 artifacts
         run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --mac dmg zip --arm64
 
@@ -171,6 +180,15 @@ jobs:
 
       - name: Build desktop app
         run: pnpm --filter @open-recorder/desktop build
+
+      - name: Normalize macOS signing identity
+        shell: bash
+        run: |
+          if [[ "${CSC_NAME:-}" == "Developer ID Application:"* ]]; then
+            normalized_name="${CSC_NAME#Developer ID Application:}"
+            normalized_name="${normalized_name#"${normalized_name%%[![:space:]]*}"}"
+            echo "CSC_NAME=$normalized_name" >> "$GITHUB_ENV"
+          fi
 
       - name: Package macOS x64 artifacts
         run: pnpm --filter @open-recorder/desktop exec electron-builder --config electron-builder.yml --publish never --mac dmg zip --x64

--- a/README.md
+++ b/README.md
@@ -161,16 +161,14 @@ The repository release flow uses two GitHub Actions workflows:
 - `.github/workflows/release-pr.yml` computes the next version and opens or updates a release PR.
 - `.github/workflows/release.yml` runs after that PR is merged to `main`, then builds and publishes the signed release artifacts.
 
-The release workflows use Tauri to produce signed and notarized macOS DMGs, Windows NSIS installers, and Linux AppImages when these GitHub repository secrets are configured:
+The release workflows use Electron Builder to produce signed and notarized macOS DMGs, Windows NSIS installers, and Linux AppImages when these GitHub repository secrets are configured:
 
 - `APPLE_CERTIFICATE`: base64-encoded `Developer ID Application` `.p12` certificate export
 - `APPLE_CERTIFICATE_PASSWORD`: password used when exporting the `.p12`
-- `APPLE_SIGNING_IDENTITY`: signing identity name
+- `APPLE_SIGNING_IDENTITY`: optional signing identity name, without the `Developer ID Application:` prefix
 - `APPLE_ID`: Apple Developer account email
 - `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for notarization
 - `APPLE_TEAM_ID`: your Apple Developer team ID
-- `TAURI_SIGNING_PRIVATE_KEY`: Tauri updater signing private key
-- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: password for the signing key (optional)
 
 This repo now includes two helper scripts:
 

--- a/scripts/setup-github-macos-signing.zsh
+++ b/scripts/setup-github-macos-signing.zsh
@@ -7,7 +7,7 @@ usage() {
 Usage: zsh scripts/setup-github-macos-signing.zsh [options]
 
 Exports the local Developer ID Application identity to a .p12, base64-encodes it
-for Tauri's code signing, and uploads the required GitHub Actions repository
+for Electron Builder code signing, and uploads the required GitHub Actions repository
 secrets.
 
 Options:
@@ -150,7 +150,7 @@ print -- "Using repository: $repo"
 print -- "Using signing identity: $identity"
 print -- "Derived Apple team ID: $team_id"
 print -- "Exporting PKCS#12 bundle to: $cert_path"
-print -- "macOS exports identities from the login keychain as a bundle; the Tauri build will use the correct Developer ID Application identity in CI."
+print -- "macOS exports identities from the login keychain as a bundle; Electron Builder will use the correct Developer ID Application identity in CI."
 
 security export \
 	-k "$HOME/Library/Keychains/login.keychain-db" \


### PR DESCRIPTION
## Summary

- Normalize `CSC_NAME` in both macOS release jobs before electron-builder runs.
- Strip the legacy `Developer ID Application:` prefix when older GitHub secrets still include it.
- Update macOS signing docs/helper wording to describe Electron Builder and the expected identity format.

## Root Cause

`electron-builder@26.8.1` rejects signing identity names that include the `Developer ID Application:` certificate-kind prefix. The release workflow passes `APPLE_SIGNING_IDENTITY` or `CSC_NAME` directly into `CSC_NAME`, so an older secret value can fail packaging before artifacts are produced.

## Validation

- `zsh -n scripts/setup-github-macos-signing.zsh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`
- Bash normalization smoke test: `Developer ID Application: Example Dev (ABCDE12345)` becomes `Example Dev (ABCDE12345)`