### PR TITLE
[codex] Apply full-stage zoom and waveform updates

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
@@ -187,6 +187,20 @@ enum TimelineWaveformDownsampler {
     }
 }
 
+struct TimelineAudioWaveform: Equatable {
+    var samples: [Double]
+
+    var isAvailable: Bool {
+        !samples.isEmpty
+    }
+
+    static let none = TimelineAudioWaveform(samples: [])
+
+    static func available(samples: [Double]) -> TimelineAudioWaveform {
+        TimelineAudioWaveform(samples: samples.map { min(max($0, 0), 1) })
+    }
+}
+
 enum TimelineAudioWaveformLoader {
     static let defaultSampleCount = 180
 
@@ -194,23 +208,27 @@ enum TimelineAudioWaveformLoader {
         TimelineWaveformDownsampler.quietSamples(targetCount: targetCount)
     }
 
-    static func loadSamples(from url: URL, targetCount: Int = defaultSampleCount) async -> [Double] {
-        guard targetCount > 0 else { return [] }
+    static func loadWaveform(from url: URL, targetCount: Int = defaultSampleCount) async -> TimelineAudioWaveform {
+        guard targetCount > 0 else { return .none }
 
         return await Task.detached(priority: .utility) {
             do {
-                return try await readSamples(from: url, targetCount: targetCount)
+                return try await readWaveform(from: url, targetCount: targetCount)
             } catch {
-                return quietSamples(targetCount: targetCount)
+                return .none
             }
         }.value
     }
 
-    private static func readSamples(from url: URL, targetCount: Int) async throws -> [Double] {
+    static func loadSamples(from url: URL, targetCount: Int = defaultSampleCount) async -> [Double] {
+        await loadWaveform(from: url, targetCount: targetCount).samples
+    }
+
+    private static func readWaveform(from url: URL, targetCount: Int) async throws -> TimelineAudioWaveform {
         let asset = AVURLAsset(url: url)
         let audioTracks = try await asset.loadTracks(withMediaType: .audio)
         guard let audioTrack = audioTracks.first else {
-            return quietSamples(targetCount: targetCount)
+            return .none
         }
 
         let format = try await audioFormat(for: audioTrack)
@@ -266,7 +284,7 @@ enum TimelineAudioWaveformLoader {
             throw reader.error ?? TimelineAudioWaveformReaderError.readerFailed
         }
 
-        return accumulator.samples()
+        return .available(samples: accumulator.samples())
     }
 
     private static func audioFormat(for track: AVAssetTrack) async throws -> AudioTrackFormat {

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -517,7 +517,7 @@ struct TimelineClipRow: View {
     var selectedClipIndex: Int?
     var seek: (Double) -> Void
     var edits: TimelineEditDriver
-    @State private var waveformSamples = TimelineAudioWaveformLoader.quietSamples()
+    @State private var waveformSamples: [Double]?
 
     var body: some View {
         GeometryReader { proxy in
@@ -570,7 +570,15 @@ struct TimelineClipRow: View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
             .fill(Theme.timelineClip.opacity(isSelected ? 0.95 : 1))
             .overlay { RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(isSelected ? Theme.timelineHandle.opacity(0.95) : Theme.timelineClipBorder, lineWidth: isSelected ? 2 : 1) }
-            .overlay(alignment: .bottom) { TimelineWaveformPreview(samples: waveformSamples).frame(height: 23).padding(.horizontal, 14).padding(.bottom, 4).allowsHitTesting(false) }
+            .overlay(alignment: .bottom) {
+                if let waveformSamples, !waveformSamples.isEmpty {
+                    TimelineWaveformPreview(samples: waveformSamples)
+                        .frame(height: 24)
+                        .padding(.horizontal, 14)
+                        .padding(.bottom, 4)
+                        .allowsHitTesting(false)
+                }
+            }
             .overlay(alignment: .center) {
                 if width > 82 {
                     VStack(spacing: 2) {
@@ -619,11 +627,11 @@ struct TimelineClipRow: View {
     }
 
     private func loadWaveform() async {
-        guard let videoURL else { waveformSamples = TimelineAudioWaveformLoader.quietSamples(); return }
-        waveformSamples = TimelineAudioWaveformLoader.quietSamples()
-        let samples = await TimelineAudioWaveformLoader.loadSamples(from: videoURL)
+        guard let videoURL else { waveformSamples = nil; return }
+        waveformSamples = nil
+        let waveform = await TimelineAudioWaveformLoader.loadWaveform(from: videoURL)
         guard !Task.isCancelled else { return }
-        waveformSamples = samples
+        waveformSamples = waveform.isAvailable ? waveform.samples : nil
     }
 }
 
@@ -643,21 +651,56 @@ struct TimelineWaveformPreview: View {
 
     var body: some View {
         Canvas { context, size in
-            let levels = samples.isEmpty ? TimelineAudioWaveformLoader.quietSamples() : samples
+            let levels = TimelineWaveformBarRenderer.resampledLevels(from: samples, width: size.width)
             guard !levels.isEmpty, size.width > 0, size.height > 0 else { return }
-            let step = size.width / CGFloat(max(levels.count - 1, 1))
-            var fillPath = Path(); var strokePath = Path()
-            fillPath.move(to: CGPoint(x: 0, y: size.height))
+
+            let spacing: CGFloat = size.width < 140 ? 1.6 : 2
+            let barWidth = max(1.5, (size.width - spacing * CGFloat(levels.count - 1)) / CGFloat(levels.count))
+            let maxBarHeight = max(1, size.height - 1)
+
             for (index, sample) in levels.enumerated() {
-                let x = CGFloat(index) * step
-                let boostedLevel = CGFloat(sqrt(max(0.0, min(sample, 1.0))))
-                let height = max(2, boostedLevel * (size.height - 2))
-                let point = CGPoint(x: x, y: size.height - height)
-                if index == 0 { fillPath.addLine(to: point); strokePath.move(to: point) } else { fillPath.addLine(to: point); strokePath.addLine(to: point) }
+                let level = CGFloat(sqrt(max(0, min(sample, 1))))
+                let barHeight = max(3, level * maxBarHeight)
+                let x = CGFloat(index) * (barWidth + spacing)
+                let y = size.height - barHeight
+                let rect = CGRect(x: x, y: y, width: barWidth, height: barHeight)
+                let barPath = RoundedRectangle(cornerRadius: barWidth / 2, style: .continuous).path(in: rect)
+                let sheenRect = CGRect(x: x, y: y, width: max(1, barWidth * 0.38), height: barHeight)
+                let sheenPath = RoundedRectangle(cornerRadius: barWidth / 2, style: .continuous).path(in: sheenRect)
+
+                context.fill(
+                    barPath,
+                    with: .linearGradient(
+                        Gradient(colors: [
+                            Color.white.opacity(0.86),
+                            Theme.timelineHandle.opacity(0.70),
+                            Theme.timelineClipBorder.opacity(0.50)
+                        ]),
+                        startPoint: CGPoint(x: rect.midX, y: rect.minY),
+                        endPoint: CGPoint(x: rect.midX, y: rect.maxY)
+                    )
+                )
+                context.fill(sheenPath, with: .color(Color.white.opacity(0.16)))
             }
-            fillPath.addLine(to: CGPoint(x: size.width, y: size.height)); fillPath.closeSubpath()
-            context.fill(fillPath, with: .color(Theme.borderStrong))
-            context.stroke(strokePath, with: .color(Color.white.opacity(0.24)), lineWidth: 1)
+        }
+    }
+}
+
+enum TimelineWaveformBarRenderer {
+    static func resampledLevels(from samples: [Double], width: CGFloat) -> [Double] {
+        guard width > 0, !samples.isEmpty else { return [] }
+
+        let targetCount = max(1, min(samples.count, Int(width / 4.5)))
+        guard targetCount < samples.count else {
+            return samples.map { min(max($0, 0), 1) }
+        }
+
+        return (0..<targetCount).map { bucket in
+            let start = Int((Double(bucket) / Double(targetCount)) * Double(samples.count))
+            let end = max(start + 1, Int((Double(bucket + 1) / Double(targetCount)) * Double(samples.count)))
+            return samples[start..<min(end, samples.count)].reduce(0) { partial, sample in
+                max(partial, min(max(sample, 0), 1))
+            }
         }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -191,6 +191,17 @@ struct VideoPreviewPanel: View {
                 in: proxy.size,
                 paddingValue: padding
             )
+            let zoomEffect = timelineEdits.snapshot.activeZoomEffect(at: playback.currentTime)
+            let zoomScale = CGFloat(zoomEffect?.depth ?? 1)
+            let zoomAnchor = PreviewStageLayout.fullStageZoomAnchor(
+                effect: zoomEffect,
+                stageSize: proxy.size,
+                recordingFrame: recordingFrame,
+                sourceSize: playback.naturalVideoSize,
+                cropSelection: cropSelection,
+                inset: inset,
+                insetBalance: insetBalance
+            )
 
             ZStack(alignment: .topLeading) {
                 BackgroundFillView(style: background)
@@ -226,6 +237,8 @@ struct VideoPreviewPanel: View {
                 )
                 .offset(x: recordingFrame.minX, y: recordingFrame.minY)
             }
+            .scaleEffect(zoomScale, anchor: zoomAnchor)
+            .animation(.easeInOut(duration: 0.18), value: zoomScale)
             .frame(width: proxy.size.width, height: proxy.size.height)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -392,6 +405,60 @@ enum PreviewStageLayout {
         let hasVisibleInset = VideoInsetGeometry.amountRatio(fromValue: inset.rounded()) > 0 && insetOpacity > 0
         return hasVisibleBackground || hasVisibleInset ? .clear : .black
     }
+
+    static func fullStageZoomAnchor(
+        effect: TimelineZoomEffect?,
+        stageSize: CGSize,
+        recordingFrame: CGRect,
+        sourceSize: CGSize,
+        cropSelection: VideoCropSelection,
+        inset: Double,
+        insetBalance: VideoInsetBalance
+    ) -> UnitPoint {
+        guard let effect,
+              stageSize.width.isFinite,
+              stageSize.height.isFinite,
+              stageSize.width > 0,
+              stageSize.height > 0,
+              recordingFrame.width.isFinite,
+              recordingFrame.height.isFinite,
+              recordingFrame.width > 0,
+              recordingFrame.height > 0 else {
+            return .center
+        }
+
+        let safeSourceSize = VideoCropSelection.safeSourceSize(sourceSize)
+        let cropRect = cropSelection.pixelRect(in: safeSourceSize)
+        guard cropRect.width > 0, cropRect.height > 0 else { return .center }
+
+        let insetLayout = VideoInsetGeometry.layout(
+            in: CGRect(origin: .zero, size: recordingFrame.size),
+            amountRatio: VideoInsetGeometry.amountRatio(fromValue: inset.rounded()),
+            balance: insetBalance
+        )
+        let contentRect = insetLayout.contentRect
+        guard contentRect.width > 0, contentRect.height > 0 else { return .center }
+
+        let scale = min(
+            contentRect.width / max(cropRect.width, 1),
+            contentRect.height / max(cropRect.height, 1)
+        )
+        let placedCropRect = CGRect(
+            x: recordingFrame.minX + contentRect.minX + (contentRect.width - cropRect.width * scale) / 2,
+            y: recordingFrame.minY + contentRect.minY + (contentRect.height - cropRect.height * scale) / 2,
+            width: cropRect.width * scale,
+            height: cropRect.height * scale
+        )
+        let focusPoint = CGPoint(
+            x: placedCropRect.minX + (safeSourceSize.width * CGFloat(effect.focusX) - cropRect.minX) * scale,
+            y: placedCropRect.minY + (safeSourceSize.height * CGFloat(effect.focusY) - cropRect.minY) * scale
+        )
+
+        return UnitPoint(
+            x: min(max(focusPoint.x / stageSize.width, 0), 1),
+            y: min(max(focusPoint.y / stageSize.height, 0), 1)
+        )
+    }
 }
 
 private struct AspectRatioFitContainer<Content: View, Overlay: View>: View {
@@ -497,8 +564,6 @@ struct PlaybackPreview: View {
                     )
                 }
             }
-            .scaleEffect(activeZoomScale, anchor: activeZoomAnchor)
-            .animation(.easeInOut(duration: 0.18), value: activeZoomScale)
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
             .clipped()
             .background(letterboxFill.color)
@@ -540,15 +605,6 @@ struct PlaybackPreview: View {
                     .shadow(color: .black.opacity(0.45), radius: 8, y: 4)
             }
         }
-    }
-
-    private var activeZoomScale: CGFloat {
-        CGFloat(edits.activeZoomEffect(at: playback.currentTime)?.depth ?? 1)
-    }
-
-    private var activeZoomAnchor: UnitPoint {
-        guard let effect = edits.activeZoomEffect(at: playback.currentTime) else { return .center }
-        return UnitPoint(x: effect.focusX, y: effect.focusY)
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -2,6 +2,28 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class TimelineAudioWaveformTests: XCTestCase {
+    func testNoAudioWaveformHasNoSamples() {
+        XCTAssertFalse(TimelineAudioWaveform.none.isAvailable)
+        XCTAssertTrue(TimelineAudioWaveform.none.samples.isEmpty)
+    }
+
+    func testAvailableWaveformClampsSamples() {
+        let waveform = TimelineAudioWaveform.available(samples: [-0.4, 0.25, 1.8])
+
+        XCTAssertTrue(waveform.isAvailable)
+        XCTAssertEqual(waveform.samples, [0, 0.25, 1])
+    }
+
+    func testWaveformBarRendererPreservesPeakWhenResampling() {
+        var samples = Array(repeating: 0.1, count: 60)
+        samples[28] = 0.95
+
+        let bars = TimelineWaveformBarRenderer.resampledLevels(from: samples, width: 60)
+
+        XCTAssertLessThan(bars.count, samples.count)
+        XCTAssertTrue(bars.contains { $0 >= 0.95 })
+    }
+
     func testEmptyWaveformReturnsQuietSamples() {
         let samples = TimelineWaveformDownsampler.downsample(
             interleavedSamples: [],

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import SwiftUI
 import XCTest
 @testable import OpenRecorderMac
 
@@ -126,6 +127,21 @@ final class VideoPreviewLayoutTests: XCTestCase {
 
         XCTAssertEqual(backgroundFill, .clear)
         XCTAssertEqual(insetFill, .clear)
+    }
+
+    func testFullStageZoomAnchorMapsSourceFocusThroughInset() {
+        let anchor = PreviewStageLayout.fullStageZoomAnchor(
+            effect: TimelineZoomEffect(depth: 2, focusX: 0.25, focusY: 0.75),
+            stageSize: CGSize(width: 1000, height: 500),
+            recordingFrame: CGRect(x: 100, y: 50, width: 800, height: 400),
+            sourceSize: CGSize(width: 1600, height: 800),
+            cropSelection: .fullFrame,
+            inset: 50,
+            insetBalance: .centered
+        )
+
+        XCTAssertEqual(anchor.x, 0.35, accuracy: 0.001)
+        XCTAssertEqual(anchor.y, 0.65, accuracy: 0.001)
     }
 
     func testInsetGeometryUsesBalanceToDistributeFreeSpace() {


### PR DESCRIPTION
## Summary
- apply editor preview zoom at the full styled stage so background, inset, facecam, and content scale together
- add full-stage zoom anchor coverage for inset/crop mapping
- include the local waveform/timeline updates currently present in the worktree

## Validation
- swift test