### PR TITLE
Add cursor preset styles and variants

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CursorPresetRenderer.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CursorPresetRenderer.swift
@@ -1,0 +1,370 @@
+import AppKit
+import CoreGraphics
+import SwiftUI
+
+struct CursorGlyphPalette {
+    var fill: SerializableColor
+    var stroke: SerializableColor
+    var shadow: SerializableColor
+}
+
+struct CursorGlyphDrawing {
+    var path: CGPath
+    var canvasSize: CGSize
+    var hotspot: CGPoint
+    var strokeWidth: CGFloat
+    var fillsShape: Bool
+}
+
+struct CursorRenderedGlyph {
+    var image: CGImage
+    var canvasSize: CGSize
+    var hotspot: CGPoint
+
+    var bottomLeftHotspot: CGPoint {
+        CGPoint(x: hotspot.x, y: canvasSize.height - hotspot.y)
+    }
+
+    var coreAnimationAnchorPoint: CGPoint {
+        CGPoint(
+            x: hotspot.x / max(canvasSize.width, 1),
+            y: 1 - hotspot.y / max(canvasSize.height, 1)
+        )
+    }
+}
+
+enum CursorPresetRenderer {
+    static let palette = CursorGlyphPalette(
+        fill: SerializableColor(hex: "#FFFFFF"),
+        stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.84),
+        shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.36)
+    )
+
+    static let macOSBlackPalette = CursorGlyphPalette(
+        fill: SerializableColor(hex: "#1F2023"),
+        stroke: SerializableColor(red: 1, green: 1, blue: 1, alpha: 0.84),
+        shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.28)
+    )
+
+    static func palette(for style: CursorStyle) -> CursorGlyphPalette {
+        switch style {
+        case .macOSBlackArrow:
+            return macOSBlackPalette
+        case .arrow, .outlineArrow, .handPointer, .iBeam, .dotPointer:
+            return palette
+        }
+    }
+
+    static func drawing(style: CursorStyle, size: CGFloat, variant: CursorVariant = .standard) -> CursorGlyphDrawing {
+        let resolvedSize = max(1, size)
+        let resolvedVariant = style.resolvedVariant(variant)
+        switch style {
+        case .arrow, .macOSBlackArrow:
+            return arrowDrawing(size: resolvedSize, fillsShape: true, variant: resolvedVariant)
+        case .outlineArrow:
+            return arrowDrawing(size: resolvedSize, fillsShape: false, variant: resolvedVariant)
+        case .handPointer:
+            return handDrawing(size: resolvedSize, variant: resolvedVariant)
+        case .iBeam:
+            return iBeamDrawing(size: resolvedSize, variant: resolvedVariant)
+        case .dotPointer:
+            return dotDrawing(size: resolvedSize, variant: resolvedVariant)
+        }
+    }
+
+    static func renderedGlyph(style: CursorStyle, variant: CursorVariant, size: CGFloat) -> CursorRenderedGlyph? {
+        let resolvedVariant = style.resolvedVariant(variant)
+        let drawing = drawing(style: style, size: size, variant: resolvedVariant)
+        let palette = palette(for: style)
+        let margin = max(3, size * 0.22)
+        let pixelSize = CGSize(
+            width: ceil(drawing.canvasSize.width + margin * 2),
+            height: ceil(drawing.canvasSize.height + margin * 2)
+        )
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+
+        guard let context = CGContext(
+            data: nil,
+            width: max(1, Int(pixelSize.width)),
+            height: max(1, Int(pixelSize.height)),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        context.clear(CGRect(origin: .zero, size: pixelSize))
+        context.translateBy(x: 0, y: pixelSize.height)
+        context.scaleBy(x: 1, y: -1)
+        context.translateBy(x: margin, y: margin)
+        context.setShadow(
+            offset: CGSize(width: 0, height: size * 0.08),
+            blur: max(2, size * 0.18),
+            color: palette.shadow.cgColor
+        )
+        draw(drawing, in: context, palette: palette)
+
+        guard let image = context.makeImage() else {
+            return nil
+        }
+
+        return CursorRenderedGlyph(
+            image: image,
+            canvasSize: pixelSize,
+            hotspot: CGPoint(x: margin + drawing.hotspot.x, y: margin + drawing.hotspot.y)
+        )
+    }
+
+    private static func draw(_ drawing: CursorGlyphDrawing, in context: CGContext, palette: CursorGlyphPalette) {
+        context.setLineJoin(.round)
+        context.setLineCap(.round)
+        context.setLineWidth(drawing.strokeWidth)
+
+        if drawing.fillsShape {
+            context.addPath(drawing.path)
+            context.setFillColor(palette.fill.cgColor)
+            context.fillPath()
+        }
+
+        context.addPath(drawing.path)
+        context.setStrokeColor(palette.stroke.cgColor)
+        context.strokePath()
+    }
+
+    private static func arrowDrawing(size: CGFloat, fillsShape: Bool, variant: CursorVariant) -> CursorGlyphDrawing {
+        let points: (tail: CGFloat, shaft: CGFloat, heel: CGFloat, notch: CGFloat, head: CGFloat, height: CGFloat)
+        let strokeScale: CGFloat
+        switch variant {
+        case .standard:
+            points = (0.24, 0.45, 0.64, 0.43, 0.78, 1.30)
+            strokeScale = fillsShape ? 0.08 : 0.11
+        case .slim:
+            points = (0.18, 0.37, 0.54, 0.35, 0.66, 1.30)
+            strokeScale = fillsShape ? 0.064 : 0.09
+        case .soft:
+            points = (0.28, 0.47, 0.67, 0.46, 0.80, 1.26)
+            strokeScale = fillsShape ? 0.075 : 0.10
+        case .bold:
+            points = (0.30, 0.52, 0.74, 0.50, 0.90, 1.33)
+            strokeScale = fillsShape ? 0.10 : 0.14
+        }
+
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 0, y: size * 1.18))
+        path.addLine(to: CGPoint(x: size * points.tail, y: size * 0.88))
+        path.addLine(to: CGPoint(x: size * points.shaft, y: size * points.height))
+        path.addLine(to: CGPoint(x: size * points.heel, y: size * (points.height - 0.07)))
+        path.addLine(to: CGPoint(x: size * points.notch, y: size * 0.82))
+        path.addLine(to: CGPoint(x: size * points.head, y: size * 0.76))
+        path.closeSubpath()
+
+        return CursorGlyphDrawing(
+            path: path,
+            canvasSize: CGSize(width: size * (points.head + 0.08), height: size * (points.height + 0.06)),
+            hotspot: .zero,
+            strokeWidth: max(1.5, size * strokeScale),
+            fillsShape: fillsShape
+        )
+    }
+
+    private static func handDrawing(size: CGFloat, variant: CursorVariant) -> CursorGlyphDrawing {
+        let xScale: CGFloat
+        let strokeScale: CGFloat
+        switch variant {
+        case .standard:
+            xScale = 1
+            strokeScale = 0.07
+        case .slim:
+            xScale = 0.86
+            strokeScale = 0.058
+        case .soft:
+            xScale = 1.02
+            strokeScale = 0.064
+        case .bold:
+            xScale = 1.08
+            strokeScale = 0.095
+        }
+
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: size * 0.47, y: size * 0.02))
+        path.addCurve(
+            to: CGPoint(x: size * 0.62, y: size * 0.15),
+            control1: CGPoint(x: size * 0.56, y: size * 0.02),
+            control2: CGPoint(x: size * 0.62, y: size * 0.07)
+        )
+        path.addLine(to: CGPoint(x: size * 0.62, y: size * 0.54))
+        path.addCurve(
+            to: CGPoint(x: size * 0.76, y: size * 0.49),
+            control1: CGPoint(x: size * 0.66, y: size * 0.49),
+            control2: CGPoint(x: size * 0.72, y: size * 0.47)
+        )
+        path.addCurve(
+            to: CGPoint(x: size * 0.91, y: size * 0.67),
+            control1: CGPoint(x: size * 0.85, y: size * 0.52),
+            control2: CGPoint(x: size * 0.91, y: size * 0.59)
+        )
+        path.addLine(to: CGPoint(x: size * 0.85, y: size * 1.00))
+        path.addCurve(
+            to: CGPoint(x: size * 0.60, y: size * 1.24),
+            control1: CGPoint(x: size * 0.81, y: size * 1.15),
+            control2: CGPoint(x: size * 0.73, y: size * 1.24)
+        )
+        path.addLine(to: CGPoint(x: size * 0.39, y: size * 1.24))
+        path.addCurve(
+            to: CGPoint(x: size * 0.18, y: size * 1.09),
+            control1: CGPoint(x: size * 0.29, y: size * 1.24),
+            control2: CGPoint(x: size * 0.22, y: size * 1.18)
+        )
+        path.addLine(to: CGPoint(x: size * 0.04, y: size * 0.82))
+        path.addCurve(
+            to: CGPoint(x: size * 0.17, y: size * 0.66),
+            control1: CGPoint(x: size * -0.01, y: size * 0.72),
+            control2: CGPoint(x: size * 0.07, y: size * 0.62)
+        )
+        path.addLine(to: CGPoint(x: size * 0.35, y: size * 0.81))
+        path.addLine(to: CGPoint(x: size * 0.35, y: size * 0.15))
+        path.addCurve(
+            to: CGPoint(x: size * 0.47, y: size * 0.02),
+            control1: CGPoint(x: size * 0.35, y: size * 0.07),
+            control2: CGPoint(x: size * 0.40, y: size * 0.02)
+        )
+        path.closeSubpath()
+
+        let hotspot = CGPoint(x: size * 0.54, y: size * 0.02)
+        let resolvedPath: CGPath
+        if xScale == 1 {
+            resolvedPath = path
+        } else {
+            var transform = CGAffineTransform(translationX: hotspot.x, y: 0)
+                .scaledBy(x: xScale, y: 1)
+                .translatedBy(x: -hotspot.x, y: 0)
+            resolvedPath = path.copy(using: &transform) ?? path
+        }
+
+        return CursorGlyphDrawing(
+            path: resolvedPath,
+            canvasSize: CGSize(width: size * max(1, xScale), height: size * 1.30),
+            hotspot: hotspot,
+            strokeWidth: max(1.4, size * strokeScale),
+            fillsShape: true
+        )
+    }
+
+    private static func iBeamDrawing(size: CGFloat, variant: CursorVariant) -> CursorGlyphDrawing {
+        let capWidth: CGFloat
+        let stemWidth: CGFloat
+        let cornerRadius: CGFloat
+        switch variant {
+        case .standard:
+            capWidth = 0.62
+            stemWidth = 0.10
+            cornerRadius = 0
+        case .slim:
+            capWidth = 0.48
+            stemWidth = 0.06
+            cornerRadius = 0
+        case .soft:
+            capWidth = 0.62
+            stemWidth = 0.11
+            cornerRadius = size * 0.035
+        case .bold:
+            capWidth = 0.74
+            stemWidth = 0.16
+            cornerRadius = 0
+        }
+
+        let path = CGMutablePath()
+        addIBeamRect(
+            CGRect(x: size * (0.5 - capWidth / 2), y: 0, width: size * capWidth, height: size * 0.12),
+            to: path,
+            cornerRadius: cornerRadius
+        )
+        addIBeamRect(
+            CGRect(x: size * (0.5 - stemWidth / 2), y: size * 0.06, width: size * stemWidth, height: size * 1.08),
+            to: path,
+            cornerRadius: cornerRadius
+        )
+        addIBeamRect(
+            CGRect(x: size * (0.5 - capWidth / 2), y: size * 1.08, width: size * capWidth, height: size * 0.12),
+            to: path,
+            cornerRadius: cornerRadius
+        )
+
+        return CursorGlyphDrawing(
+            path: path,
+            canvasSize: CGSize(width: size, height: size * 1.20),
+            hotspot: CGPoint(x: size * 0.50, y: size * 0.60),
+            strokeWidth: max(1, size * (variant == .bold ? 0.052 : 0.04)),
+            fillsShape: true
+        )
+    }
+
+    private static func dotDrawing(size: CGFloat, variant: CursorVariant) -> CursorGlyphDrawing {
+        let diameter: CGFloat
+        let fillsShape: Bool
+        let strokeScale: CGFloat
+        switch variant {
+        case .standard:
+            diameter = size * 0.58
+            fillsShape = true
+            strokeScale = 0.08
+        case .slim:
+            diameter = size * 0.42
+            fillsShape = true
+            strokeScale = 0.06
+        case .soft:
+            diameter = size * 0.62
+            fillsShape = false
+            strokeScale = 0.10
+        case .bold:
+            diameter = size * 0.72
+            fillsShape = true
+            strokeScale = 0.09
+        }
+        let origin = CGPoint(x: (size * 0.90 - diameter) / 2, y: (size * 0.90 - diameter) / 2)
+        let path = CGMutablePath()
+        path.addEllipse(in: CGRect(origin: origin, size: CGSize(width: diameter, height: diameter)))
+
+        return CursorGlyphDrawing(
+            path: path,
+            canvasSize: CGSize(width: size * 0.90, height: size * 0.90),
+            hotspot: CGPoint(x: size * 0.45, y: size * 0.45),
+            strokeWidth: max(1.4, size * strokeScale),
+            fillsShape: fillsShape
+        )
+    }
+
+    private static func addIBeamRect(_ rect: CGRect, to path: CGMutablePath, cornerRadius: CGFloat) {
+        guard cornerRadius > 0 else {
+            path.addRect(rect)
+            return
+        }
+
+        path.addRoundedRect(in: rect, cornerWidth: cornerRadius, cornerHeight: cornerRadius)
+    }
+}
+
+struct CursorGlyphView: View {
+    var style: CursorStyle
+    var variant: CursorVariant
+    var scale: Double
+    var alignsHotspot = false
+
+    var body: some View {
+        let size = max(12, 24 * CGFloat(scale))
+        let resolvedVariant = style.resolvedVariant(variant)
+        if let glyph = CursorPresetRenderer.renderedGlyph(style: style, variant: resolvedVariant, size: size) {
+            Image(nsImage: NSImage(cgImage: glyph.image, size: glyph.canvasSize))
+                .resizable()
+                .frame(width: glyph.canvasSize.width, height: glyph.canvasSize.height)
+                .offset(
+                    x: alignsHotspot ? -glyph.hotspot.x : 0,
+                    y: alignsHotspot ? -glyph.hotspot.y : 0
+                )
+                .allowsHitTesting(false)
+        }
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -83,6 +83,8 @@ struct VideoEditorStudioView: View {
     @State private var loopCursor = false
     @State private var cursorSize = 1.0
     @State private var cursorSmoothing = 0.40
+    @State private var cursorStyle = CursorStyle.arrow
+    @State private var cursorVariant = CursorVariant.standard
     @State private var facecamEnabled = false
     @State private var facecamShape = "circle"
     @State private var facecamSize = 22.0
@@ -223,6 +225,8 @@ struct VideoEditorStudioView: View {
                 loopCursor: $loopCursor,
                 cursorSize: $cursorSize,
                 cursorSmoothing: $cursorSmoothing,
+                cursorStyle: $cursorStyle,
+                cursorVariant: $cursorVariant,
                 facecamEnabled: $facecamEnabled,
                 facecamSize: $facecamSize,
                 facecamBorderWidth: $facecamBorderWidth,
@@ -376,6 +380,8 @@ struct VideoEditorStudioView: View {
         loopCursor = cursor.loops
         cursorSize = cursor.size
         cursorSmoothing = cursor.smoothing
+        cursorStyle = cursor.style
+        cursorVariant = cursor.variant
 
         let facecam = (state?.facecamSettings
             ?? recordingSession?.facecamSettings
@@ -458,7 +464,9 @@ struct VideoEditorStudioView: View {
             isVisible: showCursorOverlay,
             loops: loopCursor,
             size: cursorSize,
-            smoothing: cursorSmoothing
+            smoothing: cursorSmoothing,
+            style: cursorStyle,
+            variant: cursorStyle.resolvedVariant(cursorVariant)
         )
         .clamped
     }

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -18,6 +18,8 @@ struct SettingsInspector: View {
     @Binding var loopCursor: Bool
     @Binding var cursorSize: Double
     @Binding var cursorSmoothing: Double
+    @Binding var cursorStyle: CursorStyle
+    @Binding var cursorVariant: CursorVariant
     @Binding var facecamEnabled: Bool
     @Binding var facecamSize: Double
     @Binding var facecamBorderWidth: Double
@@ -144,8 +146,10 @@ struct SettingsInspector: View {
             BackgroundPickerView(selection: $background)
         case .cursor:
             InspectorSwitch(title: "Show Cursor", isOn: $showCursor)
+            CursorStylePicker(selection: $cursorStyle, variant: $cursorVariant)
+            CursorVariantPicker(style: cursorStyle, selection: $cursorVariant)
             InspectorSwitch(title: "Loop Cursor", isOn: $loopCursor)
-            InspectorSlider(title: "Size", valueText: String(format: "%.2fx", cursorSize), value: $cursorSize, range: 0.5...10, step: 0.05)
+            InspectorSlider(title: "Size", valueText: String(format: "%.2fx", cursorSize), value: $cursorSize, range: 1...8, step: 0.05)
             InspectorSlider(title: "Smoothing", valueText: String(format: "%.2f", cursorSmoothing), value: $cursorSmoothing, range: 0...2, step: 0.01)
         case .camera:
             InspectorSwitch(title: "Facecam", isOn: $facecamEnabled, isInteractive: hasRecordedCamera)
@@ -460,6 +464,105 @@ struct InsetBalancePicker: View {
             left: max(0, min(location.x / size.width, 1)),
             top: max(0, min(location.y / size.height, 1))
         )
+    }
+}
+
+struct CursorStylePicker: View {
+    @Binding var selection: CursorStyle
+    @Binding var variant: CursorVariant
+
+    private let columns = Array(repeating: GridItem(.flexible(minimum: 0), spacing: 6), count: 2)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Style")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: columns, spacing: 6) {
+                ForEach(CursorStyle.allCases) { style in
+                    StudioButton(hitTarget: .rounded(7), help: style.title) {
+                        selection = style
+                        variant = style.resolvedVariant(variant)
+                    } label: {
+                        VStack(spacing: 5) {
+                            CursorGlyphView(style: style, variant: style.resolvedVariant(variant), scale: 0.56)
+                                .frame(width: 38, height: 34)
+                            Text(style.title)
+                                .font(.system(size: 10, weight: .semibold))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.8)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 58)
+                        .foregroundStyle(selection == style ? Color.white : Color.primary.opacity(0.86))
+                        .background(selection == style ? Color.brand.opacity(0.82) : Color.white.opacity(0.045), in: RoundedRectangle(cornerRadius: 7))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 7)
+                                .stroke(selection == style ? Color.brand.opacity(0.95) : Color.white.opacity(0.07))
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 3)
+    }
+}
+
+struct CursorVariantPicker: View {
+    var style: CursorStyle
+    @Binding var selection: CursorVariant
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Variant")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                ForEach(style.supportedVariants) { variant in
+                    StudioButton(hitTarget: .rounded(7), help: variant.title) {
+                        selection = variant
+                    } label: {
+                        VStack(spacing: 4) {
+                            CursorGlyphView(style: style, variant: variant, scale: 0.42)
+                                .frame(width: 28, height: 24)
+                            Text(variant.title)
+                                .font(.system(size: 9, weight: .semibold))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .foregroundStyle(selection == variant ? Color.white : Color.primary.opacity(0.82))
+                        .background(selection == variant ? Color.brand.opacity(0.82) : Color.white.opacity(0.045), in: RoundedRectangle(cornerRadius: 7))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 7)
+                                .stroke(selection == variant ? Color.brand.opacity(0.95) : Color.white.opacity(0.08), lineWidth: selection == variant ? 2 : 1)
+                        }
+                        .overlay(alignment: .topTrailing) {
+                            if selection == variant {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(Color.white)
+                                    .padding(4)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 3)
+        .onAppear(perform: normalizeSelection)
+        .onChange(of: style) { _, _ in
+            normalizeSelection()
+        }
+    }
+
+    private func normalizeSelection() {
+        selection = style.resolvedVariant(selection)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -398,32 +398,165 @@ struct RecordingSession: Codable, Hashable {
     }
 }
 
+enum CursorStyle: String, CaseIterable, Codable, Hashable, Identifiable {
+    case arrow
+    case macOSBlackArrow
+    case outlineArrow
+    case handPointer
+    case iBeam
+    case dotPointer
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .arrow: "Arrow"
+        case .macOSBlackArrow: "macOS Black"
+        case .outlineArrow: "Outline"
+        case .handPointer: "Hand"
+        case .iBeam: "I-Beam"
+        case .dotPointer: "Dot"
+        }
+    }
+
+    var defaultVariant: CursorVariant {
+        .standard
+    }
+
+    var supportedVariants: [CursorVariant] {
+        CursorVariant.allCases
+    }
+
+    func resolvedVariant(_ variant: CursorVariant) -> CursorVariant {
+        supportedVariants.contains(variant) ? variant : defaultVariant
+    }
+}
+
+enum CursorVariant: String, CaseIterable, Codable, Hashable, Identifiable {
+    case standard
+    case slim
+    case soft
+    case bold
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .standard: "Standard"
+        case .slim: "Slim"
+        case .soft: "Soft"
+        case .bold: "Bold"
+        }
+    }
+
+    static func resolve(_ rawValue: String?) -> CursorVariant? {
+        guard let rawValue else { return nil }
+        if let variant = CursorVariant(rawValue: rawValue) {
+            return variant
+        }
+
+        switch rawValue {
+        case "light":
+            return .standard
+        case "dark":
+            return .slim
+        case "accent":
+            return .soft
+        case "highContrast":
+            return .bold
+        default:
+            return nil
+        }
+    }
+}
+
 struct CursorOverlaySettings: Codable, Hashable {
     var isVisible: Bool
     var loops: Bool
     var size: Double
     var smoothing: Double
+    var style: CursorStyle
+    var variant: CursorVariant
 
     static let `default` = CursorOverlaySettings(
         isVisible: true,
         loops: false,
         size: 1,
-        smoothing: 0.4
+        smoothing: 0.4,
+        style: .arrow,
+        variant: .standard
     )
 
     static let hidden = CursorOverlaySettings(
         isVisible: false,
         loops: false,
         size: 1,
-        smoothing: 0.4
+        smoothing: 0.4,
+        style: .arrow,
+        variant: .standard
     )
+
+    init(
+        isVisible: Bool,
+        loops: Bool,
+        size: Double,
+        smoothing: Double,
+        style: CursorStyle = .arrow,
+        variant: CursorVariant = .standard
+    ) {
+        self.isVisible = isVisible
+        self.loops = loops
+        self.size = max(1, min(size, 8))
+        self.smoothing = max(0, min(smoothing, 2))
+        self.style = style
+        self.variant = style.resolvedVariant(variant)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isVisible
+        case loops
+        case size
+        case smoothing
+        case style
+        case variant
+    }
+
+    init(from decoder: Decoder) throws {
+        let defaults = Self.default
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedStyle = try container.decodeIfPresent(String.self, forKey: .style)
+            .flatMap(CursorStyle.init(rawValue:)) ?? defaults.style
+        let decodedVariant = CursorVariant.resolve(try container.decodeIfPresent(String.self, forKey: .variant))
+            ?? decodedStyle.defaultVariant
+
+        self.init(
+            isVisible: try container.decodeIfPresent(Bool.self, forKey: .isVisible) ?? defaults.isVisible,
+            loops: try container.decodeIfPresent(Bool.self, forKey: .loops) ?? defaults.loops,
+            size: try container.decodeIfPresent(Double.self, forKey: .size) ?? defaults.size,
+            smoothing: try container.decodeIfPresent(Double.self, forKey: .smoothing) ?? defaults.smoothing,
+            style: decodedStyle,
+            variant: decodedVariant
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(isVisible, forKey: .isVisible)
+        try container.encode(loops, forKey: .loops)
+        try container.encode(size, forKey: .size)
+        try container.encode(smoothing, forKey: .smoothing)
+        try container.encode(style.rawValue, forKey: .style)
+        try container.encode(variant.rawValue, forKey: .variant)
+    }
 
     var clamped: CursorOverlaySettings {
         CursorOverlaySettings(
             isVisible: isVisible,
             loops: loops,
-            size: max(0.5, min(size, 10)),
-            smoothing: max(0, min(smoothing, 2))
+            size: size,
+            smoothing: smoothing,
+            style: style,
+            variant: variant
         )
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -190,12 +190,18 @@ private struct CursorGlyphImage {
     var tipOffset: CGPoint
 }
 
+private struct CursorGlyphCacheKey: Hashable {
+    var style: CursorStyle
+    var variant: CursorVariant
+    var sizeKey: Int
+}
+
 final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked Sendable {
     private let renderingQueue = DispatchQueue(label: "com.openrecorder.video.compositor", qos: .userInitiated)
     private let ciContext: CIContext
     private var renderContext: AVVideoCompositionRenderContext?
     private let renderContextLock = NSLock()
-    private var cursorGlyphCache: [Int: CursorGlyphImage] = [:]
+    private var cursorGlyphCache: [CursorGlyphCacheKey: CursorGlyphImage] = [:]
 
     override init() {
         if let device = MTLCreateSystemDefaultDevice() {
@@ -429,7 +435,11 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         )
         let baseSize = max(14, min(52, min(contentRect.width, contentRect.height) * 0.032))
         let cursorSize = baseSize * settings.size
-        guard let glyph = cursorGlyphImage(size: cursorSize) else {
+        guard let glyph = cursorGlyphImage(
+            size: cursorSize,
+            style: settings.style,
+            variant: settings.variant
+        ) else {
             return nil
         }
 
@@ -489,52 +499,28 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         return point
     }
 
-    private func cursorGlyphImage(size: CGFloat) -> CursorGlyphImage? {
-        let cacheKey = Int((size * 10).rounded())
+    private func cursorGlyphImage(size: CGFloat, style: CursorStyle, variant: CursorVariant) -> CursorGlyphImage? {
+        let resolvedVariant = style.resolvedVariant(variant)
+        let cacheKey = CursorGlyphCacheKey(
+            style: style,
+            variant: resolvedVariant,
+            sizeKey: Int((size * 10).rounded())
+        )
         if let cached = cursorGlyphCache[cacheKey] {
             return cached
         }
 
-        let margin = max(3, size * 0.22)
-        let width = max(1, Int(ceil(size + margin * 2)))
-        let height = max(1, Int(ceil(size * 1.34 + margin * 2)))
-        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
-        guard let context = CGContext(
-            data: nil,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: 0,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let rendered = CursorPresetRenderer.renderedGlyph(
+            style: style,
+            variant: resolvedVariant,
+            size: size
         ) else {
             return nil
         }
 
-        context.clear(CGRect(x: 0, y: 0, width: width, height: height))
-        context.translateBy(x: 0, y: CGFloat(height))
-        context.scaleBy(x: 1, y: -1)
-        context.translateBy(x: margin, y: margin)
-        context.setShadow(
-            offset: CGSize(width: 0, height: size * 0.08),
-            blur: max(2, size * 0.18),
-            color: CGColor(red: 0, green: 0, blue: 0, alpha: 0.36)
-        )
-        context.addPath(ExportCursorGlyph.path(size: size))
-        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
-        context.setStrokeColor(CGColor(red: 0, green: 0, blue: 0, alpha: 0.82))
-        context.setLineWidth(max(1.5, size * 0.08))
-        context.setLineJoin(.round)
-        context.setLineCap(.round)
-        context.drawPath(using: .fillStroke)
-
-        guard let image = context.makeImage() else {
-            return nil
-        }
-
         let glyph = CursorGlyphImage(
-            image: CIImage(cgImage: image),
-            tipOffset: CGPoint(x: margin, y: CGFloat(height) - margin)
+            image: CIImage(cgImage: rendered.image),
+            tipOffset: rendered.bottomLeftHotspot
         )
         cursorGlyphCache[cacheKey] = glyph
         return glyph

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -737,17 +737,20 @@ enum VideoExportRenderer {
         let resolvedSettings = settings.clamped
         let baseSize = max(14, min(52, min(contentRect.width, contentRect.height) * 0.032))
         let cursorSize = baseSize * resolvedSettings.size
-        let cursorLayer = CAShapeLayer()
-        cursorLayer.bounds = CGRect(x: 0, y: 0, width: cursorSize, height: cursorSize * 1.25)
-        cursorLayer.anchorPoint = CGPoint(x: 0, y: 1)
-        cursorLayer.path = ExportCursorGlyph.path(size: cursorSize)
-        cursorLayer.fillColor = NSColor.white.cgColor
-        cursorLayer.strokeColor = NSColor.black.withAlphaComponent(0.82).cgColor
-        cursorLayer.lineWidth = max(1.5, cursorSize * 0.08)
-        cursorLayer.shadowColor = NSColor.black.cgColor
-        cursorLayer.shadowOpacity = 0.36
-        cursorLayer.shadowRadius = max(2, cursorSize * 0.18)
-        cursorLayer.shadowOffset = CGSize(width: 0, height: -cursorSize * 0.08)
+        let cursorLayer = CALayer()
+        guard let glyph = CursorPresetRenderer.renderedGlyph(
+            style: resolvedSettings.style,
+            variant: resolvedSettings.variant,
+            size: cursorSize
+        ) else {
+            return cursorLayer
+        }
+        cursorLayer.bounds = CGRect(origin: .zero, size: glyph.canvasSize)
+        cursorLayer.anchorPoint = glyph.coreAnimationAnchorPoint
+        cursorLayer.contents = glyph.image
+        cursorLayer.contentsGravity = .resize
+        cursorLayer.magnificationFilter = .linear
+        cursorLayer.minificationFilter = .linear
 
         let duration = max(0.001, editPlan.outputDuration)
         let sampleCount = max(2, min(9_000, Int(ceil(duration * 30)) + 1))
@@ -898,20 +901,4 @@ enum VideoExportRenderer {
         )
     }
 
-}
-
-enum ExportCursorGlyph {
-    static func path(size: CGFloat) -> CGPath {
-        let path = CGMutablePath()
-        path.move(to: CGPoint(x: 0, y: size * 1.18))
-        path.addLine(to: CGPoint(x: 0, y: 0))
-        path.addLine(to: CGPoint(x: size * 0.78, y: size * 0.76))
-        path.addLine(to: CGPoint(x: size * 0.43, y: size * 0.82))
-        path.addLine(to: CGPoint(x: size * 0.64, y: size * 1.23))
-        path.addLine(to: CGPoint(x: size * 0.45, y: size * 1.30))
-        path.addLine(to: CGPoint(x: size * 0.24, y: size * 0.88))
-        path.addLine(to: CGPoint(x: 0, y: size * 1.18))
-        path.closeSubpath()
-        return path
-    }
 }

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -928,7 +928,13 @@ private struct CursorOverlayView: View {
     var body: some View {
         GeometryReader { proxy in
             if let point = currentPoint(in: proxy.size) {
-                CursorGlyph(scale: settings.clamped.size)
+                let resolvedSettings = settings.clamped
+                CursorGlyphView(
+                    style: resolvedSettings.style,
+                    variant: resolvedSettings.variant,
+                    scale: resolvedSettings.size,
+                    alignsHotspot: true
+                )
                     .offset(x: point.x, y: point.y)
                     .allowsHitTesting(false)
             }
@@ -972,18 +978,6 @@ private struct CursorOverlayView: View {
             return
         }
         track = CursorTelemetryTrack(payload: payload)
-    }
-}
-
-private struct CursorGlyph: View {
-    var scale: Double
-
-    var body: some View {
-        Image(systemName: "cursorarrow")
-            .font(.system(size: max(12, 24 * scale), weight: .semibold))
-            .foregroundStyle(.white)
-            .shadow(color: .black.opacity(0.92), radius: 1.6, x: 0, y: 1)
-            .shadow(color: .black.opacity(0.45), radius: 6, x: 0, y: 3)
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/CursorOverlaySettingsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CursorOverlaySettingsTests.swift
@@ -1,0 +1,148 @@
+import CoreGraphics
+import XCTest
+@testable import OpenRecorderMac
+
+final class CursorOverlaySettingsTests: XCTestCase {
+    func testLegacyCursorSettingsDecodeDefaultStyleAndVariant() throws {
+        let data = """
+        {
+          "isVisible": true,
+          "loops": false,
+          "size": 1.5,
+          "smoothing": 0.4
+        }
+        """.data(using: .utf8)!
+
+        let settings = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
+
+        XCTAssertEqual(settings.style, .arrow)
+        XCTAssertEqual(settings.variant, .standard)
+        XCTAssertEqual(settings.size, 1.5)
+    }
+
+    func testCursorSettingsRoundTripStyleAndVariant() throws {
+        let settings = CursorOverlaySettings(
+            isVisible: true,
+            loops: true,
+            size: 8,
+            smoothing: 0.8,
+            style: .outlineArrow,
+            variant: .bold
+        )
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
+
+        XCTAssertEqual(decoded, settings)
+    }
+
+    func testLegacyColorVariantNamesMapToShapeVariants() throws {
+        let data = """
+        {
+          "isVisible": true,
+          "loops": false,
+          "size": 1,
+          "smoothing": 0.4,
+          "style": "handPointer",
+          "variant": "highContrast"
+        }
+        """.data(using: .utf8)!
+
+        let settings = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
+
+        XCTAssertEqual(settings.style, .handPointer)
+        XCTAssertEqual(settings.variant, .bold)
+    }
+
+    func testCursorSizeClampsWhenCreatedAndDecoded() throws {
+        let tooSmall = CursorOverlaySettings(isVisible: true, loops: false, size: 0.2, smoothing: 0.4)
+        XCTAssertEqual(tooSmall.size, 1)
+
+        let data = """
+        {
+          "isVisible": true,
+          "loops": false,
+          "size": 12,
+          "smoothing": 0.4,
+          "style": "arrow",
+          "variant": "dark"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
+
+        XCTAssertEqual(decoded.size, 8)
+        XCTAssertEqual(decoded.variant, .slim)
+    }
+
+    func testProjectVideoStateDecodesLegacyCursorOverlayDefaults() throws {
+        let data = """
+        {
+          "cursorOverlay": {
+            "isVisible": true,
+            "loops": true,
+            "size": 2,
+            "smoothing": 0.7
+          }
+        }
+        """.data(using: .utf8)!
+
+        let state = try JSONDecoder().decode(ProjectVideoEditorState.self, from: data)
+
+        XCTAssertEqual(state.cursorOverlay.style, .arrow)
+        XCTAssertEqual(state.cursorOverlay.variant, .standard)
+        XCTAssertEqual(state.cursorOverlay.size, 2)
+    }
+
+    func testCursorRendererHotspotsMatchStyleRules() {
+        let size: CGFloat = 24
+        let arrow = CursorPresetRenderer.drawing(style: .arrow, size: size)
+        let macOSBlack = CursorPresetRenderer.drawing(style: .macOSBlackArrow, size: size)
+        let outline = CursorPresetRenderer.drawing(style: .outlineArrow, size: size)
+        let hand = CursorPresetRenderer.drawing(style: .handPointer, size: size)
+        let iBeam = CursorPresetRenderer.drawing(style: .iBeam, size: size)
+        let dot = CursorPresetRenderer.drawing(style: .dotPointer, size: size)
+
+        XCTAssertEqual(arrow.hotspot.x, 0, accuracy: 0.001)
+        XCTAssertEqual(arrow.hotspot.y, 0, accuracy: 0.001)
+        XCTAssertEqual(macOSBlack.hotspot.x, 0, accuracy: 0.001)
+        XCTAssertEqual(macOSBlack.hotspot.y, 0, accuracy: 0.001)
+        XCTAssertEqual(outline.hotspot.x, 0, accuracy: 0.001)
+        XCTAssertEqual(outline.hotspot.y, 0, accuracy: 0.001)
+        XCTAssertEqual(hand.hotspot.x, size * 0.54, accuracy: 0.001)
+        XCTAssertEqual(hand.hotspot.y, size * 0.02, accuracy: 0.001)
+        XCTAssertEqual(iBeam.hotspot.x, size * 0.50, accuracy: 0.001)
+        XCTAssertEqual(iBeam.hotspot.y, size * 0.60, accuracy: 0.001)
+        XCTAssertEqual(dot.hotspot.x, size * 0.45, accuracy: 0.001)
+        XCTAssertEqual(dot.hotspot.y, size * 0.45, accuracy: 0.001)
+    }
+
+    func testCursorVariantsChangeShapeGeometryWithoutChangingPalette() {
+        let size: CGFloat = 24
+        let standardArrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .standard)
+        let slimArrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .slim)
+        let boldArrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .bold)
+        let softDot = CursorPresetRenderer.drawing(style: .dotPointer, size: size, variant: .soft)
+
+        XCTAssertLessThan(slimArrow.canvasSize.width, standardArrow.canvasSize.width)
+        XCTAssertGreaterThan(boldArrow.canvasSize.width, standardArrow.canvasSize.width)
+        XCTAssertEqual(CursorPresetRenderer.palette.fill.hexString, "#FFFFFF")
+        XCTAssertFalse(softDot.fillsShape)
+    }
+
+    func testMacOSBlackCursorStyleUsesArrowGeometryWithOwnPalette() {
+        let size: CGFloat = 24
+        let arrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .standard)
+        let macOSBlack = CursorPresetRenderer.drawing(style: .macOSBlackArrow, size: size, variant: .standard)
+        let slimMacOSBlack = CursorPresetRenderer.drawing(style: .macOSBlackArrow, size: size, variant: .slim)
+        let standardPalette = CursorPresetRenderer.palette(for: .macOSBlackArrow)
+
+        XCTAssertEqual(macOSBlack.canvasSize.width, arrow.canvasSize.width, accuracy: 0.001)
+        XCTAssertEqual(macOSBlack.canvasSize.height, arrow.canvasSize.height, accuracy: 0.001)
+        XCTAssertEqual(macOSBlack.hotspot.x, 0, accuracy: 0.001)
+        XCTAssertEqual(macOSBlack.hotspot.y, 0, accuracy: 0.001)
+        XCTAssertLessThan(slimMacOSBlack.canvasSize.width, macOSBlack.canvasSize.width)
+        XCTAssertEqual(standardPalette.fill.hexString, "#1F2023")
+        XCTAssertNotEqual(standardPalette.fill.hexString, CursorPresetRenderer.palette.fill.hexString)
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -107,7 +107,14 @@ final class ProjectEditorStateCodableTests: XCTestCase {
                 normalizedRect: CGRect(x: 0.1, y: 0.2, width: 0.7, height: 0.6),
                 sizing: .custom(width: 1280, height: 720)
             ),
-            cursorOverlay: CursorOverlaySettings(isVisible: true, loops: true, size: 1.5, smoothing: 0.8),
+            cursorOverlay: CursorOverlaySettings(
+                isVisible: true,
+                loops: true,
+                size: 1.5,
+                smoothing: 0.8,
+                style: .dotPointer,
+                variant: .soft
+            ),
             facecamSettings: defaultFacecamSettings(enabled: true)
         )
         let state = ProjectEditorState(timelineEdits: timeline, video: video)
@@ -116,6 +123,8 @@ final class ProjectEditorStateCodableTests: XCTestCase {
         let decoded = try JSONDecoder().decode(ProjectEditorState.self, from: data)
 
         XCTAssertEqual(decoded, state)
+        XCTAssertEqual(decoded.video?.cursorOverlay.style, .dotPointer)
+        XCTAssertEqual(decoded.video?.cursorOverlay.variant, .soft)
     }
 }
 


### PR DESCRIPTION
Summary: Adds editor-only cursor preset styles, shape variants, and 1x-8x sizing backed by a shared preview/export renderer. Includes macOS Black cursor style, project persistence/backward-compatible decoding, and renderer/hotspot tests.\n\nTests: swift test