### PR TITLE
Fix screenshot capturing wrong display after source picker selection

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -62,6 +62,11 @@ enum ScreencaptureRegionMapper {
         )
     }
 
+    static func regionArgument(forDisplayBounds bounds: CGRect) -> String? {
+        guard !bounds.isEmpty else { return nil }
+        return "-R\(Int(bounds.origin.x.rounded())),\(Int(bounds.origin.y.rounded())),\(Int(bounds.width.rounded())),\(Int(bounds.height.rounded()))"
+    }
+
     @MainActor
     private static func primaryDisplayFrame() -> CGRect {
         NSScreen.screens.first { screen in
@@ -483,6 +488,10 @@ final class CaptureController: ObservableObject {
     private func argumentsForSource(_ source: CaptureSource, interactiveAreaMode: String) -> [String] {
         switch source.kind {
         case .display:
+            if let displayID = source.displayID,
+               let regionArg = ScreencaptureRegionMapper.regionArgument(forDisplayBounds: CGDisplayBounds(displayID)) {
+                return [regionArg]
+            }
             return source.displayIndex.map { ["-D\($0)"] } ?? []
         case .window:
             return source.windowID.map { ["-l\($0)"] } ?? []

--- a/apps/macos/Tests/OpenRecorderMacTests/ScreencaptureRegionMapperTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreencaptureRegionMapperTests.swift
@@ -22,4 +22,25 @@ final class ScreencaptureRegionMapperTests: XCTestCase {
 
         XCTAssertEqual(mapped, CaptureArea(x: -1329, y: -803, width: 647, height: 422, displayID: 4))
     }
+
+    func testRegionArgumentForPrimaryDisplayBounds() {
+        let arg = ScreencaptureRegionMapper.regionArgument(
+            forDisplayBounds: CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        )
+
+        XCTAssertEqual(arg, "-R0,0,1920,1080")
+    }
+
+    func testRegionArgumentForDisplayAboveAndLeftOfPrimary() {
+        let arg = ScreencaptureRegionMapper.regionArgument(
+            forDisplayBounds: CGRect(x: -1920, y: -1080, width: 1920, height: 1080)
+        )
+
+        XCTAssertEqual(arg, "-R-1920,-1080,1920,1080")
+    }
+
+    func testRegionArgumentRejectsEmptyBounds() {
+        XCTAssertNil(ScreencaptureRegionMapper.regionArgument(forDisplayBounds: .zero))
+        XCTAssertNil(ScreencaptureRegionMapper.regionArgument(forDisplayBounds: .null))
+    }
 }


### PR DESCRIPTION
## Summary

- Screenshot capture passed `screencapture -D<displayIndex>` where `displayIndex` was the offset within `SCShareableContent.displays`. That order has no relation to screencapture's own positional numbering (`1 = main, 2 = secondary, ...`), so the source chosen in the picker could be captured from a different physical display.
- Recording was already migrated to match by stable `CGDirectDisplayID` in 7bfbed7, but the screencapture invocation was missed.
- Switched the `.display` branch of `argumentsForSource` to build `-R<x,y,w,h>` from `CGDisplayBounds(displayID)` — same Quartz global display-space coordinates that `screencapture -R` already accepts (also used for area captures), so no enumeration-order dependency remains. Falls back to the legacy `-D` flag only when no `displayID` is available.
- Extracted the conversion as `ScreencaptureRegionMapper.regionArgument(forDisplayBounds:)` and added regression tests covering the primary display, a display above-and-left of primary (negative coordinates), and empty/null bounds.

## Test plan

- [x] `swift test --filter ScreencaptureRegionMapperTests` — 5/5 pass
- [x] `swift test` — full suite 196/196 pass
- [ ] Manual: with multiple displays attached, open the Choose Source dialog, select the non-main display, take a screenshot, confirm the captured image matches the picked display
- [ ] Manual: repeat after rearranging displays in System Settings → Displays so SCShareableContent enumeration differs from screencapture's positional order
- [ ] Manual: with a single display, confirm screenshot still works (uses `-R` with main display bounds at `0,0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)