### PR TITLE
Prepare release v0.1.1

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.0.35",
-  "releaseName": "Open Recorder v0.0.35",
+  "tagName": "v0.1.1",
+  "releaseName": "Open Recorder v0.1.1",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Patch release bumping version from `0.1.0` to `0.1.1`
- Updates `apps/rust-service/Cargo.toml`, `apps/rust-service/Cargo.lock`, and `.github/release-plan.json`
- Rust build and tests verified passing after version bump

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (2/2 tests)
- [ ] Merging triggers `.github/workflows/release.yml` for macOS build and GitHub release

https://claude.ai/code/session_01RqW1TN7p2F7t7Uyvk5opKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqW1TN7p2F7t7Uyvk5opKw)_