### PR TITLE
Fix Rust service pipe deadlock

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
@@ -41,6 +41,10 @@ struct RustServiceClient: Sendable {
         }
     }
 
+    init(executableURL: URL?) {
+        self.executableURL = executableURL
+    }
+
     var isAvailable: Bool {
         guard let executableURL else { return false }
         return FileManager.default.isExecutableFile(atPath: executableURL.path)
@@ -82,10 +86,14 @@ struct RustServiceClient: Sendable {
         process.standardError = errorPipe
 
         try process.run()
+        let outputReader = PipeDataReader(pipe: outputPipe, label: "dev.openrecorder.service.stdout")
+        let errorReader = PipeDataReader(pipe: errorPipe, label: "dev.openrecorder.service.stderr")
+        outputReader.start()
+        errorReader.start()
         process.waitUntilExit()
 
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let outputData = outputReader.waitForData()
+        let errorData = errorReader.waitForData()
 
         guard process.terminationStatus == 0 else {
             let message = String(data: errorData, encoding: .utf8)?
@@ -115,5 +123,36 @@ struct RustServiceClient: Sendable {
 
         return candidates.first { fileManager.isExecutableFile(atPath: $0.standardizedFileURL.path) }?
             .standardizedFileURL
+    }
+}
+
+private final class PipeDataReader: @unchecked Sendable {
+    private let fileHandle: FileHandle
+    private let queue: DispatchQueue
+    private let group = DispatchGroup()
+    private let lock = NSLock()
+    private var data = Data()
+
+    init(pipe: Pipe, label: String) {
+        fileHandle = pipe.fileHandleForReading
+        queue = DispatchQueue(label: label)
+    }
+
+    func start() {
+        group.enter()
+        queue.async { [self] in
+            let readData = fileHandle.readDataToEndOfFile()
+            lock.lock()
+            data = readData
+            lock.unlock()
+            group.leave()
+        }
+    }
+
+    func waitForData() -> Data {
+        group.wait()
+        lock.lock()
+        defer { lock.unlock() }
+        return data
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+@testable import OpenRecorderMac
+
+final class RustServiceClientTests: XCTestCase {
+    func testLargeServiceResponseDoesNotDeadlockWhenStdoutExceedsPipeBuffer() throws {
+        let serviceURL = try makeServiceScript(
+            name: "large-response-service",
+            body: """
+            #!/bin/sh
+            printf '{"ok":true,"result":"'
+            head -c 70000 /dev/zero | tr '\\0' x
+            printf '"}\\n'
+            """
+        )
+        let client = RustServiceClient(executableURL: serviceURL)
+        let completed = expectation(description: "service call completes")
+        let result = LockedBox<Result<String, Error>>()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            result.set(Result { try client.call("listProjects", as: String.self) })
+            completed.fulfill()
+        }
+
+        let waitResult = XCTWaiter.wait(for: [completed], timeout: 5)
+        guard waitResult == .completed else {
+            terminateServiceScript(at: serviceURL)
+            XCTFail("RustServiceClient deadlocked on a response larger than the stdout pipe buffer.")
+            return
+        }
+
+        let payload = try XCTUnwrap(result.get()).get()
+        XCTAssertEqual(payload.count, 70_000)
+    }
+
+    private func makeServiceScript(name: String, body: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenRecorderMacTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let scriptURL = directory.appendingPathComponent(name)
+        try body.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return scriptURL
+    }
+
+    private func terminateServiceScript(at url: URL) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+        process.arguments = ["-f", url.path]
+        try? process.run()
+        process.waitUntilExit()
+    }
+}
+
+private final class LockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value?
+
+    func set(_ value: Value) {
+        lock.lock()
+        storage = value
+        lock.unlock()
+    }
+
+    func get() -> Value? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}


### PR DESCRIPTION
## Summary
- drain Rust service stdout/stderr concurrently while the helper process is running
- add a regression test covering service responses larger than the stdout pipe buffer

## Validation
- swift test --package-path apps/macos --filter RustServiceClientTests
- swift test --package-path apps/macos