### PR TITLE
[codex] Clarify screen overlay choose action

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
@@ -194,7 +194,7 @@ private struct ScreenSelectionOverlayView: View {
                     .foregroundStyle(Color.white.opacity(0.92))
 
                 Button(action: onChoose) {
-                    Label("Choose Screen", systemImage: "checkmark.circle.fill")
+                    Label("Choose Screen", systemImage: "cursorarrow")
                         .font(.system(size: 14, weight: .semibold))
                         .lineLimit(1)
                         .padding(.horizontal, 18)


### PR DESCRIPTION
## Summary
- replace the checkmark icon in the screen overlay button with a neutral cursor action icon
- keep the button as a call to choose the screen, without implying it is already selected

## Validation
- swift test in apps/macos: 185 tests, 0 failures

## Note
- PR #249 merged before this visual tweak landed, so this is a small follow-up PR.