### PR TITLE
Prepare release v0.2.6

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.2.5",
-  "releaseName": "Open Recorder v0.2.5",
+  "tagName": "v0.2.6",
+  "releaseName": "Open Recorder v0.2.6",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## Release Summary
- Release type: patch
- Base version: 0.2.5 (apps/rust-service/Cargo.toml)
- Next version: 0.2.6
- Tag: v0.2.6
- Release title: Open Recorder v0.2.6
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the macOS Swift/Rust artifacts and publishes the GitHub release.

## Test plan
- [x] Rust service builds successfully (`cargo build`)
- [x] Landing page builds successfully (`pnpm build`)
- [x] Version bumped in `apps/rust-service/Cargo.toml` (0.2.5 → 0.2.6)
- [x] Version bumped in `apps/rust-service/Cargo.lock` (0.2.5 → 0.2.6)
- [x] Release plan updated in `.github/release-plan.json`

https://claude.ai/code/session_0161ojp52Sp7mmLUf2z7MHHZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0161ojp52Sp7mmLUf2z7MHHZ)_