### PR TITLE
Prepare release v0.2.13

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.2.12",
-  "releaseName": "Open Recorder v0.2.12",
+  "tagName": "v0.2.13",
+  "releaseName": "Open Recorder v0.2.13",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Patch version bump from 0.2.12 to 0.2.13
- Updates `apps/rust-service/Cargo.toml`, `apps/rust-service/Cargo.lock`, and `.github/release-plan.json`
- Rust service build and all 4 tests pass with the new version

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (4/4 tests)
- [ ] macOS Swift build verification (requires macOS CI)

https://claude.ai/code/session_01XF5pZZbM3WCQHdeDxxwHb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF5pZZbM3WCQHdeDxxwHb1)_