### PR TITLE
Add Sparkle auto-updates and menu bar Check for Updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,34 @@ jobs:
           zsh scripts/notarize-macos-dmg.zsh release-upload/open-recorder-macos-universal.dmg
           cp release-upload/open-recorder-macos-universal.zip release-upload/open-recorder-macos.zip
 
+      - name: Sign universal update with Sparkle
+        shell: bash
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-upload
+          : > release-upload/appcast-signature.txt
+          if [ -z "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
+            echo "::warning::SPARKLE_ED_PRIVATE_KEY not set; skipping appcast signing"
+            exit 0
+          fi
+
+          ( cd apps/macos && swift package resolve )
+          sparkle_sign="$PWD/apps/macos/.build/artifacts/sparkle/Sparkle/bin/sign_update"
+          if [ ! -x "$sparkle_sign" ]; then
+            echo "::error::sign_update binary not found at $sparkle_sign"
+            exit 1
+          fi
+
+          key_file="$(mktemp)"
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s\n' "$SPARKLE_ED_PRIVATE_KEY" > "$key_file"
+
+          signature_line=$("$sparkle_sign" -f "$key_file" release-upload/open-recorder-macos.zip)
+          printf '%s\n' "$signature_line" > release-upload/appcast-signature.txt
+          echo "Generated signature: $signature_line"
+
       - name: Upload universal macOS artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -222,6 +250,7 @@ jobs:
             release-upload/open-recorder-macos-universal.zip
             release-upload/open-recorder-macos-universal.dmg
             release-upload/open-recorder-macos.zip
+            release-upload/appcast-signature.txt
           if-no-files-found: error
 
   publish-release:
@@ -233,6 +262,12 @@ jobs:
     if: needs.resolve-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -273,3 +308,47 @@ jobs:
           replacesArtifacts: true
           artifactErrorsFailBuild: true
           artifacts: release-upload/*
+
+      - name: Update Sparkle appcast
+        env:
+          TAG_NAME: ${{ needs.resolve-release.outputs.tag_name }}
+          RELEASE_NOTES: ${{ needs.resolve-release.outputs.release_notes }}
+        run: |
+          set -euo pipefail
+          signature_file="release-assets/macos-universal-release-assets/appcast-signature.txt"
+          if [ ! -s "$signature_file" ]; then
+            echo "::warning::No Sparkle signature available; skipping appcast update. Add SPARKLE_ED_PRIVATE_KEY secret to enable."
+            exit 0
+          fi
+
+          signature_line="$(cat "$signature_file")"
+          signature="$(printf '%s' "$signature_line" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
+          length="$(printf '%s' "$signature_line" | sed -n 's/.*length="\([^"]*\)".*/\1/p')"
+
+          if [ -z "$signature" ] || [ -z "$length" ]; then
+            echo "::error::Could not parse Sparkle signature line: $signature_line"
+            exit 1
+          fi
+
+          version="${TAG_NAME#v}"
+          url="https://github.com/imbhargav5/open-recorder/releases/download/${TAG_NAME}/open-recorder-macos.zip"
+          min_system_version="$(/usr/bin/python3 -c 'import plistlib; print(plistlib.load(open("apps/macos/Resources/Info.plist","rb")).get("LSMinimumSystemVersion","15.0"))')"
+
+          node scripts/update-appcast.mjs \
+            --version "$version" \
+            --url "$url" \
+            --signature "$signature" \
+            --length "$length" \
+            --min-system-version "$min_system_version" \
+            --release-notes "$RELEASE_NOTES"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/appcast.xml
+          if git diff --cached --quiet; then
+            echo "No appcast changes to commit"
+            exit 0
+          fi
+          git commit -m "Update appcast for ${TAG_NAME}"
+          git pull --rebase origin main
+          git push origin main

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing",
-  "version": "0.0.21",
+  "version": "0.2.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "44da0f3471f35afecf4bb16716b6b78e4c5c13c80d63770383082aa1e4a76194",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -8,9 +8,15 @@ let package = Package(
     platforms: [
         .macOS(.v15)
     ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.4")
+    ],
     targets: [
         .executableTarget(
             name: "OpenRecorderMac",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
             resources: [
                 .process("Resources/OpenRecorderMenuBarIcon.png"),
                 .copy("Resources/Wallpapers")

--- a/apps/macos/Resources/Info.plist
+++ b/apps/macos/Resources/Info.plist
@@ -36,9 +36,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.21</string>
+	<string>0.2.10</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.21</string>
+	<string>0.2.10</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>NSHighResolutionCapable</key>
@@ -48,6 +48,16 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Open Recorder uses the camera when you choose to include a facecam in a screen recording.</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/imbhargav5/open-recorder/main/docs/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>KAaM1QcHFlWNJ3wB3nablp4fpY7tHf14RupOsrzB7A0=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
+	<key>SUAllowsAutomaticUpdates</key>
 	<true/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -10,6 +10,7 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
     private let windowActions = AppWindowActions()
     private let statusItemController = OpenRecorderStatusItemController()
     private let hotKeyController = GlobalRecordingHotKeyController()
+    private let updateChecker = UpdateChecker.shared
     private var windowCommandCancellable: AnyCancellable?
 
     func attach(model: AppModel) {
@@ -422,6 +423,16 @@ private final class OpenRecorderStatusItemController: NSObject {
 
         menu.addItem(.separator())
 
+        let checkForUpdatesItem = NSMenuItem(
+            title: "Check for Updates…",
+            action: #selector(checkForUpdates),
+            keyEquivalent: ""
+        )
+        checkForUpdatesItem.target = self
+        menu.addItem(checkForUpdatesItem)
+
+        menu.addItem(.separator())
+
         let quitItem = NSMenuItem(title: "Quit Open Recorder", action: #selector(quit), keyEquivalent: "q")
         quitItem.keyEquivalentModifierMask = [.command]
         quitItem.target = self
@@ -461,6 +472,10 @@ private final class OpenRecorderStatusItemController: NSObject {
         model.showEditor(for: session)
         windowActions.openEditorSession(session)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func checkForUpdates() {
+        UpdateChecker.shared.checkForUpdates()
     }
 
     @objc private func quit() {

--- a/apps/macos/Sources/OpenRecorderMac/UpdateChecker.swift
+++ b/apps/macos/Sources/OpenRecorderMac/UpdateChecker.swift
@@ -1,0 +1,26 @@
+import AppKit
+import Sparkle
+
+@MainActor
+final class UpdateChecker: NSObject {
+    static let shared = UpdateChecker()
+
+    private let controller: SPUStandardUpdaterController
+
+    override init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        super.init()
+    }
+
+    var updater: SPUUpdater {
+        controller.updater
+    }
+
+    func checkForUpdates() {
+        controller.checkForUpdates(nil)
+    }
+}

--- a/scripts/package-macos-app.zsh
+++ b/scripts/package-macos-app.zsh
@@ -80,6 +80,22 @@ cp "$swift_binary" "$macos_dir/OpenRecorderMac"
 cp "$service_binary" "$macos_dir/open-recorder-service"
 cp "$info_plist" "$contents_dir/Info.plist"
 cp -R "$swift_resource_bundle" "$resources_dir/"
+
+sparkle_xcframework="$(find "$repo_root/apps/macos/.build/artifacts/sparkle" -type d -name "Sparkle.xcframework" -print 2>/dev/null | head -n 1 || true)"
+if [[ -z "$sparkle_xcframework" || ! -d "$sparkle_xcframework" ]]; then
+	print -u2 -- "Sparkle.xcframework not found under apps/macos/.build/artifacts/sparkle. Run 'cd apps/macos && swift package resolve' first."
+	exit 1
+fi
+
+sparkle_framework_source="$sparkle_xcframework/macos-arm64_x86_64/Sparkle.framework"
+if [[ ! -d "$sparkle_framework_source" ]]; then
+	print -u2 -- "Sparkle macOS framework slice not found at: $sparkle_framework_source"
+	exit 1
+fi
+
+mkdir -p "$contents_dir/Frameworks"
+rm -rf "$contents_dir/Frameworks/Sparkle.framework"
+ditto "$sparkle_framework_source" "$contents_dir/Frameworks/Sparkle.framework"
 set_plist_string "CFBundleName" "$app_name"
 set_plist_string "CFBundleDisplayName" "$app_name"
 set_plist_string "CFBundleIdentifier" "$bundle_identifier"

--- a/scripts/sign-macos-app.zsh
+++ b/scripts/sign-macos-app.zsh
@@ -102,6 +102,35 @@ sign_code() {
 	codesign --verify --strict "$target" >/dev/null
 }
 
+sign_sparkle_framework() {
+	local framework_root="$bundle_dir/Contents/Frameworks/Sparkle.framework"
+	[[ -d "$framework_root" ]] || return 0
+
+	local versioned="$framework_root/Versions/B"
+	if [[ ! -d "$versioned" ]]; then
+		versioned="$(find "$framework_root/Versions" -maxdepth 1 -mindepth 1 -type d ! -name 'Current' -print -quit 2>/dev/null)"
+	fi
+	[[ -n "$versioned" && -d "$versioned" ]] || return 0
+
+	local nested_targets=(
+		"$versioned/XPCServices/Installer.xpc/Contents/MacOS/Installer"
+		"$versioned/XPCServices/Installer.xpc"
+		"$versioned/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"
+		"$versioned/XPCServices/Downloader.xpc"
+		"$versioned/Updater.app/Contents/MacOS/Updater"
+		"$versioned/Updater.app"
+		"$versioned/Autoupdate"
+		"$framework_root"
+	)
+
+	local target
+	for target in "${nested_targets[@]}"; do
+		if [[ -e "$target" ]]; then
+			sign_code "$target" "${codesign_args[@]}"
+		fi
+	done
+}
+
 if command -v codesign >/dev/null 2>&1; then
 	identity_line="$(resolve_codesign_identity)"
 	sign_identity="${identity_line%%$'\t'*}"
@@ -118,6 +147,7 @@ if command -v codesign >/dev/null 2>&1; then
 		app_codesign_args+=(--entitlements "$entitlements_plist")
 	fi
 
+	sign_sparkle_framework
 	sign_code "$service_binary" "${codesign_args[@]}"
 	sign_code "$swift_binary" "${app_codesign_args[@]}"
 	sign_code "$bundle_dir" "${app_codesign_args[@]}"

--- a/scripts/update-appcast.mjs
+++ b/scripts/update-appcast.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+const appcastPath = resolve(repoRoot, "docs", "appcast.xml");
+
+function die(message) {
+	console.error(`Error: ${message}`);
+	process.exit(1);
+}
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (!arg.startsWith("--")) {
+			die(`Unexpected positional argument: ${arg}`);
+		}
+		const key = arg.slice(2);
+		const value = argv[++index];
+		if (value === undefined) {
+			die(`--${key} requires a value`);
+		}
+		args[key] = value;
+	}
+	return args;
+}
+
+function escapeXml(value) {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
+function buildItem({ version, url, signature, length, minSystemVersion, releaseNotes }) {
+	const pubDate = new Date().toUTCString();
+	const notesBlock = releaseNotes
+		? `            <description><![CDATA[\n${releaseNotes}\n]]></description>\n`
+		: "";
+	return `        <item>
+            <title>Version ${escapeXml(version)}</title>
+            <pubDate>${pubDate}</pubDate>
+            <sparkle:version>${escapeXml(version)}</sparkle:version>
+            <sparkle:shortVersionString>${escapeXml(version)}</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>${escapeXml(minSystemVersion)}</sparkle:minimumSystemVersion>
+${notesBlock}            <enclosure url="${escapeXml(url)}" sparkle:edSignature="${escapeXml(signature)}" length="${escapeXml(length)}" type="application/octet-stream"/>
+        </item>`;
+}
+
+function skeleton(item) {
+	return `<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+    <channel>
+        <title>Open Recorder Changelog</title>
+        <link>https://raw.githubusercontent.com/imbhargav5/open-recorder/main/docs/appcast.xml</link>
+        <description>Most recent changes with links to updates.</description>
+        <language>en</language>
+${item}
+    </channel>
+</rss>
+`;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const required = ["version", "url", "signature", "length", "min-system-version"];
+for (const key of required) {
+	if (!args[key]) {
+		die(`--${key} is required`);
+	}
+}
+
+const item = buildItem({
+	version: args.version,
+	url: args.url,
+	signature: args.signature,
+	length: args.length,
+	minSystemVersion: args["min-system-version"],
+	releaseNotes: args["release-notes"] || "",
+});
+
+mkdirSync(dirname(appcastPath), { recursive: true });
+
+if (!existsSync(appcastPath)) {
+	writeFileSync(appcastPath, skeleton(item));
+	console.log(`Created ${appcastPath} with entry for ${args.version}`);
+	process.exit(0);
+}
+
+let content = readFileSync(appcastPath, "utf8");
+
+const versionPattern = new RegExp(
+	`\\s*<item>[\\s\\S]*?<sparkle:version>${args.version.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}<\\/sparkle:version>[\\s\\S]*?<\\/item>`,
+	"g",
+);
+content = content.replace(versionPattern, "");
+
+if (!content.includes("</channel>")) {
+	die("appcast.xml is malformed: missing </channel>");
+}
+
+content = content.replace(/(\s*)<\/channel>/, `\n${item}$1</channel>`);
+writeFileSync(appcastPath, content);
+console.log(`Updated ${appcastPath} with entry for ${args.version}`);


### PR DESCRIPTION
## Summary
- Adds a **Check for Updates…** item to the menu bar status icon menu, backed by Sparkle 2.9.1's `SPUStandardUpdaterController` (so the same wrapper drives manual checks, the first-launch opt-in prompt, and scheduled background checks).
- Wires the release workflow to sign the universal zip with `sign_update` (EdDSA via `SPARKLE_ED_PRIVATE_KEY` secret) and commit `docs/appcast.xml` to main after each release. `SUFeedURL` resolves to `https://raw.githubusercontent.com/imbhargav5/open-recorder/main/docs/appcast.xml` — no GitHub Pages config needed.
- Bumps `Info.plist` (`CFBundleShortVersionString`/`CFBundleVersion`) and the landing package to **0.2.10** so Sparkle's version comparison lines up with the release tag the workflow produces.

## Implementation notes
- `Sparkle.framework` (universal `arm64_x86_64` slice) is copied from `.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/` into `Contents/Frameworks/` by `scripts/package-macos-app.zsh`.
- `scripts/sign-macos-app.zsh` signs Sparkle's nested executables depth-first (`Installer.xpc`, `Downloader.xpc`, `Updater.app`, `Autoupdate`) before sealing the framework, then the main app, with Hardened Runtime + timestamp. Verified locally with `codesign --verify --strict --deep`.
- All Sparkle-specific CI steps short-circuit with `::warning::` if `SPARKLE_ED_PRIVATE_KEY` is unset, so the existing release pipeline keeps working before the secret is configured.

## Setup required (one-time)
- [x] Generate Sparkle EdDSA keypair (private key in user Keychain, public key checked in)
- [x] Public key added to `Info.plist` (`SUPublicEDKey`)
- [ ] Add `SPARKLE_ED_PRIVATE_KEY` repository secret (private key from `generate_keys -x`)

## Test plan
- [x] `cd apps/macos && swift build` — succeeds
- [x] `cd apps/macos && swift test` — 193 tests pass
- [x] `zsh scripts/package-macos-app.zsh --dev` — produces a bundle that includes `Contents/Frameworks/Sparkle.framework`
- [x] `codesign --verify --strict --deep "release/Open Recorder Dev.app"` — valid on disk, satisfies designated requirement
- [x] `scripts/update-appcast.mjs` create / append / replace flows — smoke-tested
- [ ] Cut a fresh release tag in a test repo (or against main once the secret lands) and confirm Sparkle picks up the appcast entry from `raw.githubusercontent.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)