### PR TITLE
Fix centered video inset layout

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -54,24 +54,7 @@ enum VideoInsetGeometry {
             return VideoInsetLayout(frameRect: .zero, contentRect: .zero)
         }
 
-        let resolvedAmount = max(0, min(amountRatio, 0.95))
-        guard resolvedAmount > 0 else {
-            return VideoInsetLayout(frameRect: frameRect, contentRect: contentRect)
-        }
-
-        let targetInset = min(frameRect.width, frameRect.height) * resolvedAmount / 2
-        let leftInset = min(targetInset, max(0, contentRect.minX - frameRect.minX))
-        let rightInset = min(targetInset, max(0, frameRect.maxX - contentRect.maxX))
-        let topInset = min(targetInset, max(0, contentRect.minY - frameRect.minY))
-        let bottomInset = min(targetInset, max(0, frameRect.maxY - contentRect.maxY))
-        let insetFrameRect = CGRect(
-            x: contentRect.minX - leftInset,
-            y: contentRect.minY - topInset,
-            width: contentRect.width + leftInset + rightInset,
-            height: contentRect.height + topInset + bottomInset
-        )
-
-        return VideoInsetLayout(frameRect: insetFrameRect, contentRect: contentRect)
+        return VideoInsetLayout(frameRect: frameRect, contentRect: contentRect)
     }
 
     static func contentRect(in frameRect: CGRect, amountRatio: Double, balance: VideoInsetBalance) -> CGRect {

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -141,17 +141,43 @@ final class VideoPreviewLayoutTests: XCTestCase {
         XCTAssertEqual(rect.height, 75, accuracy: 0.001)
     }
 
-    func testInsetLayoutUsesEqualCenteredInsetOnAllEdges() {
+    func testInsetLayoutKeepsInsetFrameAtRecordingFrame() {
+        let frameRect = CGRect(x: 8, y: 12, width: 200, height: 100)
+        let layout = VideoInsetGeometry.layout(
+            in: frameRect,
+            amountRatio: 0.25,
+            balance: .centered
+        )
+
+        XCTAssertEqual(layout.frameRect, frameRect)
+    }
+
+    func testInsetLayoutUsesAspectAwareCenteredInsets() {
         let layout = VideoInsetGeometry.layout(
             in: CGRect(x: 0, y: 0, width: 200, height: 100),
             amountRatio: 0.25,
             balance: .centered
         )
 
-        XCTAssertEqual(layout.contentRect.minX - layout.frameRect.minX, 12.5, accuracy: 0.001)
-        XCTAssertEqual(layout.frameRect.maxX - layout.contentRect.maxX, 12.5, accuracy: 0.001)
+        XCTAssertEqual(layout.contentRect.width, 150, accuracy: 0.001)
+        XCTAssertEqual(layout.contentRect.height, 75, accuracy: 0.001)
+        XCTAssertEqual(layout.contentRect.minX - layout.frameRect.minX, 25, accuracy: 0.001)
+        XCTAssertEqual(layout.frameRect.maxX - layout.contentRect.maxX, 25, accuracy: 0.001)
         XCTAssertEqual(layout.contentRect.minY - layout.frameRect.minY, 12.5, accuracy: 0.001)
         XCTAssertEqual(layout.frameRect.maxY - layout.contentRect.maxY, 12.5, accuracy: 0.001)
+    }
+
+    func testCenteredInsetBalancesOpposingEdgesForTallFrame() {
+        let layout = VideoInsetGeometry.layout(
+            in: CGRect(x: 0, y: 0, width: 100, height: 200),
+            amountRatio: 0.25,
+            balance: .centered
+        )
+
+        XCTAssertEqual(layout.contentRect.minX - layout.frameRect.minX, layout.frameRect.maxX - layout.contentRect.maxX, accuracy: 0.001)
+        XCTAssertEqual(layout.contentRect.minY - layout.frameRect.minY, layout.frameRect.maxY - layout.contentRect.maxY, accuracy: 0.001)
+        XCTAssertEqual(layout.contentRect.midX, layout.frameRect.midX, accuracy: 0.001)
+        XCTAssertEqual(layout.contentRect.midY, layout.frameRect.midY, accuracy: 0.001)
     }
 
     func testInsetGeometryClampsOutOfRangeBalance() {


### PR DESCRIPTION
## Summary
- keep video inset fill anchored to the full recording frame
- preserve centered content positioning as inset amount increases
- update inset geometry tests for aspect-aware centered spacing

## Tests
- swift test --package-path apps/macos --filter VideoPreviewLayoutTests

Note: full `swift test --package-path apps/macos` was attempted but hung in `xctest` with no test output, matching the earlier local behavior.