### PR TITLE
[codex] Align Mergify checks with current GitHub jobs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,12 +6,10 @@ queue_rules:
     merge_method: merge
     merge_conditions:
       - check-success=GitGuardian Security Checks
+      - check-success=changes
       - or:
-          - check-success=Run vitest suite
-          - check-skipped=Run vitest suite
-      - or:
-          - check-success=Playwright E2E
-          - check-skipped=Playwright E2E
+          - check-success=Native macOS tests
+          - check-skipped=Native macOS tests
 
 merge_queue:
   max_parallel_checks: 10


### PR DESCRIPTION
## Summary
- Update Mergify merge queue conditions to require the current GitHub Actions job names: `changes` and `Native macOS tests`.
- Remove stale conditions for the retired `Run vitest suite` and `Playwright E2E` jobs.
- Keep skipped-or-success handling for the conditional macOS test job.

## Why
Mergify was waiting for checks that no longer exist, while the active `Tests` workflow now reports `changes` and `Native macOS tests`.

## Validation
- Confirmed current PR check-run names via GitHub status rollup.
- Parsed `.mergify.yml` as YAML.
- Ran `git diff --check`.