### PR TITLE
[codex] Add HUD source type screen overlay

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -10,6 +10,7 @@ final class AppModel: ObservableObject {
     @Published var captureMode: CaptureMode = .recording
     @Published var hudState: HUDState = .choosingMode
     @Published var selectedSource: CaptureSource?
+    @Published var preferredSourceSelectorKind: CaptureSourceKind?
     @Published var paths: AppPaths?
     @Published var projects: [ProjectSummary] = []
     @Published var currentVideoURL: URL?
@@ -66,6 +67,7 @@ final class AppModel: ObservableObject {
     private let screenRecordingPermission: ScreenRecordingPermission
     private let accessibilityPermission: AccessibilityPermission
     private let onboardingStore: OnboardingStateStore
+    private let screenSelectionPresenter: ScreenSelectionPresenting
     private let screenshotCapture: @MainActor (CaptureSource, URL) throws -> Void
     private let rememberScreenshot: @Sendable (URL) throws -> Void
     private let facecamRecorder = FacecamRecorder()
@@ -77,6 +79,7 @@ final class AppModel: ObservableObject {
         screenRecordingPermission: ScreenRecordingPermission = ScreenRecordingPermission(),
         accessibilityPermission: AccessibilityPermission = AccessibilityPermission(),
         onboardingStore: OnboardingStateStore = .live,
+        screenSelectionPresenter: ScreenSelectionPresenting = ScreenSelectionOverlayController(),
         screenshotCapture: (@MainActor (CaptureSource, URL) throws -> Void)? = nil,
         rememberScreenshot: (@Sendable (URL) throws -> Void)? = nil
     ) {
@@ -87,6 +90,7 @@ final class AppModel: ObservableObject {
         self.screenRecordingPermission = screenRecordingPermission
         self.accessibilityPermission = accessibilityPermission
         self.onboardingStore = onboardingStore
+        self.screenSelectionPresenter = screenSelectionPresenter
         self.capture = capture
         self.screenshotCapture = screenshotCapture ?? { source, outputURL in
             try capture.takeScreenshot(source: source, outputURL: outputURL)
@@ -307,16 +311,15 @@ final class AppModel: ObservableObject {
         }
 
         captureMode = mode
-        if let selectedSource {
-            setHUDPhase(.ready(mode, selectedSource))
-        } else {
-            setHUDPhase(.selectingSource(mode))
-        }
-        statusMessage = selectedSource == nil ? "Choose a source." : "Ready"
-        requestWindow(.showSourceSelector)
+        preferredSourceSelectorKind = nil
+        screenSelectionPresenter.dismiss()
+        setHUDPhase(.choosingSourceType(mode))
+        statusMessage = "Choose a source type."
+        requestWindow(.showHUD)
     }
 
     func selectSource(_ source: CaptureSource) {
+        preferredSourceSelectorKind = source.kind
         selectedSource = source
         setHUDPhase(.ready(hudState.mode ?? captureMode, source))
         statusMessage = "Selected \(source.name)"
@@ -337,9 +340,102 @@ final class AppModel: ObservableObject {
             area: area,
             thumbnailData: nil
         )
+        preferredSourceSelectorKind = .area
         selectedSource = source
         setHUDPhase(.ready(hudState.mode ?? captureMode, source))
         statusMessage = "Selected area"
+    }
+
+    func chooseSourceType(_ sourceType: CaptureSourceType) {
+        let mode = hudState.mode ?? captureMode
+        captureMode = mode
+
+        switch sourceType {
+        case .screen:
+            requestScreenSelection()
+        case .window:
+            requestSourceSelector(kind: .window, mode: mode, statusMessage: "Choose a window.")
+        case .area:
+            requestSourceSelector(kind: .area, mode: mode, statusMessage: "Choose an area.")
+        }
+    }
+
+    func requestSourceSelector(kind: CaptureSourceKind? = nil) {
+        preferredSourceSelectorKind = kind ?? selectedSource?.kind ?? preferredSourceSelectorKind ?? .display
+        requestWindow(.showSourceSelector)
+    }
+
+    private func requestSourceSelector(
+        kind: CaptureSourceKind,
+        mode: CaptureMode,
+        statusMessage: String
+    ) {
+        preferredSourceSelectorKind = kind
+        setHUDPhase(.selectingSource(mode))
+        self.statusMessage = statusMessage
+        requestWindow(.showSourceSelector)
+    }
+
+    func requestScreenSelection() {
+        let mode = hudState.mode ?? captureMode
+        captureMode = mode
+        preferredSourceSelectorKind = .display
+        setHUDPhase(.screenSelecting(mode))
+        statusMessage = "Choose a screen."
+
+        let currentDisplaySources = capture.sources.filter { $0.kind == .display }
+        guard currentDisplaySources.isEmpty else {
+            presentScreenSelection(displaySources: currentDisplaySources, mode: mode)
+            return
+        }
+
+        Task { [weak self] in
+            guard let self else { return }
+            await self.refreshSources(requestScreenRecordingPermission: true)
+            let displaySources = self.capture.sources.filter { $0.kind == .display }
+            self.presentScreenSelection(displaySources: displaySources, mode: mode)
+        }
+    }
+
+    func completeScreenSelection(_ source: CaptureSource) {
+        guard source.kind == .display else {
+            statusMessage = "Choose a screen."
+            return
+        }
+
+        screenSelectionPresenter.dismiss()
+        selectSource(source)
+        requestWindow(.showHUD)
+    }
+
+    func cancelScreenSelection(message: String? = nil) {
+        screenSelectionPresenter.dismiss()
+        let mode = hudState.mode ?? captureMode
+        setHUDPhase(.choosingSourceType(mode))
+        statusMessage = message ?? "Choose a source type."
+        requestWindow(.showHUD)
+    }
+
+    private func presentScreenSelection(displaySources: [CaptureSource], mode: CaptureMode) {
+        guard case .screenSelecting(let activeMode) = hudState.phase,
+              activeMode == mode else {
+            return
+        }
+
+        guard !displaySources.isEmpty else {
+            cancelScreenSelection(message: "No screens available.")
+            return
+        }
+
+        screenSelectionPresenter.present(
+            displaySources: displaySources,
+            onSelect: { [weak self] source in
+                self?.completeScreenSelection(source)
+            },
+            onCancel: { [weak self] in
+                self?.cancelScreenSelection()
+            }
+        )
     }
 
     func requestInteractiveAreaSelection() {
@@ -369,6 +465,8 @@ final class AppModel: ObservableObject {
 
     func cancelCapture() {
         isAreaSelectionActive = false
+        screenSelectionPresenter.dismiss()
+        preferredSourceSelectorKind = nil
         setHUDPhase(.choosingMode)
         statusMessage = "Ready"
     }
@@ -396,8 +494,10 @@ final class AppModel: ObservableObject {
     }
 
     func showEditor(for session: EditorSession) {
+        screenSelectionPresenter.dismiss()
         setHUDPhase(.choosingMode)
         isAreaSelectionActive = false
+        preferredSourceSelectorKind = nil
         lastEditorSession = session
         selectedSection = .editor
         requestWindow(.showStudio, editorSession: session)
@@ -415,6 +515,10 @@ final class AppModel: ObservableObject {
         switch hudState.phase {
         case .selectingSource, .ready, .areaSelecting:
             requestWindow(.showSourceSelector)
+        case .choosingSourceType:
+            showHUD()
+        case .screenSelecting:
+            requestWindow(.showHUD)
         case .countingDownRecording, .startingRecording, .recording, .stoppingRecording, .capturingScreenshot:
             showHUD()
         case .idle, .choosingMode:
@@ -437,7 +541,7 @@ final class AppModel: ObservableObject {
         }
 
         switch previousPhase {
-        case .selectingSource, .ready, .areaSelecting:
+        case .choosingSourceType, .screenSelecting, .selectingSource, .ready, .areaSelecting:
             return true
         case .idle,
              .choosingMode,
@@ -465,6 +569,8 @@ final class AppModel: ObservableObject {
             return
         case .idle,
              .choosingMode,
+             .choosingSourceType,
+             .screenSelecting,
              .selectingSource,
              .ready,
              .areaSelecting,

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -214,6 +214,10 @@ final class CaptureController: ObservableObject {
         self.isRecording = isRecording
     }
 
+    func setSourcesForTesting(_ sources: [CaptureSource]) {
+        self.sources = sources
+    }
+
     func ensureScreenRecordingPermissionForTesting() throws {
         try ensureScreenRecordingPermission()
     }

--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -180,7 +180,7 @@ struct CaptureHUD: View {
 
     private func sourcePicker(minWidth: CGFloat = 132, maxWidth: CGFloat = 198) -> some View {
         StudioButton(hitTarget: .capsule, help: "Choose Source") {
-            model.requestWindow(.showSourceSelector)
+            model.requestSourceSelector()
             openWindow(id: "source-selector")
         } label: {
             SourceChip(source: model.selectedSource, tone: sourceChipTone, minWidth: minWidth, maxWidth: maxWidth)

--- a/apps/macos/Sources/OpenRecorderMac/CaptureViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureViews.swift
@@ -16,13 +16,20 @@ struct CaptureStudioView: View {
         ZStack {
             Color.studioBackground
 
-            if model.captureFlow == .choice {
+            switch model.hudState.phase {
+            case .idle, .choosingMode:
                 VStack {
                     Spacer()
-                    CaptureChoiceHUD(sourceTab: $sourceTab)
+                    CaptureChoiceHUD()
                         .padding(.bottom, 56)
                 }
-            } else {
+            case .choosingSourceType(let mode), .screenSelecting(let mode):
+                VStack {
+                    Spacer()
+                    SourceTypeChoiceHUD(mode: mode)
+                        .padding(.bottom, 56)
+                }
+            default:
                 VStack(spacing: 18) {
                     Spacer(minLength: 10)
                     SourceSelectorCard(
@@ -41,6 +48,10 @@ struct CaptureStudioView: View {
                 .onAppear {
                     model.reloadSourcesForPreview()
                 }
+                .onChange(of: model.preferredSourceSelectorKind) { _, kind in
+                    guard let kind else { return }
+                    sourceTab = SourceSelectorTab(sourceKind: kind)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -49,7 +60,6 @@ struct CaptureStudioView: View {
 
 struct CaptureChoiceHUD: View {
     @EnvironmentObject private var model: AppModel
-    @Binding var sourceTab: SourceSelectorTab
 
     var body: some View {
         HUDSurface {
@@ -62,7 +72,6 @@ struct CaptureChoiceHUD: View {
                     isActive: false
                 ) {
                     model.beginCapture(.screenshot)
-                    sourceTab = .screens
                 }
 
                 CaptureModeButton(
@@ -73,6 +82,72 @@ struct CaptureChoiceHUD: View {
                     model.beginCapture(.recording)
                 }
             }
+        }
+    }
+}
+
+struct SourceTypeChoiceHUD: View {
+    @EnvironmentObject private var model: AppModel
+    var mode: CaptureMode
+
+    var body: some View {
+        HUDSurface {
+            HStack(spacing: 8) {
+                DragHandle()
+                backButton
+                HUDDivider()
+
+                FlowLabel(
+                    tone: .blue,
+                    label: mode == .screenshot ? "Screenshot" : "Recording",
+                    value: "Source"
+                )
+
+                ForEach(CaptureSourceType.allCases) { sourceType in
+                    SourceTypeButton(sourceType: sourceType) {
+                        model.chooseSourceType(sourceType)
+                    }
+                }
+            }
+        }
+    }
+
+    private var backButton: some View {
+        StudioButton(hitTarget: .circle, help: "Back") {
+            model.cancelCapture()
+        } label: {
+            Image(systemName: "chevron.left")
+                .font(.system(size: 13, weight: .bold))
+                .frame(width: 38, height: 38)
+                .foregroundStyle(Color.white.opacity(0.70))
+                .background(Color.white.opacity(0.06), in: Circle())
+                .overlay {
+                    Circle()
+                        .stroke(Color.white.opacity(0.09), lineWidth: 1)
+                }
+        }
+    }
+}
+
+struct SourceTypeButton: View {
+    var sourceType: CaptureSourceType
+    var action: () -> Void
+
+    var body: some View {
+        StudioButton(hitTarget: .capsule, help: sourceType.title, action: action) {
+            Label(sourceType.title, systemImage: sourceType.symbolName)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 94)
+                .frame(height: 38)
+                .padding(.horizontal, 12)
+                .foregroundStyle(Color.white.opacity(0.76))
+                .background(Color.white.opacity(0.07), in: Capsule())
+                .overlay {
+                    Capsule()
+                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                }
         }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -51,6 +51,38 @@ enum CaptureSourceKind: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+enum CaptureSourceType: String, CaseIterable, Identifiable {
+    case screen
+    case window
+    case area
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .screen: "Screen"
+        case .window: "Window"
+        case .area: "Area"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .screen: "display"
+        case .window: "macwindow"
+        case .area: "rectangle.dashed"
+        }
+    }
+
+    var sourceKind: CaptureSourceKind {
+        switch self {
+        case .screen: .display
+        case .window: .window
+        case .area: .area
+        }
+    }
+}
+
 struct CaptureSource: Identifiable, Codable, Hashable {
     var id: String
     var kind: CaptureSourceKind
@@ -471,6 +503,8 @@ enum HUDPresentationState: Hashable {
 enum HUDPhase: Hashable {
     case idle
     case choosingMode
+    case choosingSourceType(CaptureMode)
+    case screenSelecting(CaptureMode)
     case selectingSource(CaptureMode)
     case ready(CaptureMode, CaptureSource)
     case areaSelecting(CaptureMode)
@@ -496,6 +530,14 @@ struct HUDState: Hashable {
 
     static var choosingMode: HUDState {
         HUDState(phase: .choosingMode)
+    }
+
+    static func choosingSourceType(_ mode: CaptureMode) -> HUDState {
+        HUDState(phase: .choosingSourceType(mode))
+    }
+
+    static func screenSelecting(_ mode: CaptureMode) -> HUDState {
+        HUDState(phase: .screenSelecting(mode))
     }
 
     static func selectingSource(_ mode: CaptureMode) -> HUDState {
@@ -543,6 +585,8 @@ struct HUDState: Hashable {
         case .idle, .choosingMode:
             nil
         case .selectingSource(let mode),
+             .choosingSourceType(let mode),
+             .screenSelecting(let mode),
              .areaSelecting(let mode):
             mode
         case .ready(let mode, _):
@@ -568,6 +612,8 @@ struct HUDState: Hashable {
             source
         case .idle,
              .choosingMode,
+             .choosingSourceType,
+             .screenSelecting,
              .selectingSource,
              .areaSelecting:
             nil
@@ -578,7 +624,9 @@ struct HUDState: Hashable {
         switch phase {
         case .idle, .choosingMode:
             false
-        case .selectingSource,
+        case .choosingSourceType,
+             .screenSelecting,
+             .selectingSource,
              .ready,
              .areaSelecting,
              .countingDownRecording,
@@ -594,7 +642,9 @@ struct HUDState: Hashable {
         switch phase {
         case .idle, .choosingMode:
             .choice
-        case .selectingSource(let mode),
+        case .choosingSourceType(let mode),
+             .screenSelecting(let mode),
+             .selectingSource(let mode),
              .ready(let mode, _),
              .areaSelecting(let mode):
             mode == .screenshot ? .screenshotSetup : .recordingSetup

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -472,7 +472,6 @@ private final class OpenRecorderStatusItemController: NSObject {
         guard model.canStartNewCapture else { return }
         model.beginCapture(mode)
         model.showHUD()
-        windowActions.open("source-selector")
         windowActions.open("hud")
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
@@ -1,0 +1,182 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+@MainActor
+protocol ScreenSelectionPresenting: AnyObject {
+    func present(
+        displaySources: [CaptureSource],
+        onSelect: @escaping (CaptureSource) -> Void,
+        onCancel: @escaping () -> Void
+    )
+    func dismiss()
+}
+
+@MainActor
+final class ScreenSelectionOverlayController: ScreenSelectionPresenting {
+    private var windows: [NSWindow] = []
+    private var keyMonitor: Any?
+    private var onCancel: (() -> Void)?
+
+    func present(
+        displaySources: [CaptureSource],
+        onSelect: @escaping (CaptureSource) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        dismiss()
+
+        guard !displaySources.isEmpty else {
+            onCancel()
+            return
+        }
+
+        self.onCancel = onCancel
+        installKeyMonitor()
+
+        for (screenIndex, screen) in NSScreen.screens.enumerated() {
+            guard let source = displaySource(for: screen, index: screenIndex, in: displaySources) else {
+                continue
+            }
+            let window = ScreenSelectionOverlayWindow(
+                contentRect: screen.frame,
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.hasShadow = false
+            window.level = .screenSaver
+            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+            window.isMovableByWindowBackground = false
+            window.contentView = NSHostingView(rootView: ScreenSelectionOverlayView(
+                sourceName: source.name,
+                onChoose: { onSelect(source) },
+                onCancel: onCancel
+            ))
+            windows.append(window)
+            window.orderFrontRegardless()
+        }
+
+        guard !windows.isEmpty else {
+            dismiss()
+            onCancel()
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        windows.last?.makeKeyAndOrderFront(nil)
+    }
+
+    func dismiss() {
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
+        }
+        keyMonitor = nil
+        onCancel = nil
+        windows.forEach { $0.close() }
+        windows.removeAll()
+    }
+
+    private func installKeyMonitor() {
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            if event.keyCode == UInt16(kVK_Escape) || event.charactersIgnoringModifiers == "\u{1B}" {
+                self.onCancel?()
+                return nil
+            }
+            return event
+        }
+    }
+
+    private func displaySource(
+        for screen: NSScreen,
+        index: Int,
+        in displaySources: [CaptureSource]
+    ) -> CaptureSource? {
+        if let displayID = screen.displayID,
+           let source = displaySources.first(where: { $0.displayID == displayID }) {
+            return source
+        }
+
+        if let source = displaySources.first(where: { $0.displayIndex == index + 1 }) {
+            return source
+        }
+
+        guard displaySources.indices.contains(index) else {
+            return nil
+        }
+        return displaySources[index]
+    }
+}
+
+private final class ScreenSelectionOverlayWindow: NSWindow {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+private struct ScreenSelectionOverlayView: View {
+    var sourceName: String
+    var onChoose: () -> Void
+    var onCancel: () -> Void
+
+    var body: some View {
+        ZStack {
+            overlayColor
+                .ignoresSafeArea()
+                .rectangularHitTarget()
+                .onTapGesture(perform: onCancel)
+
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(overlayColor.opacity(0.18))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(Color.white.opacity(0.74), lineWidth: 3)
+                }
+                .padding(18)
+                .allowsHitTesting(false)
+
+            VStack(spacing: 14) {
+                Image(systemName: "display")
+                    .font(.system(size: 34, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.92))
+
+                Text(sourceName)
+                    .font(.system(size: 18, weight: .semibold))
+                    .lineLimit(1)
+                    .foregroundStyle(Color.white.opacity(0.92))
+
+                Button(action: onChoose) {
+                    Label("Choose Screen", systemImage: "checkmark.circle.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .lineLimit(1)
+                        .padding(.horizontal, 18)
+                        .frame(height: 42)
+                        .background(Color.white, in: Capsule())
+                        .foregroundStyle(Color(red: 0.08, green: 0.28, blue: 0.74))
+                        .shadow(color: Color.black.opacity(0.18), radius: 18, y: 10)
+                }
+                .buttonStyle(.plain)
+                .capsuleHitTarget()
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(0.26), lineWidth: 1)
+            }
+        }
+    }
+
+    private var overlayColor: Color {
+        Color(red: 0.12, green: 0.42, blue: 1.0).opacity(0.32)
+    }
+}
+
+private extension NSScreen {
+    var displayID: UInt32? {
+        (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/SourceSelectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SourceSelectorViews.swift
@@ -52,8 +52,18 @@ struct SourceSelectorWindowView: View {
             preferredHeight = nextHeight
         }
         .onAppear {
+            applyPreferredSourceTab()
             model.reloadSourcesForPreview()
         }
+        .onChange(of: model.preferredSourceSelectorKind) { _, _ in
+            applyPreferredSourceTab()
+        }
+    }
+
+    private func applyPreferredSourceTab() {
+        sourceTab = SourceSelectorTab(
+            sourceKind: model.preferredSourceSelectorKind ?? model.selectedSource?.kind ?? .display
+        )
     }
 }
 
@@ -65,6 +75,17 @@ enum SourceSelectorTab: String, CaseIterable, Identifiable {
     case area
 
     var id: String { rawValue }
+
+    init(sourceKind: CaptureSourceKind) {
+        switch sourceKind {
+        case .display:
+            self = .screens
+        case .window:
+            self = .windows
+        case .area:
+            self = .area
+        }
+    }
 
     var title: String {
         switch self {

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -474,37 +474,17 @@ struct WindowCommandBridge: View {
 
 struct HUDOverlayWindowView: View {
     @EnvironmentObject private var model: AppModel
-    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         ZStack {
             Color.clear
 
-            if model.captureFlow == .choice {
-                HUDSurface {
-                    HStack(spacing: 12) {
-                        DragHandle()
-
-                        CaptureModeButton(
-                            title: "Screenshot",
-                            symbolName: "camera",
-                            isActive: false
-                        ) {
-                            model.beginCapture(.screenshot)
-                            openWindow(id: "source-selector")
-                        }
-
-                        CaptureModeButton(
-                            title: "Record Video",
-                            symbolName: "video",
-                            isActive: false
-                        ) {
-                            model.beginCapture(.recording)
-                            openWindow(id: "source-selector")
-                        }
-                    }
-                }
-            } else {
+            switch model.hudState.phase {
+            case .idle, .choosingMode:
+                CaptureChoiceHUD()
+            case .choosingSourceType(let mode), .screenSelecting(let mode):
+                SourceTypeChoiceHUD(mode: mode)
+            default:
                 CaptureHUD(sourceTab: .constant(model.captureMode == .screenshot ? .screens : .screens))
             }
         }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -3,25 +3,49 @@ import XCTest
 
 @MainActor
 final class AppModelStateTests: XCTestCase {
-    func testBeginRecordingMovesToSetupAndRequestsSelector() {
+    func testBeginRecordingMovesToSourceTypeChoiceAndRequestsHUD() {
         let model = AppModel()
 
         model.beginCapture(.recording)
 
         XCTAssertEqual(model.captureMode, .recording)
         XCTAssertEqual(model.captureFlow, .recordingSetup)
-        XCTAssertEqual(model.hudState, .selectingSource(.recording))
-        XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
+        XCTAssertEqual(model.hudState, .choosingSourceType(.recording))
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
-    func testBeginScreenshotMovesToSetupAndRequestsSelector() {
+    func testBeginScreenshotMovesToSourceTypeChoiceAndRequestsHUD() {
         let model = AppModel()
 
         model.beginCapture(.screenshot)
 
         XCTAssertEqual(model.captureMode, .screenshot)
         XCTAssertEqual(model.captureFlow, .screenshotSetup)
+        XCTAssertEqual(model.hudState, .choosingSourceType(.screenshot))
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+    }
+
+    func testChoosingWindowSourceTypeOpensSourceSelectorOnWindowTab() {
+        let model = AppModel()
+
+        model.beginCapture(.recording)
+        model.chooseSourceType(.window)
+
+        XCTAssertEqual(model.hudState, .selectingSource(.recording))
+        XCTAssertEqual(model.preferredSourceSelectorKind, .window)
+        XCTAssertEqual(model.statusMessage, "Choose a window.")
+        XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
+    }
+
+    func testChoosingAreaSourceTypeOpensSourceSelectorOnAreaTab() {
+        let model = AppModel()
+
+        model.beginCapture(.screenshot)
+        model.chooseSourceType(.area)
+
         XCTAssertEqual(model.hudState, .selectingSource(.screenshot))
+        XCTAssertEqual(model.preferredSourceSelectorKind, .area)
+        XCTAssertEqual(model.statusMessage, "Choose an area.")
         XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
     }
 
@@ -75,8 +99,8 @@ final class AppModelStateTests: XCTestCase {
 
         XCTAssertEqual(model.captureMode, .recording)
         XCTAssertEqual(model.captureFlow, .recordingSetup)
-        XCTAssertEqual(model.hudState, .selectingSource(.recording))
-        XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
+        XCTAssertEqual(model.hudState, .choosingSourceType(.recording))
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
     func testNewCaptureIsDisabledDuringScreenshotSetup() {
@@ -90,8 +114,8 @@ final class AppModelStateTests: XCTestCase {
 
         XCTAssertEqual(model.captureMode, .screenshot)
         XCTAssertEqual(model.captureFlow, .screenshotSetup)
-        XCTAssertEqual(model.hudState, .selectingSource(.screenshot))
-        XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
+        XCTAssertEqual(model.hudState, .choosingSourceType(.screenshot))
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
     func testNewCaptureIsDisabledOnlyWhileRecording() {
@@ -133,6 +157,9 @@ final class AppModelStateTests: XCTestCase {
             thumbnailData: nil
         )
         let occupiedStates: [HUDState] = [
+            .choosingSourceType(.recording),
+            .screenSelecting(.screenshot),
+            .selectingSource(.recording),
             .ready(.recording, source),
             .areaSelecting(.screenshot),
             .countingDownRecording(source),
@@ -213,6 +240,55 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.hudState, .ready(.recording, source))
         XCTAssertEqual(model.captureFlow, .recordingSetup)
         XCTAssertFalse(model.canStartNewCapture)
+    }
+
+    func testChoosingScreenSourceTypePresentsDisplayOverlay() {
+        let presenter = ScreenSelectionPresenterSpy()
+        let model = AppModel(screenSelectionPresenter: presenter)
+        let source = makeSource(displayID: 42)
+        model.capture.setSourcesForTesting([source])
+
+        model.beginCapture(.screenshot)
+        model.chooseSourceType(.screen)
+
+        XCTAssertEqual(model.hudState, .screenSelecting(.screenshot))
+        XCTAssertEqual(model.preferredSourceSelectorKind, .display)
+        XCTAssertEqual(presenter.presentedSources, [source])
+        XCTAssertNotNil(presenter.onSelect)
+        XCTAssertNotNil(presenter.onCancel)
+    }
+
+    func testChoosingScreenSelectsDisplayAndReturnsReadyHUD() {
+        let presenter = ScreenSelectionPresenterSpy()
+        let model = AppModel(screenSelectionPresenter: presenter)
+        let source = makeSource(displayID: 42)
+        model.capture.setSourcesForTesting([source])
+
+        model.beginCapture(.recording)
+        model.chooseSourceType(.screen)
+        presenter.select(source)
+
+        XCTAssertEqual(model.hudState, .ready(.recording, source))
+        XCTAssertEqual(model.selectedSource, source)
+        XCTAssertEqual(model.captureFlow, .recordingSetup)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+        XCTAssertGreaterThanOrEqual(presenter.dismissCallCount, 1)
+    }
+
+    func testCancelingScreenSelectionReturnsToSourceTypeChoice() {
+        let presenter = ScreenSelectionPresenterSpy()
+        let model = AppModel(screenSelectionPresenter: presenter)
+        let source = makeSource(displayID: 42)
+        model.capture.setSourcesForTesting([source])
+
+        model.beginCapture(.recording)
+        model.chooseSourceType(.screen)
+        presenter.cancel()
+
+        XCTAssertEqual(model.hudState, .choosingSourceType(.recording))
+        XCTAssertEqual(model.statusMessage, "Choose a source type.")
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+        XCTAssertGreaterThanOrEqual(presenter.dismissCallCount, 1)
     }
 
     func testScreenshotEditorReleasesCaptureSlot() {
@@ -743,18 +819,52 @@ private func makeAccessibilityPermission(isTrusted: Bool) -> AccessibilityPermis
     ))
 }
 
-private func makeSource() -> CaptureSource {
+private func makeSource(
+    id: String = "display:1",
+    kind: CaptureSourceKind = .display,
+    displayID: UInt32? = nil
+) -> CaptureSource {
     CaptureSource(
-        id: "display:1",
-        kind: .display,
+        id: id,
+        kind: kind,
         name: "Display 1",
         subtitle: "Built-in",
-        displayIndex: 1,
-        displayID: nil,
+        displayIndex: kind == .display ? 1 : nil,
+        displayID: displayID,
         windowID: nil,
         area: nil,
         thumbnailData: nil
     )
+}
+
+@MainActor
+private final class ScreenSelectionPresenterSpy: ScreenSelectionPresenting {
+    var presentedSources: [CaptureSource] = []
+    var dismissCallCount = 0
+    var onSelect: ((CaptureSource) -> Void)?
+    var onCancel: (() -> Void)?
+
+    func present(
+        displaySources: [CaptureSource],
+        onSelect: @escaping (CaptureSource) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        presentedSources = displaySources
+        self.onSelect = onSelect
+        self.onCancel = onCancel
+    }
+
+    func dismiss() {
+        dismissCallCount += 1
+    }
+
+    func select(_ source: CaptureSource) {
+        onSelect?(source)
+    }
+
+    func cancel() {
+        onCancel?()
+    }
 }
 
 private enum TestScreenshotError: Error {

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
@@ -26,8 +26,16 @@ final class HUDStateMachineTests: XCTestCase {
         XCTAssertEqual(hidden.isCaptureOccupied, visible.isCaptureOccupied)
     }
 
-    func testSourceSelectionStatesDeriveModeAndCaptureFlow() {
+    func testSourceSetupStatesDeriveModeAndCaptureFlow() {
         let source = makeSource()
+
+        XCTAssertEqual(HUDState.choosingSourceType(.recording).mode, .recording)
+        XCTAssertEqual(HUDState.choosingSourceType(.recording).captureFlow, .recordingSetup)
+        XCTAssertTrue(HUDState.choosingSourceType(.recording).isCaptureOccupied)
+
+        XCTAssertEqual(HUDState.screenSelecting(.screenshot).mode, .screenshot)
+        XCTAssertEqual(HUDState.screenSelecting(.screenshot).captureFlow, .screenshotSetup)
+        XCTAssertTrue(HUDState.screenSelecting(.screenshot).isCaptureOccupied)
 
         XCTAssertEqual(HUDState.selectingSource(.recording).mode, .recording)
         XCTAssertEqual(HUDState.selectingSource(.recording).captureFlow, .recordingSetup)
@@ -94,17 +102,17 @@ final class HUDStateMachineTests: XCTestCase {
         XCTAssertTrue(state.isCaptureOccupied)
     }
 
-    func testBeginCaptureWithExistingSourceMovesDirectlyToReadyState() {
+    func testBeginCaptureWithExistingSourceStillShowsSourceTypeChoice() {
         let model = AppModel()
         let source = makeSource()
         model.selectedSource = source
 
         model.beginCapture(.recording)
 
-        XCTAssertEqual(model.hudState, .ready(.recording, source))
+        XCTAssertEqual(model.hudState, .choosingSourceType(.recording))
         XCTAssertEqual(model.captureFlow, .recordingSetup)
         XCTAssertFalse(model.canStartNewCapture)
-        XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
     func testDuplicateCaptureRequestDuringReadyStatePreservesExistingModeAndFocusesSelector() {


### PR DESCRIPTION
## Summary
- add a source-type HUD step after choosing Screenshot or Record Video
- route Window and Area to the existing source selector on the correct tab
- add per-display translucent blue screen selection overlays with choose/cancel handling

## Validation
- swift test in apps/macos
- 184 tests passed, 0 failures

## Notes
- Screen selection returns to the ready HUD after choosing a display; it does not immediately capture or start recording.