### PR TITLE
Prepare release v0.2.11

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.2.10",
-  "releaseName": "Open Recorder v0.2.10",
+  "tagName": "v0.2.11",
+  "releaseName": "Open Recorder v0.2.11",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Patch release bump from `v0.2.10` to `v0.2.11`
- Updates version in `apps/rust-service/Cargo.toml`, `apps/rust-service/Cargo.lock`, and `.github/release-plan.json`
- Landing page build verified passing

## Test plan
- [x] Landing page build passes (`pnpm --dir apps/landing build`)
- [x] Version files updated correctly via `scripts/prepare-release-pr.mjs --release-type patch`
- [ ] Native macOS tests (Swift + Cargo) run in CI on merge

https://claude.ai/code/session_01U1W9yfEXVmYfkToC3PU8m4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1W9yfEXVmYfkToC3PU8m4)_