### PR TITLE
Prepare release v0.2.7

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.2.6",
-  "releaseName": "Open Recorder v0.2.6",
+  "tagName": "v0.2.7",
+  "releaseName": "Open Recorder v0.2.7",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Patch release bump from `v0.2.6` to `v0.2.7`
- Updated version in `apps/rust-service/Cargo.toml`, `apps/rust-service/Cargo.lock`, and `.github/release-plan.json`
- Rust service build and tests verified passing

## Release Summary
- Release type: patch
- Base version: 0.2.6 (apps/rust-service/Cargo.toml)
- Next version: 0.2.7
- Tag: v0.2.7
- Release title: Open Recorder v0.2.7

Merging this PR will trigger `.github/workflows/release.yml`, which builds the macOS Swift/Rust artifacts and publishes the GitHub release.

## Test plan
- [x] Rust service `cargo build` passes
- [x] Rust service `cargo test` passes (4/4 tests)
- [ ] macOS Swift build (requires macOS environment)

https://claude.ai/code/session_01HpBVCsfmWCktKaCEgW3MSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpBVCsfmWCktKaCEgW3MSX)_