### PR TITLE
Prepare release v0.2.5

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.2.4",
-  "releaseName": "Open Recorder v0.2.4",
+  "tagName": "v0.2.5",
+  "releaseName": "Open Recorder v0.2.5",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Patch version bump from `0.2.4` to `0.2.5`
- Updated `apps/rust-service/Cargo.toml`, `apps/rust-service/Cargo.lock`, and `.github/release-plan.json`
- Rust service build and all 4 tests pass

## Release Summary
- Release type: patch
- Base version: 0.2.4 (apps/rust-service/Cargo.toml)
- Next version: 0.2.5
- Tag: v0.2.5
- Release title: Open Recorder v0.2.5
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the macOS Swift/Rust artifacts and publishes the GitHub release.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (4/4 tests)
- [x] Version bumped correctly in Cargo.toml, Cargo.lock, and release-plan.json

https://claude.ai/code/session_01HATAVNSZ92fzuzNLc4WZ8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01HATAVNSZ92fzuzNLc4WZ8G)_