### PR TITLE
Sync macOS bundle version with releases

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -67,15 +67,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          changed_files=$(git diff --name-only -- apps/rust-service/Cargo.toml apps/rust-service/Cargo.lock .github/release-plan.json)
+          changed_files=$(git diff --name-only -- apps/rust-service/Cargo.toml apps/rust-service/Cargo.lock apps/macos/Resources/Info.plist .github/release-plan.json)
           changed_file_count=$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')
-          if [ "$changed_file_count" -lt 2 ]; then
-            echo "Expected release preparation to update native version files and release plan." >&2
+          if [ "$changed_file_count" -lt 4 ]; then
+            echo "Expected release preparation to update native version files, macOS bundle version, and release plan." >&2
             git diff --name-only >&2
             exit 1
           fi
 
-          unexpected=$(git diff --name-only -- . ':(exclude)apps/rust-service/Cargo.toml' ':(exclude)apps/rust-service/Cargo.lock' ':(exclude).github/release-plan.json')
+          unexpected=$(git diff --name-only -- . ':(exclude)apps/rust-service/Cargo.toml' ':(exclude)apps/rust-service/Cargo.lock' ':(exclude)apps/macos/Resources/Info.plist' ':(exclude).github/release-plan.json')
           if [ -n "$unexpected" ]; then
             echo "Unexpected files changed during release preparation:" >&2
             echo "$unexpected" >&2
@@ -104,3 +104,4 @@ jobs:
             .github/release-plan.json
             apps/rust-service/Cargo.toml
             apps/rust-service/Cargo.lock
+            apps/macos/Resources/Info.plist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - .github/release-plan.json
       - apps/rust-service/Cargo.toml
       - apps/rust-service/Cargo.lock
+      - apps/macos/Resources/Info.plist
   workflow_dispatch:
     inputs:
       tag_name:
@@ -104,6 +105,21 @@ jobs:
       - name: Package app bundle
         run: make package-macos
 
+      - name: Verify packaged bundle version
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="${{ needs.resolve-release.outputs.tag_name }}"
+          expected="${expected#v}"
+          plist="release/Open Recorder.app/Contents/Info.plist"
+          short_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$plist")
+          bundle_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$plist")
+          if [ "$short_version" != "$expected" ] || [ "$bundle_version" != "$expected" ]; then
+            echo "Expected packaged bundle version ${expected}, got CFBundleShortVersionString=${short_version} CFBundleVersion=${bundle_version}" >&2
+            exit 1
+          fi
+          echo "Packaged bundle version verified: ${short_version}"
+
       - name: Verify Developer ID signature
         run: zsh scripts/verify-macos-production-signature.zsh "release/Open Recorder.app"
 
@@ -189,6 +205,8 @@ jobs:
           app="universal-work/Open Recorder.app"
           arm_app="universal-work/arm64/Open Recorder.app"
           x64_app="universal-work/x64/Open Recorder.app"
+          expected_version="${{ needs.resolve-release.outputs.tag_name }}"
+          expected_version="${expected_version#v}"
 
           for binary in "OpenRecorderMac" "open-recorder-service"; do
             lipo -create \
@@ -204,6 +222,14 @@ jobs:
               exit 1
             fi
           done
+
+          short_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$app/Contents/Info.plist")
+          bundle_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$app/Contents/Info.plist")
+          if [ "$short_version" != "$expected_version" ] || [ "$bundle_version" != "$expected_version" ]; then
+            echo "Expected universal bundle version ${expected_version}, got CFBundleShortVersionString=${short_version} CFBundleVersion=${bundle_version}" >&2
+            exit 1
+          fi
+          echo "Universal bundle version verified: ${short_version}"
 
           find "$app" \( -name '._*' -o -name '.__CodeSignature' \) -delete
           zsh scripts/sign-macos-production-app.zsh "$app"

--- a/apps/macos/Resources/Info.plist
+++ b/apps/macos/Resources/Info.plist
@@ -36,9 +36,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.10</string>
+	<string>0.2.21</string>
 	<key>CFBundleVersion</key>
-	<string>0.2.10</string>
+	<string>0.2.21</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>NSHighResolutionCapable</key>

--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+
+final class ReleaseVersionTests: XCTestCase {
+    func testInfoPlistVersionsMatchRustServiceVersion() throws {
+        let plist = try loadInfoPlist()
+        let cargoVersion = try loadRustServiceVersion()
+
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, cargoVersion)
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, cargoVersion)
+    }
+
+    private func loadInfoPlist() throws -> [String: Any] {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Resources/Info.plist")
+        let data = try Data(contentsOf: url)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+
+        guard let dictionary = plist as? [String: Any] else {
+            XCTFail("Resources/Info.plist should be a dictionary")
+            return [:]
+        }
+
+        return dictionary
+    }
+
+    private func loadRustServiceVersion() throws -> String {
+        let cargoTomlURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("../rust-service/Cargo.toml")
+        let cargoToml = try String(contentsOf: cargoTomlURL, encoding: .utf8)
+        let regex = try NSRegularExpression(pattern: #"(?m)^version\s*=\s*"(\d+\.\d+\.\d+)""#)
+        let range = NSRange(cargoToml.startIndex..<cargoToml.endIndex, in: cargoToml)
+
+        guard let match = regex.firstMatch(in: cargoToml, range: range),
+              let versionRange = Range(match.range(at: 1), in: cargoToml) else {
+            XCTFail("apps/rust-service/Cargo.toml should declare a semantic version")
+            return ""
+        }
+
+        return String(cargoToml[versionRange])
+    }
+}

--- a/scripts/prepare-production-release-pr.mjs
+++ b/scripts/prepare-production-release-pr.mjs
@@ -11,6 +11,7 @@ const repoRoot = resolve(scriptDir, "..");
 const rustServiceRoot = resolve(repoRoot, "apps", "rust-service");
 const rustServiceCargoTomlPath = resolve(rustServiceRoot, "Cargo.toml");
 const rustServiceCargoLockPath = resolve(rustServiceRoot, "Cargo.lock");
+const macosInfoPlistPath = resolve(repoRoot, "apps", "macos", "Resources", "Info.plist");
 const releasePlanPath = resolve(repoRoot, ".github", "release-plan.json");
 
 process.chdir(repoRoot);
@@ -162,11 +163,47 @@ function updateCargoLockVersion(filePath, nextVersion) {
 	writeFileSync(filePath, updated);
 }
 
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function validatePlist(filePath) {
+	const result = spawnSync("plutil", ["-lint", filePath], {
+		cwd: repoRoot,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	if (result.status === 0) {
+		return;
+	}
+
+	const errorText = result.stderr.trim() || result.stdout.trim() || `plutil exited with status ${result.status}`;
+	die(errorText);
+}
+
+function updatePlistStringValue(content, key, value) {
+	const pattern = new RegExp(`(<key>${escapeRegExp(key)}</key>\\s*<string>)([^<]*)(</string>)`);
+	if (!pattern.test(content)) {
+		die(`Could not find ${key} string value in ${macosInfoPlistPath}`);
+	}
+	return content.replace(pattern, `$1${value}$3`);
+}
+
+function updateMacOSBundleVersion(filePath, nextVersion) {
+	let updated = readFileSync(filePath, "utf8");
+	updated = updatePlistStringValue(updated, "CFBundleShortVersionString", nextVersion);
+	updated = updatePlistStringValue(updated, "CFBundleVersion", nextVersion);
+	writeFileSync(filePath, updated);
+	validatePlist(filePath);
+}
+
 function syncVersionFiles(nextVersion) {
 	updateCargoVersion(rustServiceCargoTomlPath, nextVersion);
 	if (existsSync(rustServiceCargoLockPath)) {
 		updateCargoLockVersion(rustServiceCargoLockPath, nextVersion);
 	}
+	updateMacOSBundleVersion(macosInfoPlistPath, nextVersion);
 }
 
 function determineBaseVersion(packageVersion, latestTagVersion) {


### PR DESCRIPTION
## Summary
- Update the macOS bundle Info.plist version fields to match the current GitHub release version, 0.2.21.
- Make release preparation bump the macOS bundle version alongside the Rust service version and release plan.
- Harden the release workflows so the plist participates in release PRs/triggers and packaged app bundles are checked against the resolved release tag.
- Add a macOS test that fails if Info.plist drifts from apps/rust-service/Cargo.toml again.

## Root Cause
The release workflow used the Rust service Cargo version and release plan as the release source of truth, but packaging copied apps/macos/Resources/Info.plist directly into the app bundle. Because release prep did not update CFBundleShortVersionString or CFBundleVersion, the About dialog could stay stale even after GitHub releases advanced.

## Validation
- node scripts/resolve-production-release-context.mjs --event-name push --before HEAD
- Release-prep dry run in /tmp/open-recorder-release-prep-test verified the next patch updates only release-plan, Cargo.toml, Cargo.lock, and Info.plist, with both plist version fields becoming 0.2.22.
- make test-macos
- cd apps/macos && swift test --filter ReleaseVersionTests
- make package-macos
- Verified release/Open Recorder.app/Contents/Info.plist has CFBundleShortVersionString=0.2.21 and CFBundleVersion=0.2.21
- node --check scripts/prepare-production-release-pr.mjs
- git diff --check
