### PR TITLE
[codex] Add setup command for dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: build-macos dev-macos package-macos package-macos-dev install-macos install-macos-dev run-macos run-macos-dev reset-macos-permissions reset-macos-dev-permissions test-macos clean-macos
+.PHONY: setup build-macos dev-macos package-macos package-macos-dev install-macos install-macos-dev run-macos run-macos-dev reset-macos-permissions reset-macos-dev-permissions test-macos clean-macos
 
 RUST_SERVICE := $(CURDIR)/apps/rust-service/target/debug/open-recorder-service
+
+setup:
+	pnpm install --frozen-lockfile
+	pnpm --dir apps/landing install --frozen-lockfile
+	cargo fetch --locked --manifest-path apps/rust-service/Cargo.toml
 
 build-macos:
 	cd apps/rust-service && CARGO_INCREMENTAL=0 cargo build

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Requirements:
 - Xcode command line tools with Swift 6.2+
 - Rust 1.93+
 
+Install locked JavaScript dependencies and prefetch Rust crates:
+
+```bash
+pnpm run setup
+```
+
 Build everything:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"license": "Apache-2.0",
 	"packageManager": "pnpm@10.17.1",
 	"scripts": {
+		"setup": "make setup",
 		"dev": "make dev-macos",
 		"dev:landing": "pnpm --dir apps/landing dev",
 		"build": "make build-macos",


### PR DESCRIPTION
## Summary

- Add a top-level `pnpm run setup` script backed by `make setup`.
- Install root and landing JavaScript dependencies with frozen lockfiles.
- Prefetch locked Rust service crates and document the setup step in the README.

## Validation

- `git diff --check`
- `pnpm run setup`
