### PR TITLE
Prepare release v0.2.18

### DIFF
--- a/.github/release-plan.json
+++ b/.github/release-plan.json
@@ -1,6 +1,6 @@
 {
-  "tagName": "v0.2.17",
-  "releaseName": "Open Recorder v0.2.17",
+  "tagName": "v0.2.18",
+  "releaseName": "Open Recorder v0.2.18",
   "releaseNotes": "",
   "makeLatest": true
 }

--- a/apps/rust-service/Cargo.lock
+++ b/apps/rust-service/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "open-recorder-service"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/rust-service/Cargo.toml
+++ b/apps/rust-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-recorder-service"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Release Summary
- Release type: patch
- Base version: 0.2.17 (apps/rust-service/Cargo.toml)
- Next version: 0.2.18
- Tag: v0.2.18
- Release title: Open Recorder v0.2.18
- Mark as latest: true

Merging this PR will trigger `.github/workflows/release.yml`, which builds the macOS Swift/Rust artifacts and publishes the GitHub release.

## Changes
- Bumped version in `apps/rust-service/Cargo.toml` from 0.2.17 to 0.2.18
- Updated `apps/rust-service/Cargo.lock` to match
- Updated `.github/release-plan.json` with v0.2.18 metadata

## Test plan
- [x] Rust service builds successfully (`cargo build`)
- [x] All 4 Rust tests pass (`cargo test`)

https://claude.ai/code/session_013qkipYzfrxdnQ2f6HjfxDX

---
_Generated by [Claude Code](https://claude.ai/code/session_013qkipYzfrxdnQ2f6HjfxDX)_