### PR TITLE
Prepare release v0.1.1

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.35",
-  "releaseName": "Open Recorder v0.0.35",
+  "tagName": "v0.1.1",
+  "releaseName": "Open Recorder v0.1.1",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Patch release bumping Rust service version from `0.1.0` to `0.1.1`
- Updates `apps/rust-service/Cargo.toml`, `apps/rust-service/Cargo.lock`, and `.github/release-plan.json`
- Both desktop (vite) and Rust service builds verified to pass before release

## Test plan
- [x] Desktop app build (`pnpm --filter @open-recorder/desktop build`) passes
- [x] Rust service build (`cargo build`) passes
- [x] Version correctly bumped in Cargo.toml, Cargo.lock, and release-plan.json

https://claude.ai/code/session_01LPUN7YCSmgfLAXGQRZuR5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPUN7YCSmgfLAXGQRZuR5c)_