### PR TITLE
Fix macOS resource bundle lookup crash

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
+++ b/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
@@ -80,11 +80,11 @@ struct WallpaperPreset: Identifiable, Equatable, Hashable, Codable {
     var thumbAssetName: String
 
     var fullURL: URL? {
-        Bundle.module.url(forResource: fullAssetName, withExtension: "jpg", subdirectory: "Wallpapers")
+        OpenRecorderResources.url(forResource: fullAssetName, withExtension: "jpg", subdirectory: "Wallpapers")
     }
 
     var thumbURL: URL? {
-        Bundle.module.url(forResource: thumbAssetName, withExtension: "jpg", subdirectory: "Wallpapers/thumbs")
+        OpenRecorderResources.url(forResource: thumbAssetName, withExtension: "jpg", subdirectory: "Wallpapers/thumbs")
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -547,12 +547,6 @@ private enum OpenRecorderMenuBarIcon {
     }
 
     private static var resourceURL: URL? {
-        if let url = Bundle.main.resourceURL?
-            .appendingPathComponent("OpenRecorderMac_OpenRecorderMac.bundle")
-            .appendingPathComponent("OpenRecorderMenuBarIcon.png"),
-           FileManager.default.fileExists(atPath: url.path) {
-            return url
-        }
-        return Bundle.module.url(forResource: "OpenRecorderMenuBarIcon", withExtension: "png")
+        OpenRecorderResources.url(forResource: "OpenRecorderMenuBarIcon", withExtension: "png")
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderResources.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderResources.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+enum OpenRecorderResources {
+    private static let resourceBundleName = "OpenRecorderMac_OpenRecorderMac.bundle"
+
+    static func url(
+        forResource name: String,
+        withExtension fileExtension: String,
+        subdirectory: String? = nil
+    ) -> URL? {
+        for root in resourceRoots {
+            let url = resourceURL(
+                root: root,
+                name: name,
+                fileExtension: fileExtension,
+                subdirectory: subdirectory
+            )
+            if FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    private static let resourceRoots = uniqueExistingDirectories(candidateResourceRoots)
+
+    private static var candidateResourceRoots: [URL] {
+        var candidates: [URL] = []
+
+        if let resourceURL = Bundle.main.resourceURL {
+            candidates.append(resourceURL.appendingPathComponent(resourceBundleName, isDirectory: true))
+        }
+
+        candidates.append(Bundle.main.bundleURL.appendingPathComponent(resourceBundleName, isDirectory: true))
+
+        if let executableDirectory = Bundle.main.executableURL?.deletingLastPathComponent() {
+            candidates.append(executableDirectory.appendingPathComponent(resourceBundleName, isDirectory: true))
+            candidates.append(
+                executableDirectory
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("Resources", isDirectory: true)
+                    .appendingPathComponent(resourceBundleName, isDirectory: true)
+            )
+        }
+
+        let workingDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        candidates.append(workingDirectory.appendingPathComponent(".build/debug/\(resourceBundleName)", isDirectory: true))
+        candidates.append(workingDirectory.appendingPathComponent(".build/release/\(resourceBundleName)", isDirectory: true))
+        candidates.append(workingDirectory.appendingPathComponent("apps/macos/.build/debug/\(resourceBundleName)", isDirectory: true))
+        candidates.append(workingDirectory.appendingPathComponent("apps/macos/.build/release/\(resourceBundleName)", isDirectory: true))
+
+        return candidates
+    }
+
+    private static func resourceURL(
+        root: URL,
+        name: String,
+        fileExtension: String,
+        subdirectory: String?
+    ) -> URL {
+        var url = root
+        if let subdirectory, !subdirectory.isEmpty {
+            for component in subdirectory.split(separator: "/") {
+                url.appendPathComponent(String(component), isDirectory: true)
+            }
+        }
+        url.appendPathComponent(name, isDirectory: false)
+        url.appendPathExtension(fileExtension)
+        return url
+    }
+
+    private static func uniqueExistingDirectories(_ urls: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        return urls.compactMap { url in
+            let standardized = url.standardizedFileURL
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: standardized.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else {
+                return nil
+            }
+
+            guard seen.insert(standardized.path).inserted else {
+                return nil
+            }
+
+            return standardized
+        }
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
@@ -77,6 +77,13 @@ final class ScreenshotExportRendererTests: XCTestCase {
         let data = try XCTUnwrap(renderer.renderPNG(from: image))
         XCTAssertTrue(data.starts(with: Data([0x89, 0x50, 0x4E, 0x47])))
     }
+
+    func testBundledWallpaperResourcesResolveImagesAndThumbnails() throws {
+        for wallpaper in BackgroundPresets.wallpapers {
+            XCTAssertNotNil(wallpaper.fullURL, "Missing full wallpaper resource for \(wallpaper.id).")
+            XCTAssertNotNil(wallpaper.thumbURL, "Missing thumbnail wallpaper resource for \(wallpaper.id).")
+        }
+    }
 }
 
 final class ScreenshotEditorHistoryTests: XCTestCase {

--- a/scripts/package-macos-app.zsh
+++ b/scripts/package-macos-app.zsh
@@ -41,7 +41,8 @@ contents_dir="$bundle_dir/Contents"
 macos_dir="$contents_dir/MacOS"
 resources_dir="$contents_dir/Resources"
 swift_binary="$repo_root/apps/macos/.build/debug/OpenRecorderMac"
-swift_resource_bundle="$repo_root/apps/macos/.build/debug/OpenRecorderMac_OpenRecorderMac.bundle"
+swift_resource_bundle_name="OpenRecorderMac_OpenRecorderMac.bundle"
+swift_resource_bundle="$repo_root/apps/macos/.build/debug/$swift_resource_bundle_name"
 service_binary="$repo_root/apps/rust-service/target/debug/open-recorder-service"
 info_plist="$repo_root/apps/macos/Resources/Info.plist"
 icon_source="$repo_root/apps/macos/Resources/AppIcon.icns"
@@ -63,15 +64,22 @@ CARGO_INCREMENTAL=0 cargo build
 cd "$repo_root/apps/macos"
 swift build
 
+if [[ ! -d "$swift_resource_bundle" ]]; then
+	swift_resource_bundle="$(find "$repo_root/apps/macos/.build" -type d -name "$swift_resource_bundle_name" -print -quit)"
+fi
+
+if [[ ! -d "$swift_resource_bundle" ]]; then
+	print -u2 -- "Swift resource bundle not found: $swift_resource_bundle_name"
+	exit 1
+fi
+
 rm -rf "$bundle_dir"
 mkdir -p "$macos_dir" "$resources_dir"
 
 cp "$swift_binary" "$macos_dir/OpenRecorderMac"
 cp "$service_binary" "$macos_dir/open-recorder-service"
 cp "$info_plist" "$contents_dir/Info.plist"
-if [[ -d "$swift_resource_bundle" ]]; then
-	cp -R "$swift_resource_bundle" "$resources_dir/"
-fi
+cp -R "$swift_resource_bundle" "$resources_dir/"
 set_plist_string "CFBundleName" "$app_name"
 set_plist_string "CFBundleDisplayName" "$app_name"
 set_plist_string "CFBundleIdentifier" "$bundle_identifier"


### PR DESCRIPTION
Avoid Bundle.module for runtime wallpaper and menu icon lookups because SwiftPM's generated accessor can fatalError when the packaged app keeps resources under Contents/Resources. Add a packaged-app-aware resource resolver, fail packaging when the generated resource bundle is missing, and cover wallpaper thumbnails in tests.

# Pull Request Template

## Description
<!-- Briefly describe the purpose of this PR. -->

## Motivation
<!-- Explain why this change is needed. What problem does it solve? -->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
<!-- Link to any related issue(s) (e.g., #123) -->

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

**Screenshot** (if applicable):

```markdown
![Screenshot Description](path/to/screenshot.png)
```

**Video** (wherever possible):

```html
<video src="path/to/video.mp4" controls width="600"></video>
```

## Testing Guide
<!-- Describe how reviewers can test the changes. Include steps, commands, or environment setup. -->

## Checklist
- [ ] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*

