### PR TITLE
Prepare release v0.0.22

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.35",
-  "releaseName": "Open Recorder v0.0.35",
+  "tagName": "v0.0.22",
+  "releaseName": "Open Recorder v0.0.22",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Patch release bump from v0.0.21 to v0.0.22
- Updates `apps/desktop/package.json` version to `0.0.22`
- Updates `.github/release-plan.json` with new tag `v0.0.22`

## Test plan
- [x] Build passes successfully (`pnpm run build`)
- [ ] Merging this PR will trigger `.github/workflows/release.yml`, which builds the desktop artifacts and publishes the GitHub release

https://claude.ai/code/session_01BKHgyLTB1VDfZRwAbfyLef

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKHgyLTB1VDfZRwAbfyLef)_