### PR TITLE
Bump version to 0.1.2 (patch release)

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.1.1",
-  "releaseName": "Open Recorder v0.1.1",
+  "tagName": "v0.1.2",
+  "releaseName": "Open Recorder v0.1.2",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/macos/Resources/Info.plist
+++ b/apps/macos/Resources/Info.plist
@@ -36,9 +36,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.0</string>
+	<string>0.1.2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>NSHighResolutionCapable</key>

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.1 to 0.1.2 across all version files (Cargo.toml, Cargo.lock, Info.plist, release-plan.json)
- Aligns macOS Info.plist bundle version (was 0.1.0) with the current release version
- Build and all Rust tests pass

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (4/4 tests)
- [ ] Verify macOS build via CI

https://claude.ai/code/session_01XNiCFkcr8ovTTtDyMD3b2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNiCFkcr8ovTTtDyMD3b2Y)_