### PR TITLE
[codex] Add extensible cursor styles and camera timeline editing

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CursorPresetRenderer.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CursorPresetRenderer.swift
@@ -33,50 +33,25 @@ struct CursorRenderedGlyph {
     }
 }
 
-enum CursorPresetRenderer {
-    static let palette = CursorGlyphPalette(
-        fill: SerializableColor(hex: "#FFFFFF"),
-        stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.84),
-        shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.36)
-    )
-
-    static let macOSBlackPalette = CursorGlyphPalette(
-        fill: SerializableColor(hex: "#1F2023"),
-        stroke: SerializableColor(red: 1, green: 1, blue: 1, alpha: 0.84),
-        shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.28)
-    )
-
-    static func palette(for style: CursorStyle) -> CursorGlyphPalette {
-        switch style {
-        case .macOSBlackArrow:
-            return macOSBlackPalette
-        case .arrow, .outlineArrow, .handPointer, .iBeam, .dotPointer:
-            return palette
-        }
+enum CursorStyleRenderer {
+    static func drawing(styleID: CursorStyleID, size: CGFloat) -> CursorGlyphDrawing {
+        let definition = CursorStyleRegistry.definition(for: CursorStyleRegistry.resolvedStyleID(styleID))
+        return drawing(renderKind: definition?.renderKind, size: size * CGFloat(definition?.defaultScale ?? 1))
     }
 
-    static func drawing(style: CursorStyle, size: CGFloat, variant: CursorVariant = .standard) -> CursorGlyphDrawing {
-        let resolvedSize = max(1, size)
-        let resolvedVariant = style.resolvedVariant(variant)
-        switch style {
-        case .arrow, .macOSBlackArrow:
-            return arrowDrawing(size: resolvedSize, fillsShape: true, variant: resolvedVariant)
-        case .outlineArrow:
-            return arrowDrawing(size: resolvedSize, fillsShape: false, variant: resolvedVariant)
-        case .handPointer:
-            return handDrawing(size: resolvedSize, variant: resolvedVariant)
-        case .iBeam:
-            return iBeamDrawing(size: resolvedSize, variant: resolvedVariant)
-        case .dotPointer:
-            return dotDrawing(size: resolvedSize, variant: resolvedVariant)
+    static func renderedGlyph(styleID: CursorStyleID, size: CGFloat) -> CursorRenderedGlyph? {
+        let resolvedStyleID = CursorStyleRegistry.resolvedStyleID(styleID)
+        guard let definition = CursorStyleRegistry.definition(for: resolvedStyleID) else {
+            return nil
         }
-    }
+        let resolvedSize = max(1, size * CGFloat(definition.defaultScale))
+        if case .rasterAsset(let name, let hotspotRule) = definition.renderKind {
+            return rasterGlyph(name: name, hotspotRule: hotspotRule, size: resolvedSize)
+        }
 
-    static func renderedGlyph(style: CursorStyle, variant: CursorVariant, size: CGFloat) -> CursorRenderedGlyph? {
-        let resolvedVariant = style.resolvedVariant(variant)
-        let drawing = drawing(style: style, size: size, variant: resolvedVariant)
-        let palette = palette(for: style)
-        let margin = max(3, size * 0.22)
+        let drawing = drawing(renderKind: definition.renderKind, size: resolvedSize)
+        let palette = palette(for: definition.renderKind)
+        let margin = max(3, resolvedSize * 0.22)
         let pixelSize = CGSize(
             width: ceil(drawing.canvasSize.width + margin * 2),
             height: ceil(drawing.canvasSize.height + margin * 2)
@@ -100,8 +75,8 @@ enum CursorPresetRenderer {
         context.scaleBy(x: 1, y: -1)
         context.translateBy(x: margin, y: margin)
         context.setShadow(
-            offset: CGSize(width: 0, height: size * 0.08),
-            blur: max(2, size * 0.18),
+            offset: CGSize(width: 0, height: resolvedSize * 0.045),
+            blur: max(1, resolvedSize * 0.10),
             color: palette.shadow.cgColor
         )
         draw(drawing, in: context, palette: palette)
@@ -115,6 +90,76 @@ enum CursorPresetRenderer {
             canvasSize: pixelSize,
             hotspot: CGPoint(x: margin + drawing.hotspot.x, y: margin + drawing.hotspot.y)
         )
+    }
+
+    private static func drawing(renderKind: CursorRenderKind?, size: CGFloat) -> CursorGlyphDrawing {
+        let resolvedSize = max(1, size)
+        switch renderKind {
+        case .hand:
+            return handDrawing(size: resolvedSize)
+        case .iBeam:
+            return iBeamDrawing(size: resolvedSize)
+        case .dot(_, _, _, let fillsShape):
+            return dotDrawing(size: resolvedSize, diameterScale: 0.58, fillsShape: fillsShape)
+        case .ring:
+            return dotDrawing(size: resolvedSize, diameterScale: 0.82, fillsShape: false)
+        case .spotlight:
+            return dotDrawing(size: resolvedSize, diameterScale: 0.90, fillsShape: true)
+        case .arrow, .rasterAsset, nil:
+            return arrowDrawing(size: resolvedSize, fillsShape: true)
+        }
+    }
+
+    private static func palette(for renderKind: CursorRenderKind) -> CursorGlyphPalette {
+        switch renderKind {
+        case .arrow(let fill, let stroke, let shadow),
+             .hand(let fill, let stroke, let shadow),
+             .iBeam(let fill, let stroke, let shadow),
+             .dot(let fill, let stroke, let shadow, _),
+             .spotlight(let fill, let stroke, let shadow):
+            return CursorGlyphPalette(fill: fill, stroke: stroke, shadow: shadow)
+        case .ring(let stroke, let shadow):
+            return CursorGlyphPalette(
+                fill: SerializableColor(red: 1, green: 1, blue: 1, alpha: 0),
+                stroke: stroke,
+                shadow: shadow
+            )
+        case .rasterAsset:
+            return CursorGlyphPalette(
+                fill: SerializableColor(hex: "#FFFFFF"),
+                stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.84),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.36)
+            )
+        }
+    }
+
+    private static func rasterGlyph(name: String, hotspotRule: CursorHotspotRule, size: CGFloat) -> CursorRenderedGlyph? {
+        guard let image = NSImage(named: name) else { return nil }
+        let sourceSize = image.size
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return nil }
+        let scale = size / max(sourceSize.width, sourceSize.height)
+        let canvasSize = CGSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+        var rect = CGRect(origin: .zero, size: canvasSize)
+        guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
+            return nil
+        }
+
+        return CursorRenderedGlyph(
+            image: cgImage,
+            canvasSize: canvasSize,
+            hotspot: hotspot(for: hotspotRule, canvasSize: canvasSize)
+        )
+    }
+
+    private static func hotspot(for rule: CursorHotspotRule, canvasSize: CGSize) -> CGPoint {
+        switch rule {
+        case .topLeft:
+            return .zero
+        case .center:
+            return CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+        case .proportional(let x, let y):
+            return CGPoint(x: canvasSize.width * x, y: canvasSize.height * y)
+        }
     }
 
     private static func draw(_ drawing: CursorGlyphDrawing, in context: CGContext, palette: CursorGlyphPalette) {
@@ -133,23 +178,9 @@ enum CursorPresetRenderer {
         context.strokePath()
     }
 
-    private static func arrowDrawing(size: CGFloat, fillsShape: Bool, variant: CursorVariant) -> CursorGlyphDrawing {
-        let points: (tail: CGFloat, shaft: CGFloat, heel: CGFloat, notch: CGFloat, head: CGFloat, height: CGFloat)
-        let strokeScale: CGFloat
-        switch variant {
-        case .standard:
-            points = (0.24, 0.45, 0.64, 0.43, 0.78, 1.30)
-            strokeScale = fillsShape ? 0.08 : 0.11
-        case .slim:
-            points = (0.18, 0.37, 0.54, 0.35, 0.66, 1.30)
-            strokeScale = fillsShape ? 0.064 : 0.09
-        case .soft:
-            points = (0.28, 0.47, 0.67, 0.46, 0.80, 1.26)
-            strokeScale = fillsShape ? 0.075 : 0.10
-        case .bold:
-            points = (0.30, 0.52, 0.74, 0.50, 0.90, 1.33)
-            strokeScale = fillsShape ? 0.10 : 0.14
-        }
+    private static func arrowDrawing(size: CGFloat, fillsShape: Bool) -> CursorGlyphDrawing {
+        let points: (tail: CGFloat, shaft: CGFloat, heel: CGFloat, notch: CGFloat, head: CGFloat, height: CGFloat) = (0.24, 0.45, 0.64, 0.43, 0.78, 1.30)
+        let strokeScale: CGFloat = fillsShape ? 0.058 : 0.09
 
         let path = CGMutablePath()
         path.move(to: CGPoint(x: 0, y: 0))
@@ -165,28 +196,13 @@ enum CursorPresetRenderer {
             path: path,
             canvasSize: CGSize(width: size * (points.head + 0.08), height: size * (points.height + 0.06)),
             hotspot: .zero,
-            strokeWidth: max(1.5, size * strokeScale),
+            strokeWidth: max(1, size * strokeScale),
             fillsShape: fillsShape
         )
     }
 
-    private static func handDrawing(size: CGFloat, variant: CursorVariant) -> CursorGlyphDrawing {
-        let xScale: CGFloat
-        let strokeScale: CGFloat
-        switch variant {
-        case .standard:
-            xScale = 1
-            strokeScale = 0.07
-        case .slim:
-            xScale = 0.86
-            strokeScale = 0.058
-        case .soft:
-            xScale = 1.02
-            strokeScale = 0.064
-        case .bold:
-            xScale = 1.08
-            strokeScale = 0.095
-        }
+    private static func handDrawing(size: CGFloat) -> CursorGlyphDrawing {
+        let strokeScale: CGFloat = 0.052
 
         let path = CGMutablePath()
         path.move(to: CGPoint(x: size * 0.47, y: size * 0.02))
@@ -234,47 +250,20 @@ enum CursorPresetRenderer {
         path.closeSubpath()
 
         let hotspot = CGPoint(x: size * 0.54, y: size * 0.02)
-        let resolvedPath: CGPath
-        if xScale == 1 {
-            resolvedPath = path
-        } else {
-            var transform = CGAffineTransform(translationX: hotspot.x, y: 0)
-                .scaledBy(x: xScale, y: 1)
-                .translatedBy(x: -hotspot.x, y: 0)
-            resolvedPath = path.copy(using: &transform) ?? path
-        }
 
         return CursorGlyphDrawing(
-            path: resolvedPath,
-            canvasSize: CGSize(width: size * max(1, xScale), height: size * 1.30),
+            path: path,
+            canvasSize: CGSize(width: size, height: size * 1.30),
             hotspot: hotspot,
-            strokeWidth: max(1.4, size * strokeScale),
+            strokeWidth: max(1, size * strokeScale),
             fillsShape: true
         )
     }
 
-    private static func iBeamDrawing(size: CGFloat, variant: CursorVariant) -> CursorGlyphDrawing {
-        let capWidth: CGFloat
-        let stemWidth: CGFloat
-        let cornerRadius: CGFloat
-        switch variant {
-        case .standard:
-            capWidth = 0.62
-            stemWidth = 0.10
-            cornerRadius = 0
-        case .slim:
-            capWidth = 0.48
-            stemWidth = 0.06
-            cornerRadius = 0
-        case .soft:
-            capWidth = 0.62
-            stemWidth = 0.11
-            cornerRadius = size * 0.035
-        case .bold:
-            capWidth = 0.74
-            stemWidth = 0.16
-            cornerRadius = 0
-        }
+    private static func iBeamDrawing(size: CGFloat) -> CursorGlyphDrawing {
+        let capWidth: CGFloat = 0.62
+        let stemWidth: CGFloat = 0.10
+        let cornerRadius: CGFloat = 0
 
         let path = CGMutablePath()
         addIBeamRect(
@@ -297,33 +286,14 @@ enum CursorPresetRenderer {
             path: path,
             canvasSize: CGSize(width: size, height: size * 1.20),
             hotspot: CGPoint(x: size * 0.50, y: size * 0.60),
-            strokeWidth: max(1, size * (variant == .bold ? 0.052 : 0.04)),
+            strokeWidth: max(1, size * 0.04),
             fillsShape: true
         )
     }
 
-    private static func dotDrawing(size: CGFloat, variant: CursorVariant) -> CursorGlyphDrawing {
-        let diameter: CGFloat
-        let fillsShape: Bool
-        let strokeScale: CGFloat
-        switch variant {
-        case .standard:
-            diameter = size * 0.58
-            fillsShape = true
-            strokeScale = 0.08
-        case .slim:
-            diameter = size * 0.42
-            fillsShape = true
-            strokeScale = 0.06
-        case .soft:
-            diameter = size * 0.62
-            fillsShape = false
-            strokeScale = 0.10
-        case .bold:
-            diameter = size * 0.72
-            fillsShape = true
-            strokeScale = 0.09
-        }
+    private static func dotDrawing(size: CGFloat, diameterScale: CGFloat, fillsShape: Bool) -> CursorGlyphDrawing {
+        let diameter = size * diameterScale
+        let strokeScale: CGFloat = fillsShape ? 0.055 : 0.10
         let origin = CGPoint(x: (size * 0.90 - diameter) / 2, y: (size * 0.90 - diameter) / 2)
         let path = CGMutablePath()
         path.addEllipse(in: CGRect(origin: origin, size: CGSize(width: diameter, height: diameter)))
@@ -332,7 +302,7 @@ enum CursorPresetRenderer {
             path: path,
             canvasSize: CGSize(width: size * 0.90, height: size * 0.90),
             hotspot: CGPoint(x: size * 0.45, y: size * 0.45),
-            strokeWidth: max(1.4, size * strokeScale),
+            strokeWidth: max(1, size * strokeScale),
             fillsShape: fillsShape
         )
     }
@@ -348,16 +318,14 @@ enum CursorPresetRenderer {
 }
 
 struct CursorGlyphView: View {
-    var style: CursorStyle
-    var variant: CursorVariant
+    var styleID: CursorStyleID
     var scale: Double
     var glyphSize: CGFloat? = nil
     var alignsHotspot = false
 
     var body: some View {
         let size = glyphSize.map { max(1, $0) } ?? max(12, 24 * CGFloat(scale))
-        let resolvedVariant = style.resolvedVariant(variant)
-        if let glyph = CursorPresetRenderer.renderedGlyph(style: style, variant: resolvedVariant, size: size) {
+        if let glyph = CursorStyleRenderer.renderedGlyph(styleID: styleID, size: size) {
             Image(nsImage: NSImage(cgImage: glyph.image, size: glyph.canvasSize))
                 .resizable()
                 .frame(width: glyph.canvasSize.width, height: glyph.canvasSize.height)

--- a/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
@@ -138,7 +138,10 @@ enum VideoEditorEvent: Equatable {
         recordingURL: URL?,
         edits: TimelineEditSnapshot,
         snapshot: ProjectAutosaveSnapshot?,
-        cursorTelemetryURL: URL?
+        cursorTelemetryURL: URL?,
+        facecamVideoURL: URL?,
+        facecamOffsetMs: Int?,
+        cameraFallback: FacecamSettings?
     )
     case sheetDismissed(exportIsBusy: Bool)
     case autosaveSnapshotChanged(ProjectAutosaveSnapshot?)
@@ -208,8 +211,9 @@ extension VideoEditorState {
             exportDraft.frameRate = frameRate
             return []
 
-        case .exportConfirmed(let recordingURL, let edits, let snapshot, let cursorTelemetryURL):
+        case .exportConfirmed(let recordingURL, let edits, let snapshot, let cursorTelemetryURL, let facecamVideoURL, let facecamOffsetMs, let cameraFallback):
             let styledOptions = styledExportOptions(from: exportDraft.currentOptions, cursorTelemetryURL: cursorTelemetryURL)
+                .withFacecam(url: facecamVideoURL, offsetMs: facecamOffsetMs, fallbackSettings: cameraFallback)
             return [.startVideoExport(recordingURL: recordingURL, options: styledOptions, edits: edits, snapshot: snapshot)]
 
         case .sheetDismissed(let exportIsBusy):
@@ -271,8 +275,10 @@ extension VideoEditorState {
                 loops: defaults.cursorOverlay.loops,
                 size: defaults.cursorOverlay.size,
                 smoothing: defaults.cursorOverlay.smoothing,
-                style: defaults.cursorOverlay.style,
-                variant: defaults.cursorOverlay.variant
+                styleID: defaults.cursorOverlay.styleID,
+                clickEffect: defaults.cursorOverlay.clickEffect,
+                idleBehavior: defaults.cursorOverlay.idleBehavior,
+                motionEffect: defaults.cursorOverlay.motionEffect
             )
         }
 

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -185,6 +185,7 @@ struct VideoEditorStudioView: View {
                 cursorSettings: editor.state.cursorOverlaySettings,
                 cropSelection: editor.state.video.cropSelection,
                 facecamSettings: editor.state.currentFacecamSettings,
+                cameraTimelineFallback: editor.state.currentFacecamSettings,
                 previewAspectPreset: editor.previewAspectPresetBinding,
                 onCropVideo: {
                     guard let videoURL else { return }
@@ -196,7 +197,13 @@ struct VideoEditorStudioView: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } secondary: {
-            TimelinePanel(videoURL: videoURL, playback: playback, edits: timelineEdits)
+            TimelinePanel(
+                videoURL: videoURL,
+                playback: playback,
+                edits: timelineEdits,
+                hasRecordedCamera: editor.state.hasRecordedCamera,
+                defaultCameraSettings: editor.state.currentFacecamSettings
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
@@ -204,7 +211,11 @@ struct VideoEditorStudioView: View {
     @ViewBuilder
     private var sidebarContent: some View {
         if timelineEdits.hasSelection {
-            TimelineSelectionSidebar(edits: timelineEdits, playback: playback)
+            TimelineSelectionSidebar(
+                edits: timelineEdits,
+                playback: playback,
+                defaultCameraSettings: editor.state.currentFacecamSettings
+            )
         } else {
             SettingsInspector(
                 borderRadius: editor.binding(\.borderRadius),
@@ -220,12 +231,7 @@ struct VideoEditorStudioView: View {
                 loopCursor: editor.binding(\.cursorOverlay.loops),
                 cursorSize: editor.binding(\.cursorOverlay.size),
                 cursorSmoothing: editor.binding(\.cursorOverlay.smoothing),
-                cursorStyle: editor.binding(\.cursorOverlay.style),
-                cursorVariant: editor.binding(\.cursorOverlay.variant),
-                facecamEnabled: editor.facecamBinding(\.enabled, default: false),
-                facecamSize: editor.facecamBinding(\.size, default: 22),
-                facecamBorderWidth: editor.facecamBinding(\.borderWidth, default: 4),
-                facecamAnchor: editor.facecamBinding(\.anchor, default: FacecamAnchor.bottomRight.rawValue),
+                cursorStyleID: editor.binding(\.cursorOverlay.styleID),
                 recordingSession: recordingSession
             )
         }
@@ -282,7 +288,10 @@ struct VideoEditorStudioView: View {
                     recordingURL: exportRequest?.url ?? videoURL,
                     edits: timelineEdits.snapshot,
                     snapshot: autosaveSnapshot,
-                    cursorTelemetryURL: cursorTelemetryURL
+                    cursorTelemetryURL: cursorTelemetryURL,
+                    facecamVideoURL: facecamVideoURL,
+                    facecamOffsetMs: recordingSession?.facecamOffsetMs,
+                    cameraFallback: editor.state.currentFacecamSettings
                 ))
             },
             onRetrySave: {
@@ -348,6 +357,14 @@ struct VideoEditorStudioView: View {
         guard let videoURL else { return nil }
         let derivedURL = CursorTelemetryRecorder.telemetryURL(for: videoURL)
         return FileManager.default.fileExists(atPath: derivedURL.path) ? derivedURL : nil
+    }
+
+    private var facecamVideoURL: URL? {
+        guard let path = recordingSession?.facecamVideoPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: path)
     }
 
     private var isVideoExportRequestTarget: Bool {

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -18,12 +18,7 @@ struct SettingsInspector: View {
     @Binding var loopCursor: Bool
     @Binding var cursorSize: Double
     @Binding var cursorSmoothing: Double
-    @Binding var cursorStyle: CursorStyle
-    @Binding var cursorVariant: CursorVariant
-    @Binding var facecamEnabled: Bool
-    @Binding var facecamSize: Double
-    @Binding var facecamBorderWidth: Double
-    @Binding var facecamAnchor: String
+    @Binding var cursorStyleID: CursorStyleID
     var recordingSession: RecordingSession?
 
     @State private var activeTab: InspectorTab = .appearance
@@ -149,8 +144,7 @@ struct SettingsInspector: View {
         case .cursor:
             InspectorGroup(title: "Cursor", symbolName: "cursorarrow") {
                 InspectorSwitch(title: "Show Cursor", isOn: $showCursor)
-                CursorStylePicker(selection: $cursorStyle, variant: $cursorVariant)
-                CursorVariantPicker(style: cursorStyle, selection: $cursorVariant)
+                CursorStylePicker(selection: $cursorStyleID)
             }
             InspectorGroup(title: "Motion", symbolName: "point.3.connected.trianglepath.dotted") {
                 InspectorSwitch(title: "Loop Cursor", isOn: $loopCursor)
@@ -159,16 +153,10 @@ struct SettingsInspector: View {
             }
         case .camera:
             InspectorGroup(title: "Facecam", symbolName: "camera") {
-                InspectorSwitch(title: "Facecam", isOn: $facecamEnabled, isInteractive: hasRecordedCamera)
-                    .disabled(!hasRecordedCamera)
-                    .opacity(hasRecordedCamera ? 1 : 0.45)
-                VStack(alignment: .leading, spacing: 15) {
-                    InspectorSlider(title: "Facecam Size", valueText: "\(Int(facecamSize.rounded()))%", value: $facecamSize, range: 12...40, step: 1)
-                    InspectorSlider(title: "Border Width", valueText: "\(Int(facecamBorderWidth.rounded()))px", value: $facecamBorderWidth, range: 0...16, step: 1)
-                    PositionGrid(selection: $facecamAnchor)
-                }
-                .disabled(!hasRecordedCamera || !facecamEnabled)
-                .opacity(hasRecordedCamera && facecamEnabled ? 1 : 0.45)
+                Text(hasRecordedCamera ? "Timeline camera layer" : "No facecam recorded")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             if let path = recordingSession?.facecamVideoPath {
                 SessionAssetRow(title: "Facecam File", path: path)
@@ -493,8 +481,7 @@ struct InsetBalancePicker: View {
 }
 
 struct CursorStylePicker: View {
-    @Binding var selection: CursorStyle
-    @Binding var variant: CursorVariant
+    @Binding var selection: CursorStyleID
 
     private let columns = Array(repeating: GridItem(.flexible(minimum: 0), spacing: 6), count: 2)
 
@@ -504,74 +491,22 @@ struct CursorStylePicker: View {
                 .font(.system(size: 10, weight: .medium))
                 .foregroundStyle(.secondary)
 
-            LazyVGrid(columns: columns, spacing: 6) {
-                ForEach(CursorStyle.allCases) { style in
-                    StudioButton(hitTarget: .rounded(7), help: style.title) {
-                        selection = style
-                        variant = style.resolvedVariant(variant)
-                    } label: {
-                        VStack(spacing: 5) {
-                            CursorGlyphView(style: style, variant: style.resolvedVariant(variant), scale: 0.56)
-                                .frame(width: 38, height: 34)
-                            Text(style.title)
-                                .font(.system(size: 10, weight: .semibold))
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.8)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 58)
-                        .foregroundStyle(selection == style ? Color.white : Color.primary.opacity(0.86))
-                        .background(selection == style ? Theme.accent.opacity(0.82) : Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 7)
-                                .stroke(selection == style ? Theme.accent.opacity(0.95) : Theme.overlay)
-                        }
-                    }
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 3)
-    }
-}
+            ForEach(CursorStyleCategory.allCases) { category in
+                let styles = CursorStyleRegistry.definitions(in: category)
+                if !styles.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(category.title)
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.tertiary)
 
-struct CursorVariantPicker: View {
-    var style: CursorStyle
-    @Binding var selection: CursorVariant
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Variant")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 6) {
-                ForEach(style.supportedVariants) { variant in
-                    StudioButton(hitTarget: .rounded(7), help: variant.title) {
-                        selection = variant
-                    } label: {
-                        VStack(spacing: 4) {
-                            CursorGlyphView(style: style, variant: variant, scale: 0.42)
-                                .frame(width: 28, height: 24)
-                            Text(variant.title)
-                                .font(.system(size: 9, weight: .semibold))
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.7)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
-                        .foregroundStyle(selection == variant ? Color.white : Color.primary.opacity(0.82))
-                        .background(selection == variant ? Theme.accent.opacity(0.82) : Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 7)
-                                .stroke(selection == variant ? Theme.accent.opacity(0.95) : Theme.border, lineWidth: selection == variant ? 2 : 1)
-                        }
-                        .overlay(alignment: .topTrailing) {
-                            if selection == variant {
-                                Image(systemName: "checkmark")
-                                    .font(.system(size: 8, weight: .bold))
-                                    .foregroundStyle(Color.white)
-                                    .padding(4)
+                        LazyVGrid(columns: columns, spacing: 6) {
+                            ForEach(styles) { style in
+                                CursorStyleButton(
+                                    style: style,
+                                    isSelected: normalizedSelection == style.id
+                                ) {
+                                    selection = style.id
+                                }
                             }
                         }
                     }
@@ -581,13 +516,44 @@ struct CursorVariantPicker: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 3)
         .onAppear(perform: normalizeSelection)
-        .onChange(of: style) { _, _ in
+        .onChange(of: selection) { _, _ in
             normalizeSelection()
         }
     }
 
+    private var normalizedSelection: CursorStyleID {
+        CursorStyleRegistry.resolvedStyleID(selection)
+    }
+
     private func normalizeSelection() {
-        selection = style.resolvedVariant(selection)
+        selection = normalizedSelection
+    }
+}
+
+struct CursorStyleButton: View {
+    var style: CursorStyleDefinition
+    var isSelected: Bool
+    var action: () -> Void
+
+    var body: some View {
+        StudioButton(hitTarget: .rounded(7), help: style.title, action: action) {
+            VStack(spacing: 5) {
+                CursorGlyphView(styleID: style.id, scale: 0.56)
+                    .frame(width: 38, height: 34)
+                Text(style.title)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 58)
+            .foregroundStyle(isSelected ? Color.white : Color.primary.opacity(0.86))
+            .background(isSelected ? Theme.accent.opacity(0.82) : Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(isSelected ? Theme.accent.opacity(0.95) : Theme.overlay)
+            }
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -433,76 +433,183 @@ struct RecordingSession: Codable, Hashable {
     }
 }
 
-enum CursorStyle: String, CaseIterable, Codable, Hashable, Identifiable {
-    case arrow
-    case macOSBlackArrow
-    case outlineArrow
-    case handPointer
-    case iBeam
-    case dotPointer
+typealias CursorStyleID = String
+
+enum CursorStyleCategory: String, CaseIterable, Hashable, Identifiable {
+    case system
+    case touch
+    case emphasis
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .arrow: "Arrow"
-        case .macOSBlackArrow: "macOS Black"
-        case .outlineArrow: "Outline"
-        case .handPointer: "Hand"
-        case .iBeam: "I-Beam"
-        case .dotPointer: "Dot"
+        case .system: "System"
+        case .touch: "Touch"
+        case .emphasis: "Emphasis"
         }
-    }
-
-    var defaultVariant: CursorVariant {
-        .standard
-    }
-
-    var supportedVariants: [CursorVariant] {
-        CursorVariant.allCases
-    }
-
-    func resolvedVariant(_ variant: CursorVariant) -> CursorVariant {
-        supportedVariants.contains(variant) ? variant : defaultVariant
     }
 }
 
-enum CursorVariant: String, CaseIterable, Codable, Hashable, Identifiable {
-    case standard
-    case slim
-    case soft
-    case bold
+enum CursorHotspotRule: Hashable {
+    case topLeft
+    case center
+    case proportional(x: Double, y: Double)
+}
+
+enum CursorRenderKind: Hashable {
+    case arrow(fill: SerializableColor, stroke: SerializableColor, shadow: SerializableColor)
+    case hand(fill: SerializableColor, stroke: SerializableColor, shadow: SerializableColor)
+    case iBeam(fill: SerializableColor, stroke: SerializableColor, shadow: SerializableColor)
+    case dot(fill: SerializableColor, stroke: SerializableColor, shadow: SerializableColor, fillsShape: Bool)
+    case ring(stroke: SerializableColor, shadow: SerializableColor)
+    case spotlight(fill: SerializableColor, stroke: SerializableColor, shadow: SerializableColor)
+    case rasterAsset(name: String, hotspot: CursorHotspotRule)
+}
+
+struct CursorStyleDefinition: Identifiable, Hashable {
+    var id: CursorStyleID
+    var title: String
+    var category: CursorStyleCategory
+    var renderKind: CursorRenderKind
+    var hotspot: CursorHotspotRule
+    var defaultScale: Double
+    var supportsRecordedTypeOverride: Bool
+}
+
+enum CursorStyleRegistry {
+    static let defaultStyleID: CursorStyleID = "system.white"
+
+    static let styles: [CursorStyleDefinition] = [
+        CursorStyleDefinition(
+            id: "system.white",
+            title: "System White",
+            category: .system,
+            renderKind: .arrow(
+                fill: SerializableColor(hex: "#FFFFFF"),
+                stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.62),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.16)
+            ),
+            hotspot: .topLeft,
+            defaultScale: 1,
+            supportsRecordedTypeOverride: true
+        ),
+        CursorStyleDefinition(
+            id: "system.black",
+            title: "System Black",
+            category: .system,
+            renderKind: .arrow(
+                fill: SerializableColor(hex: "#1F2023"),
+                stroke: SerializableColor(red: 1, green: 1, blue: 1, alpha: 0.68),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.14)
+            ),
+            hotspot: .topLeft,
+            defaultScale: 1,
+            supportsRecordedTypeOverride: true
+        ),
+        CursorStyleDefinition(
+            id: "system.hand",
+            title: "Hand",
+            category: .system,
+            renderKind: .hand(
+                fill: SerializableColor(hex: "#FFFFFF"),
+                stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.62),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.16)
+            ),
+            hotspot: .proportional(x: 0.54, y: 0.02),
+            defaultScale: 1,
+            supportsRecordedTypeOverride: false
+        ),
+        CursorStyleDefinition(
+            id: "system.ibeam",
+            title: "I-Beam",
+            category: .system,
+            renderKind: .iBeam(
+                fill: SerializableColor(hex: "#FFFFFF"),
+                stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.56),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.12)
+            ),
+            hotspot: .center,
+            defaultScale: 1,
+            supportsRecordedTypeOverride: false
+        ),
+        CursorStyleDefinition(
+            id: "touch.dot",
+            title: "Touch Dot",
+            category: .touch,
+            renderKind: .dot(
+                fill: SerializableColor(hex: "#FFFFFF"),
+                stroke: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.54),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.14),
+                fillsShape: true
+            ),
+            hotspot: .center,
+            defaultScale: 1.08,
+            supportsRecordedTypeOverride: false
+        ),
+        CursorStyleDefinition(
+            id: "highlight.ring",
+            title: "Highlight Ring",
+            category: .emphasis,
+            renderKind: .ring(
+                stroke: SerializableColor(hex: "#FFFFFF", alpha: 0.92),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.34)
+            ),
+            hotspot: .center,
+            defaultScale: 1.55,
+            supportsRecordedTypeOverride: false
+        ),
+        CursorStyleDefinition(
+            id: "spotlight",
+            title: "Spotlight",
+            category: .emphasis,
+            renderKind: .spotlight(
+                fill: SerializableColor(hex: "#FFFFFF", alpha: 0.20),
+                stroke: SerializableColor(hex: "#FFFFFF", alpha: 0.84),
+                shadow: SerializableColor(red: 0, green: 0, blue: 0, alpha: 0.38)
+            ),
+            hotspot: .center,
+            defaultScale: 1.85,
+            supportsRecordedTypeOverride: false
+        )
+    ]
+
+    static func definition(for id: CursorStyleID) -> CursorStyleDefinition? {
+        styles.first { $0.id == id }
+    }
+
+    static func resolvedStyleID(_ id: CursorStyleID?) -> CursorStyleID {
+        guard let id, definition(for: id) != nil else {
+            return defaultStyleID
+        }
+        return id
+    }
+
+    static func definitions(in category: CursorStyleCategory) -> [CursorStyleDefinition] {
+        styles.filter { $0.category == category }
+    }
+}
+
+enum CursorClickEffect: String, CaseIterable, Codable, Hashable, Identifiable {
+    case none
+    case subtleRing
+    case ripple
 
     var id: String { rawValue }
+}
 
-    var title: String {
-        switch self {
-        case .standard: "Standard"
-        case .slim: "Slim"
-        case .soft: "Soft"
-        case .bold: "Bold"
-        }
-    }
+enum CursorIdleBehavior: String, CaseIterable, Codable, Hashable, Identifiable {
+    case alwaysVisible
+    case fadeWhenIdle
 
-    static func resolve(_ rawValue: String?) -> CursorVariant? {
-        guard let rawValue else { return nil }
-        if let variant = CursorVariant(rawValue: rawValue) {
-            return variant
-        }
+    var id: String { rawValue }
+}
 
-        switch rawValue {
-        case "light":
-            return .standard
-        case "dark":
-            return .slim
-        case "accent":
-            return .soft
-        case "highContrast":
-            return .bold
-        default:
-            return nil
-        }
-    }
+enum CursorMotionEffect: String, CaseIterable, Codable, Hashable, Identifiable {
+    case none
+    case subtleLean
+
+    var id: String { rawValue }
 }
 
 struct CursorOverlaySettings: Codable, Hashable {
@@ -510,25 +617,23 @@ struct CursorOverlaySettings: Codable, Hashable {
     var loops: Bool
     var size: Double
     var smoothing: Double
-    var style: CursorStyle
-    var variant: CursorVariant
+    var styleID: CursorStyleID
+    var clickEffect: CursorClickEffect
+    var idleBehavior: CursorIdleBehavior
+    var motionEffect: CursorMotionEffect
 
     static let `default` = CursorOverlaySettings(
         isVisible: true,
         loops: false,
         size: 1,
-        smoothing: 0.4,
-        style: .arrow,
-        variant: .standard
+        smoothing: 0.4
     )
 
     static let hidden = CursorOverlaySettings(
         isVisible: false,
         loops: false,
         size: 1,
-        smoothing: 0.4,
-        style: .arrow,
-        variant: .standard
+        smoothing: 0.4
     )
 
     init(
@@ -536,15 +641,19 @@ struct CursorOverlaySettings: Codable, Hashable {
         loops: Bool,
         size: Double,
         smoothing: Double,
-        style: CursorStyle = .arrow,
-        variant: CursorVariant = .standard
+        styleID: CursorStyleID = CursorStyleRegistry.defaultStyleID,
+        clickEffect: CursorClickEffect = .subtleRing,
+        idleBehavior: CursorIdleBehavior = .alwaysVisible,
+        motionEffect: CursorMotionEffect = .none
     ) {
         self.isVisible = isVisible
         self.loops = loops
         self.size = max(1, min(size, 8))
         self.smoothing = max(0, min(smoothing, 2))
-        self.style = style
-        self.variant = style.resolvedVariant(variant)
+        self.styleID = CursorStyleRegistry.resolvedStyleID(styleID)
+        self.clickEffect = clickEffect
+        self.idleBehavior = idleBehavior
+        self.motionEffect = motionEffect
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -552,25 +661,30 @@ struct CursorOverlaySettings: Codable, Hashable {
         case loops
         case size
         case smoothing
+        case styleID
         case style
         case variant
+        case clickEffect
+        case idleBehavior
+        case motionEffect
     }
 
     init(from decoder: Decoder) throws {
         let defaults = Self.default
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let decodedStyle = try container.decodeIfPresent(String.self, forKey: .style)
-            .flatMap(CursorStyle.init(rawValue:)) ?? defaults.style
-        let decodedVariant = CursorVariant.resolve(try container.decodeIfPresent(String.self, forKey: .variant))
-            ?? decodedStyle.defaultVariant
+        let decodedStyleID = CursorStyleRegistry.resolvedStyleID(
+            try container.decodeIfPresent(String.self, forKey: .styleID)
+        )
 
         self.init(
             isVisible: try container.decodeIfPresent(Bool.self, forKey: .isVisible) ?? defaults.isVisible,
             loops: try container.decodeIfPresent(Bool.self, forKey: .loops) ?? defaults.loops,
             size: try container.decodeIfPresent(Double.self, forKey: .size) ?? defaults.size,
             smoothing: try container.decodeIfPresent(Double.self, forKey: .smoothing) ?? defaults.smoothing,
-            style: decodedStyle,
-            variant: decodedVariant
+            styleID: decodedStyleID,
+            clickEffect: (try? container.decodeIfPresent(CursorClickEffect.self, forKey: .clickEffect)) ?? defaults.clickEffect,
+            idleBehavior: (try? container.decodeIfPresent(CursorIdleBehavior.self, forKey: .idleBehavior)) ?? defaults.idleBehavior,
+            motionEffect: (try? container.decodeIfPresent(CursorMotionEffect.self, forKey: .motionEffect)) ?? defaults.motionEffect
         )
     }
 
@@ -580,8 +694,10 @@ struct CursorOverlaySettings: Codable, Hashable {
         try container.encode(loops, forKey: .loops)
         try container.encode(size, forKey: .size)
         try container.encode(smoothing, forKey: .smoothing)
-        try container.encode(style.rawValue, forKey: .style)
-        try container.encode(variant.rawValue, forKey: .variant)
+        try container.encode(styleID, forKey: .styleID)
+        try container.encode(clickEffect, forKey: .clickEffect)
+        try container.encode(idleBehavior, forKey: .idleBehavior)
+        try container.encode(motionEffect, forKey: .motionEffect)
     }
 
     var clamped: CursorOverlaySettings {
@@ -590,8 +706,10 @@ struct CursorOverlaySettings: Codable, Hashable {
             loops: loops,
             size: size,
             smoothing: smoothing,
-            style: style,
-            variant: variant
+            styleID: styleID,
+            clickEffect: clickEffect,
+            idleBehavior: idleBehavior,
+            motionEffect: motionEffect
         )
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -852,4 +852,5 @@ enum Theme {
     static let timelineClipForeground = Color.white.opacity(0.94)
     static let timelineClipBorder     = Color(red: 0.28, green: 0.62, blue: 1.0).opacity(0.88)
     static let timelineHandle         = Color(red: 0.34, green: 0.68, blue: 1.0)
+    static let timelineCamera         = Color(red: 0.02, green: 0.66, blue: 0.58)
 }

--- a/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
@@ -62,6 +62,11 @@ enum TimelineRegionKind: String, CaseIterable, Identifiable {
     }
 }
 
+enum TimelineCameraMergeDirection: Equatable {
+    case previous
+    case next
+}
+
 struct TimelineSpan: Codable, Equatable, Hashable {
     var start: Double
     var end: Double
@@ -144,6 +149,35 @@ struct TimelineAnnotationRegion: Identifiable, Codable, Equatable, Hashable {
     var fontSize: CGFloat = 34
 }
 
+struct TimelineCameraClip: Identifiable, Codable, Equatable, Hashable {
+    var id = TimelineRegionID()
+    var span: TimelineSpan
+    var settings: FacecamSettings
+
+    init(
+        id: TimelineRegionID = TimelineRegionID(),
+        span: TimelineSpan,
+        settings: FacecamSettings
+    ) {
+        self.id = id
+        self.span = span
+        self.settings = settings.clamped
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case span
+        case settings
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(TimelineRegionID.self, forKey: .id) ?? TimelineRegionID()
+        span = try container.decode(TimelineSpan.self, forKey: .span)
+        settings = (try container.decodeIfPresent(FacecamSettings.self, forKey: .settings) ?? defaultFacecamSettings(enabled: true)).clamped
+    }
+}
+
 struct TimelineClipSegment: Identifiable, Equatable {
     var index: Int
     var start: Double
@@ -209,11 +243,47 @@ struct TimelineEditSnapshot: Codable, Equatable, Hashable {
     var annotationRegions: [TimelineAnnotationRegion] = []
     var clipSplitTimes: [Double] = []
     var clipSpeeds: [Int: Double] = [:]
+    var cameraClips: [TimelineCameraClip] = []
 
     static let empty = TimelineEditSnapshot()
 
+    init(
+        zoomRegions: [TimelineZoomRegion] = [],
+        trimRegions: [TimelineTrimRegion] = [],
+        annotationRegions: [TimelineAnnotationRegion] = [],
+        clipSplitTimes: [Double] = [],
+        clipSpeeds: [Int: Double] = [:],
+        cameraClips: [TimelineCameraClip] = []
+    ) {
+        self.zoomRegions = zoomRegions
+        self.trimRegions = trimRegions
+        self.annotationRegions = annotationRegions
+        self.clipSplitTimes = clipSplitTimes
+        self.clipSpeeds = clipSpeeds
+        self.cameraClips = cameraClips.map { TimelineCameraClip(id: $0.id, span: $0.span, settings: $0.settings) }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case zoomRegions
+        case trimRegions
+        case annotationRegions
+        case clipSplitTimes
+        case clipSpeeds
+        case cameraClips
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        zoomRegions = try container.decodeIfPresent([TimelineZoomRegion].self, forKey: .zoomRegions) ?? []
+        trimRegions = try container.decodeIfPresent([TimelineTrimRegion].self, forKey: .trimRegions) ?? []
+        annotationRegions = try container.decodeIfPresent([TimelineAnnotationRegion].self, forKey: .annotationRegions) ?? []
+        clipSplitTimes = try container.decodeIfPresent([Double].self, forKey: .clipSplitTimes) ?? []
+        clipSpeeds = try container.decodeIfPresent([Int: Double].self, forKey: .clipSpeeds) ?? [:]
+        cameraClips = try container.decodeIfPresent([TimelineCameraClip].self, forKey: .cameraClips) ?? []
+    }
+
     var hasEdits: Bool {
-        !zoomRegions.isEmpty || !trimRegions.isEmpty || !annotationRegions.isEmpty || !clipSplitTimes.isEmpty || hasClipSpeedEdits
+        !zoomRegions.isEmpty || !trimRegions.isEmpty || !annotationRegions.isEmpty || !clipSplitTimes.isEmpty || hasClipSpeedEdits || !cameraClips.isEmpty
     }
 
     var hasClipSpeedEdits: Bool {
@@ -252,6 +322,45 @@ struct TimelineEditSnapshot: Codable, Equatable, Hashable {
 
     func annotations(at time: Double) -> [TimelineAnnotationRegion] {
         annotationRegions.filter { $0.span.contains(time) }.sorted { $0.span.start < $1.span.start }
+    }
+
+    func resolvedCameraClips(duration: Double, fallback: FacecamSettings?) -> [TimelineCameraClip] {
+        let normalized = cameraClips
+            .map { TimelineCameraClip(id: $0.id, span: $0.span.normalized(duration: duration), settings: $0.settings) }
+            .filter { $0.span.duration > 0.001 }
+            .sorted { $0.span.start < $1.span.start }
+
+        if !normalized.isEmpty {
+            return normalized
+        }
+
+        guard duration.isFinite,
+              duration > 0,
+              let fallback = fallback?.clamped else {
+            return []
+        }
+
+        return [
+            TimelineCameraClip(
+                span: TimelineSpan(start: 0, end: duration),
+                settings: fallback
+            )
+        ]
+    }
+
+    func activeCameraSettings(at time: Double, duration: Double, fallback: FacecamSettings?) -> FacecamSettings? {
+        guard duration.isFinite,
+              duration > 0 else {
+            return nil
+        }
+
+        let clips = resolvedCameraClips(duration: duration, fallback: fallback)
+        guard let clip = clips.last(where: { time >= $0.span.start && (time < $0.span.end || abs($0.span.end - duration) < 0.001) }) else {
+            return nil
+        }
+
+        let settings = clip.settings.clamped
+        return settings.enabled ? settings : nil
     }
 }
 
@@ -339,12 +448,13 @@ struct TimelineEditState: Equatable {
     var selectedKind: TimelineRegionKind?
     var selectedID: TimelineRegionID?
     var selectedClipIndex: Int?
+    var selectedCameraClipID: TimelineRegionID?
     var statusMessage = "Use shortcuts to edit. Space plays, Z zooms, S cycles clip speed, T splits clips."
 
     static let empty = TimelineEditState()
 
     var hasSelection: Bool {
-        selectedClipIndex != nil || (selectedKind != nil && selectedID != nil)
+        selectedClipIndex != nil || selectedCameraClipID != nil || (selectedKind != nil && selectedID != nil)
     }
 }
 
@@ -355,6 +465,11 @@ enum TimelineEditEvent: Equatable {
     case regenerateAutoZoomsRequested(videoURL: URL?, duration: Double)
     case replaceAutoZooms([TimelineZoomRegion])
     case addClipSplit(currentTime: Double, duration: Double)
+    case ensureCameraClips(duration: Double, fallback: FacecamSettings?)
+    case splitCameraClip(currentTime: Double, duration: Double, fallback: FacecamSettings?)
+    case selectCameraClip(TimelineRegionID)
+    case updateCameraClipSettings(id: TimelineRegionID, settings: FacecamSettings)
+    case mergeCameraClip(id: TimelineRegionID, direction: TimelineCameraMergeDirection)
     case select(TimelineRegionKind?, TimelineRegionID?)
     case selectClip(index: Int)
     case clearSelection
@@ -406,6 +521,26 @@ extension TimelineEditState {
 
         case .addClipSplit(let currentTime, let duration):
             addClipSplit(at: currentTime, duration: duration)
+            return []
+
+        case .ensureCameraClips(let duration, let fallback):
+            ensureCameraClips(duration: duration, fallback: fallback)
+            return []
+
+        case .splitCameraClip(let currentTime, let duration, let fallback):
+            splitCameraClip(at: currentTime, duration: duration, fallback: fallback)
+            return []
+
+        case .selectCameraClip(let id):
+            selectCameraClip(id: id)
+            return []
+
+        case .updateCameraClipSettings(let id, let settings):
+            updateCameraClipSettings(id: id, settings: settings)
+            return []
+
+        case .mergeCameraClip(let id, let direction):
+            mergeCameraClip(id: id, direction: direction)
             return []
 
         case .select(let kind, let id):
@@ -467,6 +602,11 @@ extension TimelineEditState {
         let segments = snapshot.clipSegments(duration: duration)
         guard segments.indices.contains(selectedClipIndex) else { return nil }
         return segments[selectedClipIndex]
+    }
+
+    func selectedCameraClip(duration: Double, fallback: FacecamSettings?) -> TimelineCameraClip? {
+        guard let selectedCameraClipID else { return nil }
+        return snapshot.resolvedCameraClips(duration: duration, fallback: fallback).first { $0.id == selectedCameraClipID }
     }
 
     func clipSpeed(index: Int) -> Double {
@@ -550,8 +690,61 @@ extension TimelineEditState {
         statusMessage = "Split clip at \(formatPlaybackTime(splitTime))."
     }
 
+    private mutating func ensureCameraClips(duration: Double, fallback: FacecamSettings?) {
+        guard snapshot.cameraClips.isEmpty,
+              duration.isFinite,
+              duration > 0,
+              let fallback = fallback?.clamped else {
+            return
+        }
+
+        snapshot.cameraClips = [
+            TimelineCameraClip(
+                span: TimelineSpan(start: 0, end: duration),
+                settings: fallback
+            )
+        ]
+    }
+
+    private mutating func splitCameraClip(at currentTime: Double, duration: Double, fallback: FacecamSettings?) {
+        ensureCameraClips(duration: duration, fallback: fallback)
+        guard duration.isFinite, duration > 0, !snapshot.cameraClips.isEmpty else {
+            statusMessage = "Record with camera before splitting camera settings."
+            return
+        }
+
+        let minimumDistance = min(0.05, duration / 4)
+        let splitTime = min(max(currentTime, 0), duration)
+        guard splitTime > minimumDistance, splitTime < duration - minimumDistance else {
+            statusMessage = "Move the playhead inside the camera clip before splitting."
+            return
+        }
+
+        var clips = snapshot.resolvedCameraClips(duration: duration, fallback: fallback)
+        guard let index = clips.firstIndex(where: { splitTime > $0.span.start + minimumDistance && splitTime < $0.span.end - minimumDistance }) else {
+            statusMessage = "There is already a camera split at \(formatPlaybackTime(splitTime))."
+            return
+        }
+
+        let clip = clips[index]
+        let left = TimelineCameraClip(
+            id: clip.id,
+            span: TimelineSpan(start: clip.span.start, end: splitTime),
+            settings: clip.settings
+        )
+        let right = TimelineCameraClip(
+            span: TimelineSpan(start: splitTime, end: clip.span.end),
+            settings: clip.settings
+        )
+        clips.replaceSubrange(index...index, with: [left, right])
+        snapshot.cameraClips = clips
+        selectCameraClip(id: right.id)
+        statusMessage = "Split camera at \(formatPlaybackTime(splitTime))."
+    }
+
     private mutating func select(_ kind: TimelineRegionKind?, id: TimelineRegionID?) {
         selectedClipIndex = nil
+        selectedCameraClipID = nil
         guard let kind, let id else {
             selectedKind = nil
             selectedID = nil
@@ -564,13 +757,22 @@ extension TimelineEditState {
     private mutating func selectClip(index: Int) {
         selectedKind = nil
         selectedID = nil
+        selectedCameraClipID = nil
         selectedClipIndex = max(0, index)
+    }
+
+    private mutating func selectCameraClip(id: TimelineRegionID) {
+        selectedKind = nil
+        selectedID = nil
+        selectedClipIndex = nil
+        selectedCameraClipID = id
     }
 
     private mutating func clearSelection() {
         selectedKind = nil
         selectedID = nil
         selectedClipIndex = nil
+        selectedCameraClipID = nil
     }
 
     private mutating func deleteSelection(duration: Double? = nil) {
@@ -704,6 +906,48 @@ extension TimelineEditState {
         mutate(&snapshot.annotationRegions, id: id) { $0.text = text }
     }
 
+    private mutating func updateCameraClipSettings(id: TimelineRegionID, settings: FacecamSettings) {
+        mutate(&snapshot.cameraClips, id: id) { clip in
+            clip.settings = settings.clamped
+        }
+        selectedCameraClipID = id
+        statusMessage = "Updated camera settings."
+    }
+
+    private mutating func mergeCameraClip(id: TimelineRegionID, direction: TimelineCameraMergeDirection) {
+        let clips = snapshot.cameraClips.sorted { $0.span.start < $1.span.start }
+        guard let index = clips.firstIndex(where: { $0.id == id }) else { return }
+
+        let neighborIndex: Int
+        switch direction {
+        case .previous:
+            neighborIndex = index - 1
+        case .next:
+            neighborIndex = index + 1
+        }
+        guard clips.indices.contains(neighborIndex) else { return }
+
+        let selected = clips[index]
+        let neighbor = clips[neighborIndex]
+        let merged = TimelineCameraClip(
+            id: selected.id,
+            span: TimelineSpan(
+                start: min(selected.span.start, neighbor.span.start),
+                end: max(selected.span.end, neighbor.span.end)
+            ),
+            settings: selected.settings
+        )
+
+        var next = clips
+        for removeIndex in [index, neighborIndex].sorted(by: >) {
+            next.remove(at: removeIndex)
+        }
+        next.append(merged)
+        snapshot.cameraClips = next.sorted { $0.span.start < $1.span.start }
+        selectCameraClip(id: selected.id)
+        statusMessage = "Merged camera clips."
+    }
+
     private mutating func removeClipSplit(at splitTime: Double, duration: Double) {
         guard let index = snapshot.clipSplitTimes.firstIndex(where: { abs($0 - splitTime) < 0.001 }) else { return }
         let oldSegments = TimelineClipSegment.segments(
@@ -818,6 +1062,11 @@ final class TimelineEditDriver {
         set { state.snapshot.clipSpeeds = newValue }
     }
 
+    var cameraClips: [TimelineCameraClip] {
+        get { state.snapshot.cameraClips }
+        set { state.snapshot.cameraClips = newValue }
+    }
+
     var selectedKind: TimelineRegionKind? {
         get { state.selectedKind }
         set { state.selectedKind = newValue }
@@ -831,6 +1080,11 @@ final class TimelineEditDriver {
     var selectedClipIndex: Int? {
         get { state.selectedClipIndex }
         set { state.selectedClipIndex = newValue }
+    }
+
+    var selectedCameraClipID: TimelineRegionID? {
+        get { state.selectedCameraClipID }
+        set { state.selectedCameraClipID = newValue }
     }
 
     var statusMessage: String {
@@ -897,6 +1151,18 @@ final class TimelineEditDriver {
         send(.addClipSplit(currentTime: currentTime, duration: duration))
     }
 
+    func ensureCameraClips(duration: Double, fallback: FacecamSettings?) {
+        send(.ensureCameraClips(duration: duration, fallback: fallback), recordsUndo: false)
+    }
+
+    func splitCameraClip(at currentTime: Double, duration: Double, fallback: FacecamSettings?) {
+        send(.splitCameraClip(currentTime: currentTime, duration: duration, fallback: fallback))
+    }
+
+    func selectCameraClip(id: TimelineRegionID) {
+        send(.selectCameraClip(id), recordsUndo: false)
+    }
+
     func select(_ kind: TimelineRegionKind?, id: TimelineRegionID?) {
         send(.select(kind, id), recordsUndo: false)
     }
@@ -957,6 +1223,22 @@ final class TimelineEditDriver {
         state.selectedClip(duration: duration)
     }
 
+    func selectedCameraClip(duration: Double, fallback: FacecamSettings?) -> TimelineCameraClip? {
+        state.selectedCameraClip(duration: duration, fallback: fallback)
+    }
+
+    func resolvedCameraClips(duration: Double, fallback: FacecamSettings?) -> [TimelineCameraClip] {
+        state.snapshot.resolvedCameraClips(duration: duration, fallback: fallback)
+    }
+
+    func updateCameraClipSettings(id: TimelineRegionID, settings: FacecamSettings) {
+        send(.updateCameraClipSettings(id: id, settings: settings))
+    }
+
+    func mergeCameraClip(id: TimelineRegionID, direction: TimelineCameraMergeDirection) {
+        send(.mergeCameraClip(id: id, direction: direction))
+    }
+
     func removeClipSplit(at splitTime: Double, duration: Double) {
         send(.removeClipSplit(splitTime: splitTime, duration: duration))
     }
@@ -1007,6 +1289,7 @@ struct TimelineExportEditPlan: Equatable {
         boundaries.append(contentsOf: edits.trimRegions.flatMap { [$0.span.start, $0.span.end] })
         boundaries.append(contentsOf: edits.zoomRegions.flatMap { [$0.span.start, $0.span.end] })
         boundaries.append(contentsOf: edits.annotationRegions.flatMap { [$0.span.start, $0.span.end] })
+        boundaries.append(contentsOf: edits.cameraClips.flatMap { [$0.span.start, $0.span.end] })
         boundaries.append(contentsOf: edits.clipSplitTimes)
 
         let sorted = Set(boundaries.map { min(max($0, 0.0), duration) }).sorted()

--- a/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
@@ -358,7 +358,7 @@ enum TimelineEditEvent: Equatable {
     case select(TimelineRegionKind?, TimelineRegionID?)
     case selectClip(index: Int)
     case clearSelection
-    case deleteSelection
+    case deleteSelection(duration: Double?)
     case updateSpan(kind: TimelineRegionKind, id: TimelineRegionID, span: TimelineSpan, duration: Double)
     case cycleClipSpeed(index: Int)
     case cycleClipSpeedAt(currentTime: Double, duration: Double)
@@ -420,8 +420,8 @@ extension TimelineEditState {
             clearSelection()
             return []
 
-        case .deleteSelection:
-            deleteSelection()
+        case .deleteSelection(let duration):
+            deleteSelection(duration: duration)
             return []
 
         case .updateSpan(let kind, let id, let span, let duration):
@@ -573,7 +573,12 @@ extension TimelineEditState {
         selectedClipIndex = nil
     }
 
-    private mutating func deleteSelection() {
+    private mutating func deleteSelection(duration: Double? = nil) {
+        if let selectedClipIndex {
+            deleteSelectedClip(index: selectedClipIndex, duration: duration)
+            return
+        }
+
         guard let selectedKind, let selectedID else { return }
         switch selectedKind {
         case .zoom: snapshot.zoomRegions.removeAll { $0.id == selectedID }
@@ -582,6 +587,37 @@ extension TimelineEditState {
         }
         clearSelection()
         statusMessage = "Deleted \(selectedKind.title.lowercased())."
+    }
+
+    private mutating func deleteSelectedClip(index selectedClipIndex: Int, duration: Double?) {
+        guard let duration,
+              duration.isFinite,
+              duration > 0 else {
+            statusMessage = "Open a video before deleting a clip."
+            return
+        }
+
+        let segments = snapshot.clipSegments(duration: duration)
+        guard segments.indices.contains(selectedClipIndex) else {
+            clearSelection()
+            statusMessage = "Selected clip is no longer available."
+            return
+        }
+
+        let segment = segments[selectedClipIndex]
+        let deleteRegion = TimelineTrimRegion(span: segment.span.normalized(duration: duration))
+        var candidate = snapshot
+        candidate.trimRegions.append(deleteRegion)
+        candidate.trimRegions = mergedTrimRegions(candidate.trimRegions, duration: duration)
+
+        guard !TimelineExportEditPlan.build(duration: duration, edits: candidate).segments.isEmpty else {
+            statusMessage = "Cannot delete the only playable clip."
+            return
+        }
+
+        snapshot = candidate
+        clearSelection()
+        statusMessage = "Deleted clip \(segment.index + 1)."
     }
 
     private mutating func updateSpan(kind: TimelineRegionKind, id: TimelineRegionID, span: TimelineSpan, duration: Double) {
@@ -680,6 +716,35 @@ extension TimelineEditState {
         snapshot.clipSpeeds = remappedClipSpeeds(from: oldSegments, to: newSegments)
         clearSelection()
         statusMessage = "Removed split at \(formatPlaybackTime(splitTime))."
+    }
+
+    private func mergedTrimRegions(_ regions: [TimelineTrimRegion], duration: Double) -> [TimelineTrimRegion] {
+        let sorted = regions
+            .map { region in
+                var copy = region
+                copy.span = copy.span.normalized(duration: duration)
+                return copy
+            }
+            .filter { $0.span.duration > 0.001 }
+            .sorted { $0.span.start < $1.span.start }
+
+        return sorted.reduce(into: [TimelineTrimRegion]()) { result, region in
+            guard var last = result.popLast() else {
+                result.append(region)
+                return
+            }
+
+            if region.span.start <= last.span.end + 0.001 {
+                last.span = TimelineSpan(
+                    start: min(last.span.start, region.span.start),
+                    end: max(last.span.end, region.span.end)
+                ).normalized(duration: duration)
+                result.append(last)
+            } else {
+                result.append(last)
+                result.append(region)
+            }
+        }
     }
 
     private func canPlaceNonOverlapping(_ span: TimelineSpan, existing: [TimelineSpan]) -> Bool {
@@ -845,7 +910,11 @@ final class TimelineEditDriver {
     }
 
     func deleteSelection() {
-        send(.deleteSelection)
+        send(.deleteSelection(duration: nil))
+    }
+
+    func deleteSelection(duration: Double) {
+        send(.deleteSelection(duration: duration))
     }
 
     func updateSpan(kind: TimelineRegionKind, id: TimelineRegionID, span: TimelineSpan, duration: Double) {

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct TimelineSelectionSidebar: View {
     var edits: TimelineEditDriver
     var playback: VideoPlaybackController
+    var defaultCameraSettings: FacecamSettings?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -55,6 +56,8 @@ struct TimelineSelectionSidebar: View {
     private var selectionContent: some View {
         if let clip = edits.selectedClip(duration: playback.duration) {
             clipControls(clip)
+        } else if let cameraClip = edits.selectedCameraClip(duration: playback.duration, fallback: defaultCameraSettings) {
+            cameraControls(cameraClip)
         } else if let kind = edits.selectedKind, let id = edits.selectedID {
             regionControls(kind: kind, id: id)
         } else {
@@ -105,6 +108,60 @@ struct TimelineSelectionSidebar: View {
             if playback.duration - clip.end > 0.001 {
                 TimelineSelectionActionButton(title: "Merge Next", symbolName: "arrow.right.to.line") {
                     edits.removeClipSplit(at: clip.end, duration: playback.duration)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func cameraControls(_ clip: TimelineCameraClip) -> some View {
+        InspectorGroup(title: "Camera", symbolName: clip.settings.clamped.enabled ? "camera.fill" : "camera.slash.fill") {
+            TimelineSelectionInfoRow(title: "Start", value: formatPlaybackTime(clip.span.start))
+            TimelineSelectionInfoRow(title: "End", value: formatPlaybackTime(clip.span.end))
+            TimelineSelectionInfoRow(title: "Duration", value: formatClipDuration(clip.span.duration))
+        }
+
+        InspectorGroup(title: "Visibility", symbolName: "eye") {
+            InspectorSwitch(title: "Visible", isOn: cameraEnabledBinding(id: clip.id))
+        }
+
+        InspectorGroup(title: "Position", symbolName: "square.grid.3x3") {
+            PositionGrid(selection: cameraAnchorBinding(id: clip.id))
+        }
+
+        InspectorGroup(title: "Style", symbolName: "slider.horizontal.3") {
+            InspectorSlider(
+                title: "Size",
+                valueText: "\(Int(clip.settings.clamped.size.rounded()))%",
+                value: cameraSizeBinding(id: clip.id),
+                range: 12...40,
+                step: 1,
+                onEditingChanged: handleUndoTransaction
+            )
+            InspectorSlider(
+                title: "Border",
+                valueText: "\(Int(clip.settings.clamped.borderWidth.rounded()))px",
+                value: cameraBorderWidthBinding(id: clip.id),
+                range: 0...16,
+                step: 1,
+                onEditingChanged: handleUndoTransaction
+            )
+        }
+
+        InspectorGroup(title: "Split", symbolName: "timeline.selection") {
+            TimelineSelectionActionButton(title: "Split at Playhead", symbolName: "scissors") {
+                edits.splitCameraClip(at: playback.currentTime, duration: playback.duration, fallback: defaultCameraSettings)
+            }
+
+            if clip.span.start > 0.001 {
+                TimelineSelectionActionButton(title: "Merge Previous", symbolName: "arrow.left.to.line") {
+                    edits.mergeCameraClip(id: clip.id, direction: .previous)
+                }
+            }
+
+            if playback.duration - clip.span.end > 0.001 {
+                TimelineSelectionActionButton(title: "Merge Next", symbolName: "arrow.right.to.line") {
+                    edits.mergeCameraClip(id: clip.id, direction: .next)
                 }
             }
         }
@@ -172,6 +229,9 @@ struct TimelineSelectionSidebar: View {
         if let clip = edits.selectedClip(duration: playback.duration) {
             return "Selected Clip \(clip.index + 1)"
         }
+        if let clip = edits.selectedCameraClip(duration: playback.duration, fallback: defaultCameraSettings) {
+            return clip.settings.clamped.enabled ? "Selected Camera" : "Hidden Camera"
+        }
         if let kind = edits.selectedKind {
             return "Selected \(kind.title)"
         }
@@ -181,6 +241,9 @@ struct TimelineSelectionSidebar: View {
     private var selectionSubtitle: String {
         if let clip = edits.selectedClip(duration: playback.duration) {
             return "\(formatPlaybackTime(clip.start)) - \(formatPlaybackTime(clip.end)) @ \(TimelineClipSpeed.label(clip.speed))"
+        }
+        if let clip = edits.selectedCameraClip(duration: playback.duration, fallback: defaultCameraSettings) {
+            return "\(formatPlaybackTime(clip.span.start)) - \(formatPlaybackTime(clip.span.end))"
         }
         if let kind = edits.selectedKind, let id = edits.selectedID, let span = selectedRegionSpan(kind: kind, id: id) {
             return "\(formatPlaybackTime(span.start)) - \(formatPlaybackTime(span.end))"
@@ -192,12 +255,19 @@ struct TimelineSelectionSidebar: View {
         if edits.selectedClipIndex != nil {
             return Theme.timelineHandle
         }
+        if edits.selectedCameraClipID != nil {
+            return Theme.timelineCamera
+        }
         return edits.selectedKind?.accent ?? Theme.accent
     }
 
     private var selectionSymbolName: String {
         if edits.selectedClipIndex != nil {
             return "rectangle.on.rectangle"
+        }
+
+        if edits.selectedCameraClipID != nil {
+            return "camera.fill"
         }
 
         switch edits.selectedKind {
@@ -248,6 +318,40 @@ struct TimelineSelectionSidebar: View {
         Binding(
             get: { edits.clipSpeed(index: index) },
             set: { edits.updateClipSpeed(index: index, speed: $0) }
+        )
+    }
+
+    private func cameraEnabledBinding(id: TimelineRegionID) -> Binding<Bool> {
+        cameraBinding(id: id, keyPath: \.enabled, default: true)
+    }
+
+    private func cameraSizeBinding(id: TimelineRegionID) -> Binding<Double> {
+        cameraBinding(id: id, keyPath: \.size, default: defaultFacecamSettings(enabled: true).size)
+    }
+
+    private func cameraBorderWidthBinding(id: TimelineRegionID) -> Binding<Double> {
+        cameraBinding(id: id, keyPath: \.borderWidth, default: defaultFacecamSettings(enabled: true).borderWidth)
+    }
+
+    private func cameraAnchorBinding(id: TimelineRegionID) -> Binding<String> {
+        cameraBinding(id: id, keyPath: \.anchor, default: FacecamAnchor.bottomRight.rawValue)
+    }
+
+    private func cameraBinding<Value: Equatable>(
+        id: TimelineRegionID,
+        keyPath: WritableKeyPath<FacecamSettings, Value>,
+        default defaultValue: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: {
+                edits.cameraClips.first(where: { $0.id == id })?.settings[keyPath: keyPath] ?? defaultValue
+            },
+            set: { value in
+                guard var settings = edits.cameraClips.first(where: { $0.id == id })?.settings else { return }
+                guard settings[keyPath: keyPath] != value else { return }
+                settings[keyPath: keyPath] = value
+                edits.updateCameraClipSettings(id: id, settings: settings)
+            }
         )
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -68,9 +68,9 @@ struct TimelineSelectionSidebar: View {
                 edits.clearSelection()
             }
 
-            if edits.selectedKind != nil {
+            if edits.selectedKind != nil || edits.selectedClipIndex != nil {
                 TimelineSelectionActionButton(title: "Delete", symbolName: "trash", isDestructive: true) {
-                    edits.deleteSelection()
+                    edits.deleteSelection(duration: playback.duration)
                 }
             }
         }

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -20,12 +20,15 @@ enum TimelineMetrics {
         + rulerHeight
         + clipHeight
         + layerHeight
+        + layerHeight
 }
 
 struct TimelinePanel: View {
     var videoURL: URL?
     var playback: VideoPlaybackController
     var edits: TimelineEditDriver
+    var hasRecordedCamera: Bool
+    var defaultCameraSettings: FacecamSettings?
     @State private var timelineViewport = TimelineViewport(duration: 0)
     @State private var isDraggingTimelineZoom = false
     @FocusState private var isTimelineFocused: Bool
@@ -44,7 +47,14 @@ struct TimelinePanel: View {
                         isTimelineFocused = true
                     }
 
-                TimelineTrackContent(videoURL: videoURL, playback: playback, edits: edits, viewport: $timelineViewport)
+                TimelineTrackContent(
+                    videoURL: videoURL,
+                    playback: playback,
+                    edits: edits,
+                    hasRecordedCamera: hasRecordedCamera,
+                    defaultCameraSettings: defaultCameraSettings,
+                    viewport: $timelineViewport
+                )
                     .padding(.horizontal, TimelineMetrics.panelPadding)
                     .padding(.top, TimelineMetrics.trackTopPadding)
             }
@@ -71,9 +81,17 @@ struct TimelinePanel: View {
         }
         .onAppear {
             syncTimelineViewportDuration(playback.duration)
+            ensureCameraLayer()
         }
         .onChange(of: playback.duration) { _, newDuration in
             syncTimelineViewportDuration(newDuration)
+            ensureCameraLayer()
+        }
+        .onChange(of: hasRecordedCamera) { _, _ in
+            ensureCameraLayer()
+        }
+        .onChange(of: defaultCameraSettings) { _, _ in
+            ensureCameraLayer()
         }
         .onChange(of: playback.currentTime) { _, newTime in
             updateTimelineViewport(for: newTime)
@@ -132,6 +150,11 @@ struct TimelinePanel: View {
         }
     }
 
+    private func ensureCameraLayer() {
+        guard hasRecordedCamera else { return }
+        edits.ensureCameraClips(duration: playback.duration, fallback: defaultCameraSettings)
+    }
+
     private func deleteTimelineSelection() {
         edits.deleteSelection(duration: playback.duration)
     }
@@ -141,6 +164,8 @@ struct TimelineTrackContent: View {
     var videoURL: URL?
     var playback: VideoPlaybackController
     var edits: TimelineEditDriver
+    var hasRecordedCamera: Bool
+    var defaultCameraSettings: FacecamSettings?
     @Binding var viewport: TimelineViewport
     @State private var timelineSize = CGSize.zero
 
@@ -153,6 +178,14 @@ struct TimelineTrackContent: View {
                 }
             TimelineClipRow(videoURL: videoURL, duration: playback.duration, viewport: viewport, splitTimes: edits.clipSplitTimes, trimRegions: edits.trimRegions, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
             TimelineLayerRow(kind: .zoom, duration: playback.duration, viewport: viewport, regions: edits.zoomRegions.map(TimelineRegionRenderData.zoom), selectedID: edits.selectedKind == .zoom ? edits.selectedID : nil, edits: edits)
+            TimelineCameraLayerRow(
+                duration: playback.duration,
+                viewport: viewport,
+                hasRecordedCamera: hasRecordedCamera,
+                cameraClips: edits.resolvedCameraClips(duration: playback.duration, fallback: defaultCameraSettings),
+                selectedID: edits.selectedCameraClipID,
+                edits: edits
+            )
         }
         .overlay(alignment: .topLeading) { TimelinePlayhead(viewport: viewport, currentTime: playback.currentTime) }
         .readSize { timelineSize = $0 }
@@ -812,6 +845,122 @@ struct TimelineLayerRow: View {
         }
 
         edits.add(.zoom, at: time, duration: duration)
+    }
+}
+
+struct TimelineCameraLayerRow: View {
+    var duration: Double
+    var viewport: TimelineViewport
+    var hasRecordedCamera: Bool
+    var cameraClips: [TimelineCameraClip]
+    var selectedID: TimelineRegionID?
+    var edits: TimelineEditDriver
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .fill(Color(red: 0.095, green: 0.095, blue: 0.11))
+                    .rectangularHitTarget()
+                    .gesture(
+                        SpatialTapGesture()
+                            .onEnded { value in
+                                handleBackgroundTap(at: value.location, width: proxy.size.width)
+                            }
+                    )
+
+                if cameraClips.isEmpty {
+                    Text(emptyMessage)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.secondary.opacity(0.64))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                        .allowsHitTesting(false)
+                }
+
+                ForEach(cameraClips.filter { viewport.intersects($0.span) }) { clip in
+                    TimelineCameraClipItem(
+                        clip: clip,
+                        duration: duration,
+                        viewport: viewport,
+                        width: proxy.size.width,
+                        isSelected: clip.id == selectedID,
+                        edits: edits
+                    )
+                }
+            }
+            .rectangularHitTarget()
+            .clipped()
+        }
+        .frame(height: TimelineMetrics.layerHeight)
+        .overlay(alignment: .bottom) { Rectangle().fill(Theme.border).frame(height: 1) }
+    }
+
+    private var emptyMessage: String {
+        hasRecordedCamera ? "Camera settings unavailable" : "No camera recorded"
+    }
+
+    private func handleBackgroundTap(at location: CGPoint, width: CGFloat) {
+        guard hasRecordedCamera,
+              duration.isFinite,
+              duration > 0,
+              let time = TimelineSeekMapper.time(forX: location.x, viewport: viewport, width: width) else {
+            edits.clearSelection()
+            return
+        }
+
+        guard let clip = cameraClips.first(where: { time >= $0.span.start && (time < $0.span.end || $0.id == cameraClips.last?.id) }) else {
+            edits.clearSelection()
+            return
+        }
+        edits.selectCameraClip(id: clip.id)
+    }
+}
+
+private struct TimelineCameraClipItem: View {
+    var clip: TimelineCameraClip
+    var duration: Double
+    var viewport: TimelineViewport
+    var width: CGFloat
+    var isSelected: Bool
+    var edits: TimelineEditDriver
+
+    private var accent: Color {
+        clip.settings.clamped.enabled ? Theme.timelineCamera : Color.secondary.opacity(0.52)
+    }
+
+    var body: some View {
+        let startX = x(for: clip.span.start)
+        let itemWidth = max(1, x(for: clip.span.end) - startX)
+
+        RoundedRectangle(cornerRadius: 7, style: .continuous)
+            .fill(accent.opacity(clip.settings.clamped.enabled ? (isSelected ? 0.55 : 0.34) : 0.18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1)
+            }
+            .overlay { label(width: itemWidth) }
+            .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
+            .position(x: startX + itemWidth / 2, y: TimelineMetrics.layerHeight / 2)
+            .onTapGesture { edits.selectCameraClip(id: clip.id) }
+    }
+
+    private func label(width: CGFloat) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: clip.settings.clamped.enabled ? "camera.fill" : "camera.slash.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text(clip.settings.clamped.enabled ? "Camera" : "Hidden")
+                .font(.system(size: 10, weight: .bold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(.white.opacity(clip.settings.clamped.enabled ? 0.94 : 0.66))
+        .minimumScaleFactor(0.72)
+        .padding(.horizontal, 8)
+        .frame(maxWidth: max(1, width))
+        .allowsHitTesting(false)
+    }
+
+    private func x(for time: Double) -> CGFloat {
+        viewport.x(for: time, width: width, clamped: true) ?? 0
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -28,6 +28,7 @@ struct TimelinePanel: View {
     var edits: TimelineEditDriver
     @State private var timelineViewport = TimelineViewport(duration: 0)
     @State private var isDraggingTimelineZoom = false
+    @FocusState private var isTimelineFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,6 +41,7 @@ struct TimelinePanel: View {
                     .rectangularHitTarget()
                     .onTapGesture {
                         edits.clearSelection()
+                        isTimelineFocused = true
                     }
 
                 TimelineTrackContent(videoURL: videoURL, playback: playback, edits: edits, viewport: $timelineViewport)
@@ -49,10 +51,11 @@ struct TimelinePanel: View {
         }
         .studioEditorPaneChrome()
         .focusable()
+        .focused($isTimelineFocused)
         .focusEffectDisabled()
         .onKeyPress { press in
             if press.key == .delete || press.key == .deleteForward {
-                edits.deleteSelection()
+                deleteTimelineSelection()
                 return .handled
             }
 
@@ -62,6 +65,9 @@ struct TimelinePanel: View {
             case "t": edits.addClipSplit(at: playback.currentTime, duration: playback.duration); return .handled
             default: return .ignored
             }
+        }
+        .onDeleteCommand {
+            deleteTimelineSelection()
         }
         .onAppear {
             syncTimelineViewportDuration(playback.duration)
@@ -75,6 +81,10 @@ struct TimelinePanel: View {
         .onChange(of: playback.isPlaying) { _, isPlaying in
             guard isPlaying else { return }
             timelineViewport = timelineViewport.following(time: playback.currentTime)
+        }
+        .onChange(of: edits.state.hasSelection) { _, hasSelection in
+            guard hasSelection else { return }
+            isTimelineFocused = true
         }
     }
 
@@ -121,6 +131,10 @@ struct TimelinePanel: View {
             timelineViewport = timelineViewport.keepingVisible(time: currentTime)
         }
     }
+
+    private func deleteTimelineSelection() {
+        edits.deleteSelection(duration: playback.duration)
+    }
 }
 
 struct TimelineTrackContent: View {
@@ -137,7 +151,7 @@ struct TimelineTrackContent: View {
                 .onTapGesture {
                     edits.clearSelection()
                 }
-            TimelineClipRow(videoURL: videoURL, duration: playback.duration, viewport: viewport, splitTimes: edits.clipSplitTimes, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
+            TimelineClipRow(videoURL: videoURL, duration: playback.duration, viewport: viewport, splitTimes: edits.clipSplitTimes, trimRegions: edits.trimRegions, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
             TimelineLayerRow(kind: .zoom, duration: playback.duration, viewport: viewport, regions: edits.zoomRegions.map(TimelineRegionRenderData.zoom), selectedID: edits.selectedKind == .zoom ? edits.selectedID : nil, edits: edits)
         }
         .overlay(alignment: .topLeading) { TimelinePlayhead(viewport: viewport, currentTime: playback.currentTime) }
@@ -513,6 +527,7 @@ struct TimelineClipRow: View {
     var duration: Double
     var viewport: TimelineViewport
     var splitTimes: [Double]
+    var trimRegions: [TimelineTrimRegion]
     var clipSpeeds: [Int: Double]
     var selectedClipIndex: Int?
     var seek: (Double) -> Void
@@ -559,19 +574,20 @@ struct TimelineClipRow: View {
                 let startX = x(for: segment.start, width: width)
                 let endX = x(for: segment.end, width: width)
                 let segmentWidth = max(1, endX - startX - (segments.count > 1 ? 3 : 0))
-                clipBody(segment: segment, width: segmentWidth, isSelected: selectedClipIndex == segment.index)
+                clipBody(segment: segment, width: segmentWidth, isSelected: selectedClipIndex == segment.index, isDeleted: isDeleted(segment))
                     .frame(width: segmentWidth, height: TimelineMetrics.clipHeight)
                     .position(x: startX + (endX - startX) / 2, y: TimelineMetrics.clipHeight / 2)
             }
         }
     }
 
-    private func clipBody(segment: TimelineClipSegment, width: CGFloat, isSelected: Bool) -> some View {
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(Theme.timelineClip.opacity(isSelected ? 0.95 : 1))
-            .overlay { RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(isSelected ? Theme.timelineHandle.opacity(0.95) : Theme.timelineClipBorder, lineWidth: isSelected ? 2 : 1) }
+    private func clipBody(segment: TimelineClipSegment, width: CGFloat, isSelected: Bool, isDeleted: Bool) -> some View {
+        let foreground = isDeleted ? Color.white.opacity(0.48) : Theme.timelineClipForeground
+        return RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(isDeleted ? Color.secondary.opacity(isSelected ? 0.30 : 0.20) : Theme.timelineClip.opacity(isSelected ? 0.95 : 1))
+            .overlay { RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(isSelected ? Theme.timelineHandle.opacity(0.95) : (isDeleted ? Color.secondary.opacity(0.42) : Theme.timelineClipBorder), lineWidth: isSelected ? 2 : 1) }
             .overlay(alignment: .bottom) {
-                if let waveformSamples, !waveformSamples.isEmpty {
+                if let waveformSamples, !waveformSamples.isEmpty, !isDeleted {
                     TimelineWaveformPreview(samples: waveformSamples)
                         .frame(height: 24)
                         .padding(.horizontal, 14)
@@ -582,20 +598,26 @@ struct TimelineClipRow: View {
             .overlay(alignment: .center) {
                 if width > 82 {
                     VStack(spacing: 2) {
-                        Label("Clip \(segment.index + 1)", systemImage: "rectangle.on.rectangle")
+                        Label(isDeleted ? "Deleted" : "Clip \(segment.index + 1)", systemImage: isDeleted ? "trash" : "rectangle.on.rectangle")
                             .font(.system(size: 10, weight: .semibold))
                         Text("\(formatClipDuration(segment.end - segment.start)) @ \(TimelineClipSpeed.label(segment.speed))")
                             .font(.system(size: 10, weight: .semibold, design: .monospaced))
                     }
-                    .foregroundStyle(Theme.timelineClipForeground)
+                    .foregroundStyle(foreground)
                     .shadow(color: Theme.borderStrong, radius: 3, y: 1)
                     .allowsHitTesting(false)
                 }
             }
-            .overlay(alignment: .bottomLeading) { Text(formatPlaybackTime(segment.start)).font(.system(size: 8, weight: .medium, design: .monospaced)).foregroundStyle(Theme.timelineClipForeground.opacity(0.52)).padding(.leading, 9).padding(.bottom, 4) }
-            .overlay(alignment: .bottomTrailing) { Text(formatPlaybackTime(segment.end)).font(.system(size: 8, weight: .medium, design: .monospaced)).foregroundStyle(Theme.timelineClipForeground.opacity(0.52)).padding(.trailing, 9).padding(.bottom, 4) }
+            .overlay(alignment: .bottomLeading) { Text(formatPlaybackTime(segment.start)).font(.system(size: 8, weight: .medium, design: .monospaced)).foregroundStyle(foreground.opacity(0.52)).padding(.leading, 9).padding(.bottom, 4) }
+            .overlay(alignment: .bottomTrailing) { Text(formatPlaybackTime(segment.end)).font(.system(size: 8, weight: .medium, design: .monospaced)).foregroundStyle(foreground.opacity(0.52)).padding(.trailing, 9).padding(.bottom, 4) }
             .padding(.vertical, 5)
             .padding(.horizontal, 2)
+    }
+
+    private func isDeleted(_ segment: TimelineClipSegment) -> Bool {
+        trimRegions.contains { region in
+            region.span.start <= segment.start + 0.001 && region.span.end >= segment.end - 0.001
+        }
     }
 
     private func seek(to x: CGFloat, width: CGFloat) {

--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -114,40 +114,54 @@ final class VideoBackgroundCompositionInstruction: NSObject, AVVideoCompositionI
     let requiredSourceTrackIDs: [NSValue]?
     let passthroughTrackID: CMPersistentTrackID = kCMPersistentTrackID_Invalid
 
+    let sourceTrackID: CMPersistentTrackID
+    let facecamTrackID: CMPersistentTrackID?
     let styling: VideoBackgroundStyling
     let preferredTransform: CGAffineTransform
     let normalizedSize: CGSize
+    let facecamPreferredTransform: CGAffineTransform
+    let facecamNormalizedSize: CGSize
     let cropRect: CGRect
     let renderSize: CGSize
     let edits: TimelineEditSnapshot
     let editPlan: TimelineExportEditPlan
     let cursorTrack: CursorTelemetryTrack?
     let cursorSettings: CursorOverlaySettings
+    let facecamFallbackSettings: FacecamSettings?
 
     init(
         timeRange: CMTimeRange,
         trackID: CMPersistentTrackID,
+        facecamTrackID: CMPersistentTrackID? = nil,
         styling: VideoBackgroundStyling,
         preferredTransform: CGAffineTransform,
         normalizedSize: CGSize,
+        facecamPreferredTransform: CGAffineTransform = .identity,
+        facecamNormalizedSize: CGSize = .zero,
         cropRect: CGRect,
         renderSize: CGSize,
         edits: TimelineEditSnapshot = .empty,
         editPlan: TimelineExportEditPlan = TimelineExportEditPlan(segments: [], outputDuration: 0),
         cursorTrack: CursorTelemetryTrack? = nil,
-        cursorSettings: CursorOverlaySettings = .hidden
+        cursorSettings: CursorOverlaySettings = .hidden,
+        facecamFallbackSettings: FacecamSettings? = nil
     ) {
         self.timeRange = timeRange
-        self.requiredSourceTrackIDs = [NSNumber(value: trackID)]
+        self.sourceTrackID = trackID
+        self.facecamTrackID = facecamTrackID
+        self.requiredSourceTrackIDs = ([trackID] + (facecamTrackID.map { [$0] } ?? [])).map { NSNumber(value: $0) }
         self.styling = styling
         self.preferredTransform = preferredTransform
         self.normalizedSize = normalizedSize
+        self.facecamPreferredTransform = facecamPreferredTransform
+        self.facecamNormalizedSize = facecamNormalizedSize
         self.cropRect = cropRect
         self.renderSize = renderSize
         self.edits = edits
         self.editPlan = editPlan
         self.cursorTrack = cursorTrack
         self.cursorSettings = cursorSettings.clamped
+        self.facecamFallbackSettings = facecamFallbackSettings?.clamped
         super.init()
     }
 }
@@ -174,8 +188,7 @@ private struct CursorGlyphImage {
 }
 
 private struct CursorGlyphCacheKey: Hashable {
-    var style: CursorStyle
-    var variant: CursorVariant
+    var styleID: CursorStyleID
     var sizeKey: Int
 }
 
@@ -240,11 +253,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
             throw VideoCompositorError.missingInstruction
         }
 
-        guard let trackIDValue = instruction.requiredSourceTrackIDs?.first as? NSNumber else {
-            throw VideoCompositorError.missingSourceFrame
-        }
-        let trackID = CMPersistentTrackID(trackIDValue.int32Value)
-        guard let sourceBuffer = request.sourceFrame(byTrackID: trackID) else {
+        guard let sourceBuffer = request.sourceFrame(byTrackID: instruction.sourceTrackID) else {
             throw VideoCompositorError.missingSourceFrame
         }
 
@@ -254,6 +263,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
 
         let composedImage = try makeComposedImage(
             source: sourceBuffer,
+            facecam: instruction.facecamTrackID.flatMap { request.sourceFrame(byTrackID: $0) },
             instruction: instruction,
             compositionTime: request.compositionTime.seconds
         )
@@ -270,6 +280,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
 
     private func makeComposedImage(
         source: CVPixelBuffer,
+        facecam: CVPixelBuffer?,
         instruction: VideoBackgroundCompositionInstruction,
         compositionTime: Double
     ) throws -> CIImage {
@@ -368,8 +379,90 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         if let cursor = makeCursorLayer(for: instruction, compositionTime: compositionTime, contentRect: contentRect) {
             composed = cursor.composited(over: composed)
         }
+        if let facecam = makeFacecamLayer(
+            facecam,
+            for: instruction,
+            compositionTime: compositionTime
+        ) {
+            composed = facecam.composited(over: composed)
+        }
 
         return composed.cropped(to: renderRect)
+    }
+
+    private func makeFacecamLayer(
+        _ facecam: CVPixelBuffer?,
+        for instruction: VideoBackgroundCompositionInstruction,
+        compositionTime: Double
+    ) -> CIImage? {
+        guard let facecam,
+              instruction.facecamTrackID != nil else {
+            return nil
+        }
+
+        let sourceTime = instruction.editPlan.sourceTime(forOutputTime: compositionTime) ?? compositionTime
+        guard let settings = instruction.edits.activeCameraSettings(
+            at: sourceTime,
+            duration: max(instruction.editPlan.segments.last?.sourceEnd ?? instruction.timeRange.duration.seconds, 0),
+            fallback: instruction.facecamFallbackSettings
+        ) else {
+            return nil
+        }
+
+        let renderSize = instruction.renderSize
+        let topLeftFrame = FacecamOverlayLayout.frame(in: renderSize, settings: settings)
+        guard !topLeftFrame.isEmpty else { return nil }
+
+        let frame = CGRect(
+            x: topLeftFrame.minX,
+            y: renderSize.height - topLeftFrame.maxY,
+            width: topLeftFrame.width,
+            height: topLeftFrame.height
+        )
+        let radius = facecamCornerRadius(for: frame, settings: settings)
+
+        var image = CIImage(cvPixelBuffer: facecam)
+        image = image.transformed(by: instruction.facecamPreferredTransform)
+        let normalizedRect = image.extent
+        let normalizedSize = instruction.facecamNormalizedSize == .zero
+            ? CGSize(width: max(normalizedRect.width, 1), height: max(normalizedRect.height, 1))
+            : instruction.facecamNormalizedSize
+        image = image
+            .cropped(to: CGRect(origin: normalizedRect.origin, size: normalizedSize))
+            .transformed(by: CGAffineTransform(translationX: -normalizedRect.minX, y: -normalizedRect.minY))
+
+        let scale = max(frame.width / max(normalizedSize.width, 1), frame.height / max(normalizedSize.height, 1))
+        image = image.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let dx = frame.midX - image.extent.midX
+        let dy = frame.midY - image.extent.midY
+        image = image.transformed(by: CGAffineTransform(translationX: dx, y: dy))
+        let clipped = applyRoundedMask(image.cropped(to: frame), cornerRadius: radius, in: frame)
+
+        guard settings.clamped.borderWidth > 0 else {
+            return clipped
+        }
+
+        let borderColor = SerializableColor(hex: settings.clamped.borderColor)
+        let border = makeRoundedStroke(
+            color: CIColor(
+                red: CGFloat(borderColor.red),
+                green: CGFloat(borderColor.green),
+                blue: CGFloat(borderColor.blue),
+                alpha: CGFloat(borderColor.alpha)
+            ),
+            lineWidth: CGFloat(settings.clamped.borderWidth),
+            in: frame,
+            cornerRadius: radius
+        )
+        return border.composited(over: clipped)
+    }
+
+    private func facecamCornerRadius(for frame: CGRect, settings: FacecamSettings) -> CGFloat {
+        if settings.clamped.isCircle {
+            return min(frame.width, frame.height) / 2
+        }
+
+        return min(CGFloat(settings.clamped.cornerRadius), min(frame.width, frame.height) / 2)
     }
 
     private func sourceLayout(frameRect: CGRect, styling: VideoBackgroundStyling) -> VideoInsetLayout {
@@ -420,8 +513,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         )
         guard let glyph = cursorGlyphImage(
             size: cursorSize,
-            style: settings.style,
-            variant: settings.variant
+            styleID: settings.styleID
         ) else {
             return nil
         }
@@ -470,22 +562,17 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         return point
     }
 
-    private func cursorGlyphImage(size: CGFloat, style: CursorStyle, variant: CursorVariant) -> CursorGlyphImage? {
-        let resolvedVariant = style.resolvedVariant(variant)
+    private func cursorGlyphImage(size: CGFloat, styleID: CursorStyleID) -> CursorGlyphImage? {
+        let resolvedStyleID = CursorStyleRegistry.resolvedStyleID(styleID)
         let cacheKey = CursorGlyphCacheKey(
-            style: style,
-            variant: resolvedVariant,
+            styleID: resolvedStyleID,
             sizeKey: Int((size * 10).rounded())
         )
         if let cached = cursorGlyphCache[cacheKey] {
             return cached
         }
 
-        guard let rendered = CursorPresetRenderer.renderedGlyph(
-            style: style,
-            variant: resolvedVariant,
-            size: size
-        ) else {
+        guard let rendered = CursorStyleRenderer.renderedGlyph(styleID: resolvedStyleID, size: size) else {
             return nil
         }
 
@@ -511,6 +598,56 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     private func makeRoundedFill(color: CIColor, in rect: CGRect, cornerRadius: CGFloat) -> CIImage {
         let fill = CIImage(color: color).cropped(to: rect)
         return applyRoundedMask(fill, cornerRadius: cornerRadius, in: rect)
+    }
+
+    private func makeRoundedStroke(color: CIColor, lineWidth: CGFloat, in rect: CGRect, cornerRadius: CGFloat) -> CIImage {
+        let width = max(Int(ceil(rect.width + lineWidth * 2)), 1)
+        let height = max(Int(ceil(rect.height + lineWidth * 2)), 1)
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return CIImage(color: color).cropped(to: .zero)
+        }
+
+        context.setStrokeColor(CGColor(
+            srgbRed: color.red,
+            green: color.green,
+            blue: color.blue,
+            alpha: color.alpha
+        ))
+        context.setLineWidth(lineWidth)
+        let inset = lineWidth / 2
+        let drawRect = CGRect(
+            x: lineWidth,
+            y: lineWidth,
+            width: max(1, rect.width - lineWidth),
+            height: max(1, rect.height - lineWidth)
+        ).insetBy(dx: inset, dy: inset)
+        context.addPath(CGPath(
+            roundedRect: drawRect,
+            cornerWidth: max(0, cornerRadius - inset),
+            cornerHeight: max(0, cornerRadius - inset),
+            transform: nil
+        ))
+        context.strokePath()
+
+        guard let cgImage = context.makeImage() else {
+            return CIImage(color: color).cropped(to: .zero)
+        }
+
+        return CIImage(cgImage: cgImage).transformed(
+            by: CGAffineTransform(
+                translationX: rect.minX - lineWidth,
+                y: rect.minY - lineWidth
+            )
+        )
     }
 
     private static func coreImageCropRect(fromTopLeftRect rect: CGRect, sourceSize: CGSize) -> CGRect {

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -192,6 +192,9 @@ struct VideoExportOptions: Equatable {
     var customOutputSize: CGSize?
     var cursorOverlay: CursorOverlaySettings = .hidden
     var cursorTelemetryURL: URL? = nil
+    var facecamVideoURL: URL? = nil
+    var facecamOffsetMs: Int? = nil
+    var facecamFallbackSettings: FacecamSettings? = nil
 
     static let `default` = VideoExportOptions(
         resolution: VideoExportResolution.defaultExportOption,
@@ -202,7 +205,10 @@ struct VideoExportOptions: Equatable {
         cropSelection: nil,
         customOutputSize: nil,
         cursorOverlay: .hidden,
-        cursorTelemetryURL: nil
+        cursorTelemetryURL: nil,
+        facecamVideoURL: nil,
+        facecamOffsetMs: nil,
+        facecamFallbackSettings: nil
     )
 
     func with(
@@ -259,6 +265,14 @@ struct VideoExportOptions: Equatable {
         var copy = self
         copy.cursorOverlay = settings.clamped
         copy.cursorTelemetryURL = telemetryURL
+        return copy
+    }
+
+    func withFacecam(url: URL?, offsetMs: Int?, fallbackSettings: FacecamSettings?) -> VideoExportOptions {
+        var copy = self
+        copy.facecamVideoURL = url
+        copy.facecamOffsetMs = offsetMs
+        copy.facecamFallbackSettings = fallbackSettings?.clamped
         return copy
     }
 }
@@ -353,7 +367,13 @@ enum VideoExportRenderer {
             .flatMap { try? CursorTelemetryPayload.load(from: $0) }
             .map(CursorTelemetryTrack.init(payload:))
 
-        let exportAsset = try await makeEditedAsset(from: asset, duration: duration, edits: edits)
+        let exportAsset = try await makeEditedAsset(
+            from: asset,
+            duration: duration,
+            edits: edits,
+            facecamURL: options.facecamVideoURL,
+            facecamOffsetMs: options.facecamOffsetMs
+        )
 
         guard let exportSession = AVAssetExportSession(asset: exportAsset.asset, presetName: AVAssetExportPresetHighestQuality) else {
             throw VideoExportRendererError.exportSessionUnavailable
@@ -374,7 +394,11 @@ enum VideoExportRenderer {
             edits: edits,
             editPlan: exportAsset.plan,
             cursorTrack: cursorTrack,
-            cursorSettings: options.cursorOverlay
+            cursorSettings: options.cursorOverlay,
+            facecamTrack: exportAsset.facecamVideoTrack,
+            facecamPreferredTransform: exportAsset.facecamPreferredTransform,
+            facecamNormalizedSize: exportAsset.facecamNormalizedSize,
+            facecamFallbackSettings: options.facecamFallbackSettings
         )
 
         if Task.isCancelled {
@@ -428,14 +452,26 @@ enum VideoExportRenderer {
     private struct EditedAsset {
         var asset: AVAsset
         var videoTrack: AVAssetTrack?
+        var facecamVideoTrack: AVAssetTrack?
+        var facecamPreferredTransform: CGAffineTransform = .identity
+        var facecamNormalizedSize: CGSize = .zero
         var duration: Double
         var plan: TimelineExportEditPlan
     }
 
-    private static func makeEditedAsset(from asset: AVAsset, duration: CMTime, edits: TimelineEditSnapshot) async throws -> EditedAsset {
+    private static func makeEditedAsset(
+        from asset: AVAsset,
+        duration: CMTime,
+        edits: TimelineEditSnapshot,
+        facecamURL: URL?,
+        facecamOffsetMs: Int?
+    ) async throws -> EditedAsset {
         let sourceDuration = max(0, duration.seconds)
         let plan = TimelineExportEditPlan.build(duration: sourceDuration, edits: edits)
-        guard edits.trimRegions.isEmpty == false || edits.hasClipSpeedEdits else {
+        let facecamAsset = facecamURL.map { AVURLAsset(url: $0) }
+        let facecamTracks = try await facecamAsset?.loadTracks(withMediaType: .video) ?? []
+        let facecamSourceTrack = facecamTracks.first
+        guard edits.trimRegions.isEmpty == false || edits.hasClipSpeedEdits || facecamSourceTrack != nil else {
             return EditedAsset(asset: asset, videoTrack: nil, duration: sourceDuration, plan: plan)
         }
         guard plan.segments.isEmpty == false else {
@@ -471,9 +507,49 @@ enum VideoExportRenderer {
             }
         }
 
+        var compositionFacecamTrack: AVMutableCompositionTrack?
+        var facecamPreferredTransform = CGAffineTransform.identity
+        var facecamNormalizedSize = CGSize.zero
+        if let facecamAsset,
+           let facecamSourceTrack {
+            let facecamDuration = max(0, (try? await facecamAsset.load(.duration).seconds) ?? 0)
+            facecamPreferredTransform = (try? await facecamSourceTrack.load(.preferredTransform)) ?? .identity
+            let facecamNaturalSize = (try? await facecamSourceTrack.load(.naturalSize)) ?? .zero
+            facecamNormalizedSize = normalizedSize(for: facecamNaturalSize, preferredTransform: facecamPreferredTransform)
+            let offsetSeconds = Double(facecamOffsetMs ?? 0) / 1000
+            let facecamTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+            compositionFacecamTrack = facecamTrack
+            facecamTrack?.preferredTransform = facecamPreferredTransform
+
+            for segment in plan.segments {
+                let sourceFaceStart = segment.sourceStart - offsetSeconds
+                let sourceFaceEnd = segment.sourceEnd - offsetSeconds
+                let clippedStart = max(0, sourceFaceStart)
+                let clippedEnd = min(facecamDuration, sourceFaceEnd)
+                guard clippedEnd - clippedStart > 0.001 else { continue }
+
+                let speed = max(0.05, segment.speed)
+                let outputStartSeconds = segment.outputStart + (clippedStart - sourceFaceStart) / speed
+                let sourceRange = CMTimeRange(
+                    start: CMTime(seconds: clippedStart, preferredTimescale: 600),
+                    end: CMTime(seconds: clippedEnd, preferredTimescale: 600)
+                )
+                let outputStart = CMTime(seconds: outputStartSeconds, preferredTimescale: 600)
+                try facecamTrack?.insertTimeRange(sourceRange, of: facecamSourceTrack, at: outputStart)
+                let outputRange = CMTimeRange(start: outputStart, duration: sourceRange.duration)
+                facecamTrack?.scaleTimeRange(
+                    outputRange,
+                    toDuration: CMTime(seconds: (clippedEnd - clippedStart) / speed, preferredTimescale: 600)
+                )
+            }
+        }
+
         return EditedAsset(
             asset: composition,
             videoTrack: compositionVideoTrack,
+            facecamVideoTrack: compositionFacecamTrack,
+            facecamPreferredTransform: facecamPreferredTransform,
+            facecamNormalizedSize: facecamNormalizedSize,
             duration: plan.outputDuration,
             plan: plan
         )
@@ -560,7 +636,11 @@ enum VideoExportRenderer {
         edits: TimelineEditSnapshot = .empty,
         editPlan: TimelineExportEditPlan = TimelineExportEditPlan(segments: [], outputDuration: 0),
         cursorTrack: CursorTelemetryTrack? = nil,
-        cursorSettings: CursorOverlaySettings = .hidden
+        cursorSettings: CursorOverlaySettings = .hidden,
+        facecamTrack: AVAssetTrack? = nil,
+        facecamPreferredTransform: CGAffineTransform = .identity,
+        facecamNormalizedSize: CGSize = .zero,
+        facecamFallbackSettings: FacecamSettings? = nil
     ) -> AVMutableVideoComposition {
         let naturalRect = CGRect(origin: .zero, size: sourceSize).applying(preferredTransform)
         let normalizedTransform = preferredTransform.translatedBy(x: -naturalRect.origin.x, y: -naturalRect.origin.y)
@@ -579,7 +659,7 @@ enum VideoExportRenderer {
             .concatenating(CGAffineTransform(scaleX: scale, y: scale))
             .concatenating(translation)
 
-        if styling.isPassthrough {
+        if styling.isPassthrough, facecamTrack == nil {
             let instruction = AVMutableVideoCompositionInstruction()
             instruction.timeRange = CMTimeRange(start: .zero, duration: duration)
 
@@ -614,15 +694,19 @@ enum VideoExportRenderer {
         let instruction = VideoBackgroundCompositionInstruction(
             timeRange: CMTimeRange(start: .zero, duration: duration),
             trackID: videoTrack.trackID,
+            facecamTrackID: facecamTrack?.trackID,
             styling: styling,
             preferredTransform: normalizedTransform,
             normalizedSize: normalizedSize,
+            facecamPreferredTransform: facecamPreferredTransform,
+            facecamNormalizedSize: facecamNormalizedSize,
             cropRect: clampedCropRect,
             renderSize: outputSize,
             edits: edits,
             editPlan: editPlan,
             cursorTrack: cursorTrack,
-            cursorSettings: cursorSettings
+            cursorSettings: cursorSettings,
+            facecamFallbackSettings: facecamFallbackSettings
         )
 
         let composition = AVMutableVideoComposition()
@@ -653,6 +737,7 @@ enum VideoExportRenderer {
     nonisolated static func needsFinalCanvasOverlayTool(edits: TimelineEditSnapshot, cursorTrack: CursorTelemetryTrack?, cursorSettings: CursorOverlaySettings) -> Bool {
         edits.zoomRegions.isEmpty == false ||
             edits.annotationRegions.isEmpty == false ||
+            edits.cameraClips.isEmpty == false ||
             (cursorSettings.clamped.isVisible && cursorTrack?.samples.isEmpty == false)
     }
 
@@ -786,11 +871,7 @@ enum VideoExportRenderer {
             settings: resolvedSettings
         )
         let cursorLayer = CALayer()
-        guard let glyph = CursorPresetRenderer.renderedGlyph(
-            style: resolvedSettings.style,
-            variant: resolvedSettings.variant,
-            size: cursorSize
-        ) else {
+        guard let glyph = CursorStyleRenderer.renderedGlyph(styleID: resolvedSettings.styleID, size: cursorSize) else {
             return cursorLayer
         }
         cursorLayer.bounds = CGRect(origin: .zero, size: glyph.canvasSize)

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -78,6 +78,7 @@ struct VideoPreviewPanel: View {
     var cursorSettings: CursorOverlaySettings = .hidden
     var cropSelection: VideoCropSelection = .fullFrame
     var facecamSettings: FacecamSettings?
+    var cameraTimelineFallback: FacecamSettings?
     @Binding var previewAspectPreset: VideoPreviewAspectPreset
     var onCropVideo: () -> Void = {}
     var onRequestClearSelection: () -> Void = {}
@@ -212,7 +213,7 @@ struct VideoPreviewPanel: View {
                         cropSelection: cropSelection,
                         facecamURL: facecamVideoURL,
                         facecamOffsetMs: recordingSession?.facecamOffsetMs,
-                        facecamSettings: resolvedFacecamSettings,
+                        cameraFallbackSettings: resolvedFacecamSettings,
                         sourceSize: playback.naturalVideoSize,
                         letterboxFill: previewLetterboxFill
                     )
@@ -255,14 +256,22 @@ struct VideoPreviewPanel: View {
         guard facecamVideoURL != nil else {
             return nil
         }
-        return (facecamSettings ?? recordingSession?.facecamSettings ?? defaultFacecamSettings(enabled: true)).clamped
+        return (cameraTimelineFallback ?? facecamSettings ?? recordingSession?.facecamSettings ?? defaultFacecamSettings(enabled: true)).clamped
+    }
+
+    private var activeFacecamSettings: FacecamSettings? {
+        timelineEdits.snapshot.activeCameraSettings(
+            at: playback.currentTime,
+            duration: playback.duration,
+            fallback: resolvedFacecamSettings
+        )
     }
 
     @ViewBuilder
     private var recordingSessionBadges: some View {
         if let recordingSession,
            recordingSession.hasRecordedCamera,
-           resolvedFacecamSettings?.enabled != true {
+           activeFacecamSettings?.enabled != true {
             Label("Facecam captured", systemImage: "video.fill")
                 .font(.system(size: 11, weight: .semibold))
                 .padding(.horizontal, 10)
@@ -565,7 +574,7 @@ struct PlaybackPreview: View {
     var cropSelection: VideoCropSelection = .fullFrame
     var facecamURL: URL?
     var facecamOffsetMs: Int?
-    var facecamSettings: FacecamSettings?
+    var cameraFallbackSettings: FacecamSettings?
     var sourceSize: CGSize = .zero
     var letterboxFill: VideoPreviewLetterboxFill = .black
 
@@ -612,8 +621,7 @@ struct PlaybackPreview: View {
                     .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
 
                 if let facecamURL,
-                   let facecamSettings,
-                   facecamSettings.clamped.enabled {
+                   let facecamSettings = activeFacecamSettings {
                     FacecamPlaybackOverlay(
                         facecamURL: facecamURL,
                         screenPlayback: playback,
@@ -658,6 +666,14 @@ struct PlaybackPreview: View {
                     .shadow(color: .black.opacity(0.45), radius: 8, y: 4)
             }
         }
+    }
+
+    private var activeFacecamSettings: FacecamSettings? {
+        edits.activeCameraSettings(
+            at: playback.currentTime,
+            duration: playback.duration,
+            fallback: cameraFallbackSettings
+        )
     }
 }
 
@@ -886,8 +902,7 @@ private struct CursorOverlayView: View {
             if let point = currentPoint(in: proxy.size) {
                 let resolvedSettings = settings.clamped
                 CursorGlyphView(
-                    style: resolvedSettings.style,
-                    variant: resolvedSettings.variant,
+                    styleID: resolvedSettings.styleID,
                     scale: resolvedSettings.size,
                     glyphSize: cursorGlyphSize(in: proxy.size, settings: resolvedSettings),
                     alignsHotspot: true

--- a/apps/macos/Tests/OpenRecorderMacTests/CursorOverlaySettingsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CursorOverlaySettingsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class CursorOverlaySettingsTests: XCTestCase {
-    func testLegacyCursorSettingsDecodeDefaultStyleAndVariant() throws {
+    func testLegacyCursorSettingsDecodeDefaultStyleID() throws {
         let data = """
         {
           "isVisible": true,
@@ -15,19 +15,20 @@ final class CursorOverlaySettingsTests: XCTestCase {
 
         let settings = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
 
-        XCTAssertEqual(settings.style, .arrow)
-        XCTAssertEqual(settings.variant, .standard)
+        XCTAssertEqual(settings.styleID, CursorStyleRegistry.defaultStyleID)
         XCTAssertEqual(settings.size, 1.5)
     }
 
-    func testCursorSettingsRoundTripStyleAndVariant() throws {
+    func testCursorSettingsRoundTripStyleIDAndEffects() throws {
         let settings = CursorOverlaySettings(
             isVisible: true,
             loops: true,
             size: 8,
             smoothing: 0.8,
-            style: .outlineArrow,
-            variant: .bold
+            styleID: "touch.dot",
+            clickEffect: .ripple,
+            idleBehavior: .fadeWhenIdle,
+            motionEffect: .subtleLean
         )
 
         let data = try JSONEncoder().encode(settings)
@@ -36,22 +37,37 @@ final class CursorOverlaySettingsTests: XCTestCase {
         XCTAssertEqual(decoded, settings)
     }
 
-    func testLegacyColorVariantNamesMapToShapeVariants() throws {
+    func testLegacyStyleAndVariantNamesFallBackToDefaultStyleID() throws {
         let data = """
         {
           "isVisible": true,
           "loops": false,
           "size": 1,
           "smoothing": 0.4,
-          "style": "handPointer",
-          "variant": "highContrast"
+          "style": "dotPointer",
+          "variant": "soft"
         }
         """.data(using: .utf8)!
 
         let settings = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
 
-        XCTAssertEqual(settings.style, .handPointer)
-        XCTAssertEqual(settings.variant, .bold)
+        XCTAssertEqual(settings.styleID, CursorStyleRegistry.defaultStyleID)
+    }
+
+    func testUnknownStyleIDFallsBackToDefaultStyleID() throws {
+        let data = """
+        {
+          "isVisible": true,
+          "loops": false,
+          "size": 1,
+          "smoothing": 0.4,
+          "styleID": "future.missing"
+        }
+        """.data(using: .utf8)!
+
+        let settings = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
+
+        XCTAssertEqual(settings.styleID, CursorStyleRegistry.defaultStyleID)
     }
 
     func testCursorSizeClampsWhenCreatedAndDecoded() throws {
@@ -64,15 +80,14 @@ final class CursorOverlaySettingsTests: XCTestCase {
           "loops": false,
           "size": 12,
           "smoothing": 0.4,
-          "style": "arrow",
-          "variant": "dark"
+          "styleID": "system.black"
         }
         """.data(using: .utf8)!
 
         let decoded = try JSONDecoder().decode(CursorOverlaySettings.self, from: data)
 
         XCTAssertEqual(decoded.size, 8)
-        XCTAssertEqual(decoded.variant, .slim)
+        XCTAssertEqual(decoded.styleID, "system.black")
     }
 
     func testCursorOverlayGeometryUsesSourceSizedDefaultAtFullScale() {
@@ -126,60 +141,39 @@ final class CursorOverlaySettingsTests: XCTestCase {
 
         let state = try JSONDecoder().decode(ProjectVideoEditorState.self, from: data)
 
-        XCTAssertEqual(state.cursorOverlay.style, .arrow)
-        XCTAssertEqual(state.cursorOverlay.variant, .standard)
+        XCTAssertEqual(state.cursorOverlay.styleID, CursorStyleRegistry.defaultStyleID)
         XCTAssertEqual(state.cursorOverlay.size, 2)
     }
 
     func testCursorRendererHotspotsMatchStyleRules() {
         let size: CGFloat = 24
-        let arrow = CursorPresetRenderer.drawing(style: .arrow, size: size)
-        let macOSBlack = CursorPresetRenderer.drawing(style: .macOSBlackArrow, size: size)
-        let outline = CursorPresetRenderer.drawing(style: .outlineArrow, size: size)
-        let hand = CursorPresetRenderer.drawing(style: .handPointer, size: size)
-        let iBeam = CursorPresetRenderer.drawing(style: .iBeam, size: size)
-        let dot = CursorPresetRenderer.drawing(style: .dotPointer, size: size)
+        let arrow = CursorStyleRenderer.drawing(styleID: "system.white", size: size)
+        let blackArrow = CursorStyleRenderer.drawing(styleID: "system.black", size: size)
+        let hand = CursorStyleRenderer.drawing(styleID: "system.hand", size: size)
+        let iBeam = CursorStyleRenderer.drawing(styleID: "system.ibeam", size: size)
+        let dot = CursorStyleRenderer.drawing(styleID: "touch.dot", size: size)
 
         XCTAssertEqual(arrow.hotspot.x, 0, accuracy: 0.001)
         XCTAssertEqual(arrow.hotspot.y, 0, accuracy: 0.001)
-        XCTAssertEqual(macOSBlack.hotspot.x, 0, accuracy: 0.001)
-        XCTAssertEqual(macOSBlack.hotspot.y, 0, accuracy: 0.001)
-        XCTAssertEqual(outline.hotspot.x, 0, accuracy: 0.001)
-        XCTAssertEqual(outline.hotspot.y, 0, accuracy: 0.001)
+        XCTAssertEqual(blackArrow.hotspot.x, 0, accuracy: 0.001)
+        XCTAssertEqual(blackArrow.hotspot.y, 0, accuracy: 0.001)
         XCTAssertEqual(hand.hotspot.x, size * 0.54, accuracy: 0.001)
         XCTAssertEqual(hand.hotspot.y, size * 0.02, accuracy: 0.001)
         XCTAssertEqual(iBeam.hotspot.x, size * 0.50, accuracy: 0.001)
         XCTAssertEqual(iBeam.hotspot.y, size * 0.60, accuracy: 0.001)
-        XCTAssertEqual(dot.hotspot.x, size * 0.45, accuracy: 0.001)
-        XCTAssertEqual(dot.hotspot.y, size * 0.45, accuracy: 0.001)
+        XCTAssertEqual(dot.hotspot.x, size * 1.08 * 0.45, accuracy: 0.001)
+        XCTAssertEqual(dot.hotspot.y, size * 1.08 * 0.45, accuracy: 0.001)
     }
 
-    func testCursorVariantsChangeShapeGeometryWithoutChangingPalette() {
-        let size: CGFloat = 24
-        let standardArrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .standard)
-        let slimArrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .slim)
-        let boldArrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .bold)
-        let softDot = CursorPresetRenderer.drawing(style: .dotPointer, size: size, variant: .soft)
+    func testCursorRegistryHasUniqueRenderableStyles() {
+        let ids = CursorStyleRegistry.styles.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
 
-        XCTAssertLessThan(slimArrow.canvasSize.width, standardArrow.canvasSize.width)
-        XCTAssertGreaterThan(boldArrow.canvasSize.width, standardArrow.canvasSize.width)
-        XCTAssertEqual(CursorPresetRenderer.palette.fill.hexString, "#FFFFFF")
-        XCTAssertFalse(softDot.fillsShape)
-    }
-
-    func testMacOSBlackCursorStyleUsesArrowGeometryWithOwnPalette() {
-        let size: CGFloat = 24
-        let arrow = CursorPresetRenderer.drawing(style: .arrow, size: size, variant: .standard)
-        let macOSBlack = CursorPresetRenderer.drawing(style: .macOSBlackArrow, size: size, variant: .standard)
-        let slimMacOSBlack = CursorPresetRenderer.drawing(style: .macOSBlackArrow, size: size, variant: .slim)
-        let standardPalette = CursorPresetRenderer.palette(for: .macOSBlackArrow)
-
-        XCTAssertEqual(macOSBlack.canvasSize.width, arrow.canvasSize.width, accuracy: 0.001)
-        XCTAssertEqual(macOSBlack.canvasSize.height, arrow.canvasSize.height, accuracy: 0.001)
-        XCTAssertEqual(macOSBlack.hotspot.x, 0, accuracy: 0.001)
-        XCTAssertEqual(macOSBlack.hotspot.y, 0, accuracy: 0.001)
-        XCTAssertLessThan(slimMacOSBlack.canvasSize.width, macOSBlack.canvasSize.width)
-        XCTAssertEqual(standardPalette.fill.hexString, "#1F2023")
-        XCTAssertNotEqual(standardPalette.fill.hexString, CursorPresetRenderer.palette.fill.hexString)
+        for style in CursorStyleRegistry.styles {
+            let glyph = CursorStyleRenderer.renderedGlyph(styleID: style.id, size: 24)
+            XCTAssertNotNil(glyph, "Expected \(style.id) to render")
+            XCTAssertGreaterThan(glyph?.canvasSize.width ?? 0, 0)
+            XCTAssertGreaterThan(glyph?.canvasSize.height ?? 0, 0)
+        }
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -155,6 +155,8 @@ final class VideoEditorStateMachineTests: XCTestCase {
         state.previewAspectPreset = .wide
         let recordingURL = URL(fileURLWithPath: "/tmp/export.mp4")
         let telemetryURL = URL(fileURLWithPath: "/tmp/export.cursor.json")
+        let facecamURL = URL(fileURLWithPath: "/tmp/export.facecam.mov")
+        let facecamSettings = defaultFacecamSettings(enabled: true)
         let edits = TimelineEditSnapshot(clipSplitTimes: [1.25])
         let snapshot = ProjectAutosaveSnapshot(
             projectPath: "/tmp/export.openrecorder",
@@ -170,7 +172,10 @@ final class VideoEditorStateMachineTests: XCTestCase {
             recordingURL: recordingURL,
             edits: edits,
             snapshot: snapshot,
-            cursorTelemetryURL: telemetryURL
+            cursorTelemetryURL: telemetryURL,
+            facecamVideoURL: facecamURL,
+            facecamOffsetMs: 120,
+            cameraFallback: facecamSettings
         ))
 
         guard case .startVideoExport(let effectURL, let options, let effectEdits, let effectSnapshot) = effects.first else {
@@ -183,6 +188,9 @@ final class VideoEditorStateMachineTests: XCTestCase {
         XCTAssertEqual(options.resolution, .p720)
         XCTAssertEqual(options.cropSelection, state.video.cropSelection)
         XCTAssertEqual(options.cursorTelemetryURL, telemetryURL)
+        XCTAssertEqual(options.facecamVideoURL, facecamURL)
+        XCTAssertEqual(options.facecamOffsetMs, 120)
+        XCTAssertEqual(options.facecamFallbackSettings, facecamSettings.clamped)
         XCTAssertNotEqual(options.styling, .none)
     }
 
@@ -219,7 +227,10 @@ final class VideoEditorStateMachineTests: XCTestCase {
             recordingURL: recordingURL,
             edits: .empty,
             snapshot: nil,
-            cursorTelemetryURL: nil
+            cursorTelemetryURL: nil,
+            facecamVideoURL: nil,
+            facecamOffsetMs: nil,
+            cameraFallback: nil
         ))
 
         guard case .startVideoExport(_, let options, _, _) = effects.first else {
@@ -610,6 +621,43 @@ final class TimelineEditStateMachineTests: XCTestCase {
         XCTAssertEqual(state.snapshot.clipSplitTimes, [3])
         XCTAssertEqual(state.snapshot.clipSegments(duration: 8).map(\.speed), [1.5, 1.5])
         XCTAssertNil(state.selectedClipIndex)
+    }
+
+    func testTimelineReducerSynthesizesAndSplitsCameraClips() {
+        var state = TimelineEditState()
+        let fallback = defaultFacecamSettings(enabled: true)
+
+        _ = state.applying(.ensureCameraClips(duration: 8, fallback: fallback))
+        XCTAssertEqual(state.snapshot.cameraClips.count, 1)
+        XCTAssertEqual(state.snapshot.cameraClips[0].span, TimelineSpan(start: 0, end: 8))
+
+        _ = state.applying(.splitCameraClip(currentTime: 3, duration: 8, fallback: fallback))
+
+        XCTAssertEqual(state.snapshot.cameraClips.count, 2)
+        XCTAssertEqual(state.snapshot.cameraClips.map(\.span), [
+            TimelineSpan(start: 0, end: 3),
+            TimelineSpan(start: 3, end: 8)
+        ])
+        XCTAssertEqual(state.snapshot.cameraClips.map(\.settings), [fallback.clamped, fallback.clamped])
+        XCTAssertEqual(state.selectedCameraClipID, state.snapshot.cameraClips[1].id)
+    }
+
+    func testTimelineReducerUpdatesCameraVisibilityAndMergesWithSelectedSettings() {
+        var state = TimelineEditState()
+        let fallback = defaultFacecamSettings(enabled: true)
+
+        _ = state.applying(.ensureCameraClips(duration: 8, fallback: fallback))
+        _ = state.applying(.splitCameraClip(currentTime: 3, duration: 8, fallback: fallback))
+        let selectedID = state.snapshot.cameraClips[1].id
+        var hidden = fallback
+        hidden.enabled = false
+        _ = state.applying(.updateCameraClipSettings(id: selectedID, settings: hidden))
+        _ = state.applying(.mergeCameraClip(id: selectedID, direction: .previous))
+
+        XCTAssertEqual(state.snapshot.cameraClips.count, 1)
+        XCTAssertEqual(state.snapshot.cameraClips[0].span, TimelineSpan(start: 0, end: 8))
+        XCTAssertFalse(state.snapshot.cameraClips[0].settings.enabled)
+        XCTAssertEqual(state.selectedCameraClipID, selectedID)
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -93,6 +93,12 @@ final class ProjectEditorStateCodableTests: XCTestCase {
     func testProjectEditorStateRoundTripsVideoState() throws {
         var timeline = TimelineEditSnapshot.empty
         timeline.clipSplitTimes = [2.25]
+        timeline.cameraClips = [
+            TimelineCameraClip(
+                span: TimelineSpan(start: 0, end: 2.25),
+                settings: defaultFacecamSettings(enabled: false)
+            )
+        ]
         let video = ProjectVideoEditorState(
             background: .solid(SerializableColor(hex: "#112233")),
             padding: 24,
@@ -112,8 +118,10 @@ final class ProjectEditorStateCodableTests: XCTestCase {
                 loops: true,
                 size: 1.5,
                 smoothing: 0.8,
-                style: .dotPointer,
-                variant: .soft
+                styleID: "touch.dot",
+                clickEffect: .ripple,
+                idleBehavior: .fadeWhenIdle,
+                motionEffect: .subtleLean
             ),
             facecamSettings: defaultFacecamSettings(enabled: true)
         )
@@ -123,8 +131,9 @@ final class ProjectEditorStateCodableTests: XCTestCase {
         let decoded = try JSONDecoder().decode(ProjectEditorState.self, from: data)
 
         XCTAssertEqual(decoded, state)
-        XCTAssertEqual(decoded.video?.cursorOverlay.style, .dotPointer)
-        XCTAssertEqual(decoded.video?.cursorOverlay.variant, .soft)
+        XCTAssertEqual(decoded.timelineEdits.cameraClips, timeline.cameraClips)
+        XCTAssertEqual(decoded.video?.cursorOverlay.styleID, "touch.dot")
+        XCTAssertEqual(decoded.video?.cursorOverlay.clickEffect, .ripple)
     }
 
     func testProjectEditorStateRoundTripsScreenshotState() throws {

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -258,6 +258,19 @@ final class TimelineEditingPlanTests: XCTestCase {
         XCTAssertEqual(plan.outputDuration, 4, accuracy: 0.001)
     }
 
+    func testExportPlanOmitsDeletedClipSpan() {
+        let edits = TimelineEditSnapshot(
+            trimRegions: [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 5))],
+            clipSplitTimes: [2, 5]
+        )
+
+        let plan = TimelineExportEditPlan.build(duration: 8, edits: edits)
+
+        XCTAssertEqual(plan.outputDuration, 5, accuracy: 0.001)
+        XCTAssertEqual(plan.segments.map(\.sourceStart), [0, 5])
+        XCTAssertEqual(plan.segments.map(\.sourceEnd), [2, 8])
+    }
+
     @MainActor
     func testClipSplitUsesPlayheadAndDeduplicatesNearbySplits() {
         let edits = TimelineEditDriver()
@@ -304,6 +317,60 @@ final class TimelineEditingPlanTests: XCTestCase {
         XCTAssertEqual(edits.clipSplitTimes, [4])
         XCTAssertNil(edits.selectedClipIndex)
         XCTAssertFalse(edits.hasSelection)
+    }
+
+    @MainActor
+    func testDeletingSelectedClipAddsTrimRegion() {
+        let edits = TimelineEditDriver()
+        edits.clipSplitTimes = [2, 5]
+        edits.selectClip(index: 1)
+
+        edits.deleteSelection(duration: 8)
+
+        XCTAssertEqual(edits.trimRegions.map(\.span), [TimelineSpan(start: 2, end: 5)])
+        XCTAssertNil(edits.selectedClipIndex)
+        XCTAssertEqual(edits.statusMessage, "Deleted clip 2.")
+    }
+
+    @MainActor
+    func testDeletingSelectedClipIsUndoableAndRedoable() {
+        let edits = TimelineEditDriver()
+        edits.clipSplitTimes = [2, 5]
+        edits.selectClip(index: 1)
+
+        edits.deleteSelection(duration: 8)
+        XCTAssertEqual(edits.trimRegions.map(\.span), [TimelineSpan(start: 2, end: 5)])
+
+        edits.undo()
+        XCTAssertTrue(edits.trimRegions.isEmpty)
+
+        edits.redo()
+        XCTAssertEqual(edits.trimRegions.map(\.span), [TimelineSpan(start: 2, end: 5)])
+    }
+
+    @MainActor
+    func testDeletingOnlyPlayableClipIsBlocked() {
+        let edits = TimelineEditDriver()
+        edits.selectClip(index: 0)
+
+        edits.deleteSelection(duration: 8)
+
+        XCTAssertTrue(edits.trimRegions.isEmpty)
+        XCTAssertEqual(edits.selectedClipIndex, 0)
+        XCTAssertEqual(edits.statusMessage, "Cannot delete the only playable clip.")
+        XCTAssertFalse(edits.canUndo)
+    }
+
+    @MainActor
+    func testDeletingSelectedClipMergesAdjacentTrimRegions() {
+        let edits = TimelineEditDriver()
+        edits.clipSplitTimes = [2, 4, 6]
+        edits.trimRegions = [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 4))]
+        edits.selectClip(index: 2)
+
+        edits.deleteSelection(duration: 8)
+
+        XCTAssertEqual(edits.trimRegions.map(\.span), [TimelineSpan(start: 2, end: 6)])
     }
 
     @MainActor

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -291,6 +291,28 @@ final class VideoPreviewLayoutTests: XCTestCase {
         XCTAssertEqual(settings.resolvedAnchor, .bottomRight)
     }
 
+    func testTimelineCameraSettingsResolveByActiveClipAndVisibility() {
+        var visible = defaultFacecamSettings(enabled: true)
+        visible.anchor = FacecamAnchor.topLeft.rawValue
+        var hidden = visible
+        hidden.enabled = false
+        let edits = TimelineEditSnapshot(cameraClips: [
+            TimelineCameraClip(span: TimelineSpan(start: 0, end: 2), settings: visible),
+            TimelineCameraClip(span: TimelineSpan(start: 2, end: 5), settings: hidden)
+        ])
+
+        XCTAssertEqual(edits.activeCameraSettings(at: 1, duration: 5, fallback: nil)?.anchor, FacecamAnchor.topLeft.rawValue)
+        XCTAssertNil(edits.activeCameraSettings(at: 3, duration: 5, fallback: nil))
+    }
+
+    func testTimelineCameraSettingsFallbackCoversFullClip() {
+        let fallback = defaultFacecamSettings(enabled: true)
+        let edits = TimelineEditSnapshot.empty
+
+        XCTAssertEqual(edits.resolvedCameraClips(duration: 5, fallback: fallback).count, 1)
+        XCTAssertEqual(edits.activeCameraSettings(at: 4.99, duration: 5, fallback: fallback), fallback.clamped)
+    }
+
     func testFinalCanvasZoomTransformIsIdentityAtOneX() {
         let transform = TimelineZoomCanvasTransform.transform(
             for: TimelineZoomEffect(depth: 1, focusX: 0.25, focusY: 0.75),
@@ -331,6 +353,21 @@ final class VideoPreviewLayoutTests: XCTestCase {
     func testZoomOnlyExportRequiresFinalCanvasOverlayTool() {
         let edits = TimelineEditSnapshot(zoomRegions: [
             TimelineZoomRegion(span: TimelineSpan(start: 1, end: 2), depth: 2)
+        ])
+
+        XCTAssertTrue(VideoExportRenderer.needsFinalCanvasOverlayTool(
+            edits: edits,
+            cursorTrack: nil,
+            cursorSettings: .hidden
+        ))
+    }
+
+    func testCameraClipExportRequiresFinalCanvasOverlayTool() {
+        let edits = TimelineEditSnapshot(cameraClips: [
+            TimelineCameraClip(
+                span: TimelineSpan(start: 0, end: 3),
+                settings: defaultFacecamSettings(enabled: true)
+            )
         ])
 
         XCTAssertTrue(VideoExportRenderer.needsFinalCanvasOverlayTool(


### PR DESCRIPTION
## Summary
- add a registry-backed cursor style system that persists `styleID` and supports future cursor styles without new enum cases
- replace the old cursor style/variant picker with grouped registry styles and soften the system cursor rendering
- add timeline-owned camera clip editing and preview/export compositor parity for camera overlays
- include the existing selected timeline clip deletion fix on this branch

## Validation
- `swift test --package-path apps/macos`
- `git diff --check`
- rebuilt and launched `/Applications/Open Recorder Dev.app` with `make dev-macos`
- smoke-tested the cursor picker in the dev app via Computer Use
