### PR TITLE
Fix recording capturing wrong source after window/display changes

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -96,9 +96,60 @@ final class AppModel: ObservableObject {
     }
 
     func refreshSources(requestScreenRecordingPermission: Bool = false) async {
+        let previousSelection = selectedSource
         await capture.reloadSources(requestScreenRecordingPermission: requestScreenRecordingPermission)
-        if selectedSource == nil || !capture.sources.contains(where: { $0.id == selectedSource?.id }) {
-            selectedSource = capture.sources.first
+
+        let resolved = resolveSelection(previous: previousSelection, in: capture.sources)
+        selectedSource = resolved
+
+        guard let resolved, let previousSelection else {
+            return
+        }
+        if case .ready(let mode, let hudSource) = hudState.phase,
+           hudSource.id == previousSelection.id || matchesIdentity(hudSource, previousSelection) {
+            setHUDPhase(.ready(mode, resolved))
+        }
+    }
+
+    private func resolveSelection(previous: CaptureSource?, in sources: [CaptureSource]) -> CaptureSource? {
+        guard let previous else {
+            return sources.first
+        }
+        if previous.kind == .area {
+            return previous
+        }
+        if let match = sources.first(where: { matchesIdentity($0, previous) }) {
+            return match
+        }
+        return sources.first
+    }
+
+    private func matchesIdentity(_ candidate: CaptureSource, _ reference: CaptureSource) -> Bool {
+        guard candidate.kind == reference.kind else {
+            return false
+        }
+        switch candidate.kind {
+        case .display:
+            if let candidateID = candidate.displayID, let referenceID = reference.displayID {
+                return candidateID == referenceID
+            }
+            return candidate.id == reference.id
+        case .window:
+            if let candidateWindowID = candidate.windowID,
+               let referenceWindowID = reference.windowID,
+               candidateWindowID == referenceWindowID,
+               candidate.ownerBundleID == reference.ownerBundleID {
+                return true
+            }
+            if let bundleID = reference.ownerBundleID,
+               candidate.ownerBundleID == bundleID,
+               candidate.name == reference.name,
+               !candidate.name.isEmpty {
+                return true
+            }
+            return false
+        case .area:
+            return candidate.id == reference.id
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -499,7 +499,7 @@ final class CaptureController: ObservableObject {
             let displayIndex = index + 1
             let screen = screensByID[display.displayID]
             displaySources.append(CaptureSource(
-                id: "display:\(displayIndex)",
+                id: "display:\(display.displayID)",
                 kind: .display,
                 name: screen?.localizedName ?? "Display \(displayIndex)",
                 subtitle: "\(display.width) x \(display.height)",
@@ -543,7 +543,9 @@ final class CaptureController: ObservableObject {
                 displayID: nil,
                 windowID: window.windowID,
                 area: nil,
-                thumbnailData: await thumbnailDataForWindow(window)
+                thumbnailData: await thumbnailDataForWindow(window),
+                ownerBundleID: window.owningApplication?.bundleIdentifier,
+                ownerName: window.owningApplication?.applicationName
             ))
         }
         return windowSources
@@ -556,7 +558,7 @@ final class CaptureController: ObservableObject {
                 .uint32Value
             let frame = screen.frame
             return CaptureSource(
-                id: "display:\(displayIndex)",
+                id: displayID.map { "display:\($0)" } ?? "display:\(displayIndex)",
                 kind: .display,
                 name: screen.localizedName,
                 subtitle: "\(Int(frame.width)) x \(Int(frame.height))",
@@ -583,11 +585,15 @@ final class CaptureController: ObservableObject {
                 return nil
             }
             let windowID = windowNumber.uint32Value
+            let ownerName = window[kCGWindowOwnerName as String] as? String
+            let ownerPID = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
+            let runningApp = ownerPID.flatMap { NSRunningApplication(processIdentifier: pid_t($0)) }
+            let bundleID = runningApp?.bundleIdentifier
 
             let metadata = WindowSourceMetadata(
                 title: window[kCGWindowName as String] as? String,
-                ownerName: window[kCGWindowOwnerName as String] as? String,
-                bundleIdentifier: nil,
+                ownerName: ownerName,
+                bundleIdentifier: bundleID,
                 frame: legacyWindowFrame(from: window),
                 layer: (window[kCGWindowLayer as String] as? NSNumber)?.intValue,
                 alpha: (window[kCGWindowAlpha as String] as? NSNumber)?.doubleValue
@@ -608,7 +614,9 @@ final class CaptureController: ObservableObject {
                 displayID: nil,
                 windowID: windowID,
                 area: nil,
-                thumbnailData: nil
+                thumbnailData: nil,
+                ownerBundleID: bundleID,
+                ownerName: ownerName
             )
         }
     }

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -60,6 +60,8 @@ struct CaptureSource: Identifiable, Codable, Hashable {
     var windowID: UInt32?
     var area: CaptureArea?
     var thumbnailData: Data?
+    var ownerBundleID: String? = nil
+    var ownerName: String? = nil
 }
 
 struct AppPaths: Codable, Equatable {

--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -7,19 +7,24 @@ import Foundation
 enum NativeScreenRecorderError: LocalizedError {
     case missingDisplay
     case missingWindow
+    case windowIdentityChanged(expected: String?, actual: String?)
     case unsupportedSource
     case recordingOutputUnavailable
 
     var errorDescription: String? {
         switch self {
         case .missingDisplay:
-            "The selected display is no longer available."
+            return "The selected display is no longer available. Refresh sources and pick again."
         case .missingWindow:
-            "The selected window is no longer available."
+            return "The selected window is no longer available. Refresh sources and pick again."
+        case .windowIdentityChanged(let expected, let actual):
+            let expectedLabel = expected ?? "the selected window"
+            let actualLabel = actual.map { " (now belongs to \($0))" } ?? ""
+            return "The selected window has been replaced\(actualLabel). Refresh sources and pick \(expectedLabel) again."
         case .unsupportedSource:
-            "Selected-area video recording is not implemented in the native recorder yet."
+            return "Selected-area video recording is not implemented in the native recorder yet."
         case .recordingOutputUnavailable:
-            "ScreenCaptureKit recording output is not available on this macOS version."
+            return "ScreenCaptureKit recording output is not available on this macOS version."
         }
     }
 }
@@ -128,10 +133,10 @@ final class NativeScreenRecorder: NSObject {
             )
 
         case .window:
-            guard let windowID = source.windowID,
-                  let window = content.windows.first(where: { $0.windowID == windowID }) else {
+            guard let window = resolveWindow(for: source, in: content) else {
                 throw NativeScreenRecorderError.missingWindow
             }
+            try verifyWindowIdentity(source: source, window: window)
             let width = max(Int(window.frame.width), 640)
             let height = max(Int(window.frame.height), 360)
             return (
@@ -161,6 +166,46 @@ final class NativeScreenRecorder: NSObject {
                 sourceRect
             )
         }
+    }
+
+    private func resolveWindow(for source: CaptureSource, in content: SCShareableContent) -> SCWindow? {
+        if let windowID = source.windowID,
+           let window = content.windows.first(where: { $0.windowID == windowID }) {
+            if let expectedBundleID = source.ownerBundleID,
+               let actualBundleID = window.owningApplication?.bundleIdentifier,
+               expectedBundleID != actualBundleID {
+                if let recovered = findWindowByIdentity(source: source, in: content) {
+                    return recovered
+                }
+                return window
+            }
+            return window
+        }
+
+        return findWindowByIdentity(source: source, in: content)
+    }
+
+    private func findWindowByIdentity(source: CaptureSource, in content: SCShareableContent) -> SCWindow? {
+        guard let bundleID = source.ownerBundleID else {
+            return nil
+        }
+        return content.windows.first {
+            $0.owningApplication?.bundleIdentifier == bundleID && $0.title == source.name
+        }
+    }
+
+    private func verifyWindowIdentity(source: CaptureSource, window: SCWindow) throws {
+        guard let expectedBundleID = source.ownerBundleID else {
+            return
+        }
+        let actualBundleID = window.owningApplication?.bundleIdentifier
+        guard expectedBundleID != actualBundleID else {
+            return
+        }
+        throw NativeScreenRecorderError.windowIdentityChanged(
+            expected: source.ownerName ?? source.name,
+            actual: window.owningApplication?.applicationName
+        )
     }
 
     private func sourceRect(for area: CaptureArea, display: SCDisplay) -> CGRect {


### PR DESCRIPTION
The source shown in the HUD could differ from what was actually recorded
because the recording path matched only by windowID/displayID, both of
which can become stale between selection and recording start:

- CGWindowID is recycled by macOS WindowServer after a window closes,
  so the selected ID could point at a different window (potentially a
  different app entirely) by the time recording started.
- Display source IDs were positional (display:1), so a reordering of
  SCShareableContent.displays caused the same id to map to different
  physical displays in the UI.
- refreshSources() only checked id presence, leaving selectedSource
  with stale metadata.

Now CaptureSource carries ownerBundleID/ownerName identity, display ids
are displayID-based, refreshSources resolves the previous selection by
stable identity, and NativeScreenRecorder verifies the matched window's
bundle identifier and falls back to a strict bundle+title search before
recording. Identity mismatches now surface a clear error instead of
silently capturing the wrong window.

https://claude.ai/code/session_01DxEMk2sHbtwjyVY6fhLQH2