### PR TITLE
[codex] Update landing docs and source links

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,5 +1,8 @@
 import Image from "next/image";
 
+const docsUrl = "http://docs.openrecorder.xyz/";
+const sourceUrl = "https://github.com/imbhargav5/open-recorder";
+
 const proofPoints = [
   ["Native macOS", "Swift capture UI with system privacy flows"],
   ["Local-first", "Recordings stay under your Movies folder"],
@@ -63,6 +66,21 @@ const architectureNotes = [
   },
 ];
 
+function GitHubIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      focusable="false"
+    >
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.09 3.29 9.4 7.86 10.92.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.69 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.47.11-3.05 0 0 .97-.31 3.17 1.18.92-.26 1.9-.38 2.88-.39.98 0 1.96.13 2.88.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.42-2.7 5.39-5.27 5.68.42.36.79 1.07.79 2.16 0 1.56-.01 2.82-.01 3.2 0 .31.21.68.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+    </svg>
+  );
+}
+
 export default function Home() {
   return (
     <main>
@@ -83,7 +101,9 @@ export default function Home() {
             <a href="#features">Features</a>
             <a href="#workflow">Workflow</a>
             <a href="#architecture">Architecture</a>
-            <a href="https://github.com/imbhargav5/open-recorder">GitHub</a>
+            <a href={docsUrl} target="_blank" rel="noreferrer">
+              <span className="primary-action">Docs</span>
+            </a>
           </div>
         </div>
       </nav>
@@ -98,11 +118,11 @@ export default function Home() {
             pipeline.
           </p>
           <div className="hero-actions">
-            <a className="primary-action" href="https://github.com/imbhargav5/open-recorder">
-              Get the source
+            <a className="primary-action" href={docsUrl} target="_blank" rel="noreferrer">
+              Docs
             </a>
-            <a className="secondary-action" href="#features">
-              See the workflow
+            <a className="secondary-action" href={sourceUrl}>
+              <GitHubIcon /> Source
             </a>
           </div>
 


### PR DESCRIPTION
## Summary
- Add a primary Docs button as the rightmost navbar action linking to `http://docs.openrecorder.xyz/` in a new tab.
- Change the hero primary action to Docs and the secondary action to Source with a GitHub icon.
- Reuse existing landing page button classes without adding new CSS.

## Validation
- `pnpm lint:landing`
- `pnpm build:landing` (passes with the existing Next.js workspace-root warning)