### PR TITLE
[codex] Add camera usage description

### DIFF
--- a/apps/macos/Resources/Info.plist
+++ b/apps/macos/Resources/Info.plist
@@ -45,6 +45,8 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Open Recorder uses the microphone when you choose to include narration in a screen recording.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Open Recorder uses the camera when you choose to include a facecam in a screen recording.</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 	<key>UTExportedTypeDeclarations</key>

--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+final class PrivacyUsageDescriptionTests: XCTestCase {
+    func testInfoPlistDeclaresCameraAndMicrophoneUsageDescriptions() throws {
+        let plist = try loadInfoPlist()
+
+        XCTAssertEqual(
+            plist["NSCameraUsageDescription"] as? String,
+            "Open Recorder uses the camera when you choose to include a facecam in a screen recording."
+        )
+        XCTAssertEqual(
+            plist["NSMicrophoneUsageDescription"] as? String,
+            "Open Recorder uses the microphone when you choose to include narration in a screen recording."
+        )
+    }
+
+    private func loadInfoPlist() throws -> [String: Any] {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Resources/Info.plist")
+        let data = try Data(contentsOf: url)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+
+        guard let dictionary = plist as? [String: Any] else {
+            XCTFail("Resources/Info.plist should be a dictionary")
+            return [:]
+        }
+
+        return dictionary
+    }
+}


### PR DESCRIPTION
## Summary
- add the macOS camera privacy usage description needed for facecam permission prompts
- add a regression test that verifies camera and microphone usage descriptions stay declared

## Why
Facecam recording can request camera access, but the app plist only declared microphone usage. macOS requires a camera purpose string for camera access to work correctly in the packaged app.

## Validation
- `swift test`
