### PR TITLE
chore: patch release v0.0.22

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/imbhargav5/open-recorder/issues"
 	},
 	"private": true,
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"packageManager": "pnpm@10.17.1",
 	"type": "module",
 	"main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary

- Bumps desktop app version from `0.0.21` to `0.0.22` for a patch release
- Build verified passing before version bump

## Test plan

- [x] Verified `pnpm run build` passes successfully
- [ ] Merge and trigger release workflow

https://claude.ai/code/session_01UrPMsTUkPP1mmjJ6mGoruf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrPMsTUkPP1mmjJ6mGoruf)_