### PR TITLE
[codex] Add timeline clip menus and facecam prewarm

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -60,6 +60,7 @@ final class AppModel: ObservableObject {
     private var activeScreenStartedAt: Date?
     private var activeFacecamStartedAt: Date?
     private var activeFacecamURL: URL?
+    private var facecamPrewarmTask: Task<Void, Never>?
     private var displayFlashWindows: [NSWindow] = []
     private let countdownOverlayController = RecordingCountdownOverlayController()
     private let captureUIHideDelayNanoseconds: UInt64
@@ -781,10 +782,21 @@ final class AppModel: ObservableObject {
     private func runRecordingStartFlow(source selectedSource: CaptureSource, outputURL: URL) async {
         do {
             refreshCaptureDevices()
-            let options = currentCaptureOptions
+            var options = currentCaptureOptions
             guard await preparePermissions(for: options) else {
                 restoreRecordingSetup(source: selectedSource)
                 return
+            }
+
+            if options.includeCamera {
+                do {
+                    try await prepareFacecam(cameraDeviceID: options.cameraDeviceID)
+                } catch {
+                    captureOptions.send(.cameraDisabled)
+                    syncCaptureOptionsMirror()
+                    options = currentCaptureOptions
+                    statusMessage = "Recording without facecam: \(error.localizedDescription)"
+                }
             }
 
             try await countdownOverlayController.run(for: selectedSource)
@@ -792,30 +804,41 @@ final class AppModel: ObservableObject {
 
             dispatch(.recordingStarting(selectedSource))
 
+            activeFacecamURL = nil
+            activeFacecamStartedAt = nil
+            var facecamURL: URL?
+            var facecamStartTask: Task<Date, Error>?
+            if options.includeCamera {
+                let url = facecamOutputURL(for: outputURL)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try FileManager.default.removeItem(at: url)
+                }
+                facecamURL = url
+                let cameraDeviceID = options.cameraDeviceID
+                facecamStartTask = Task { @MainActor in
+                    try await self.facecamRecorder.start(outputURL: url, cameraDeviceID: cameraDeviceID)
+                }
+            }
+
             cursorTelemetryRecorder.start(for: selectedSource)
+            let screenStartedAt = Date()
             try await capture.startRecording(
                 source: selectedSource,
                 outputURL: outputURL,
                 options: options
             )
-            activeScreenStartedAt = Date()
-            activeFacecamURL = nil
-            activeFacecamStartedAt = nil
+            activeScreenStartedAt = screenStartedAt
 
-            if options.includeCamera {
+            if let facecamStartTask {
                 do {
-                    let facecamURL = facecamOutputURL(for: outputURL)
-                    if FileManager.default.fileExists(atPath: facecamURL.path) {
-                        try FileManager.default.removeItem(at: facecamURL)
-                    }
-                    activeFacecamStartedAt = try await facecamRecorder.start(
-                        outputURL: facecamURL,
-                        cameraDeviceID: options.cameraDeviceID
-                    )
+                    activeFacecamStartedAt = try await facecamStartTask.value
                     activeFacecamURL = facecamURL
                 } catch {
                     captureOptions.send(.cameraDisabled)
                     syncCaptureOptionsMirror()
+                    if let facecamURL {
+                        try? FileManager.default.removeItem(at: facecamURL)
+                    }
                     activeFacecamURL = nil
                     activeFacecamStartedAt = nil
                     statusMessage = "Recording without facecam: \(error.localizedDescription)"
@@ -845,6 +868,11 @@ final class AppModel: ObservableObject {
             }
         } catch {
             facecamRecorder.cancel()
+            if let partialURL = activeFacecamURL {
+                try? FileManager.default.removeItem(at: partialURL)
+            } else {
+                try? FileManager.default.removeItem(at: facecamOutputURL(for: outputURL))
+            }
             _ = cursorTelemetryRecorder.stop(videoURL: nil)
             activeScreenStartedAt = nil
             activeFacecamStartedAt = nil
@@ -1353,6 +1381,7 @@ final class AppModel: ObservableObject {
         syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.cameraSelected(deviceID))
         syncCaptureOptionsMirror()
+        prewarmSelectedFacecamIfNeeded()
     }
 
     func selectNoMicrophoneInput() {
@@ -1382,6 +1411,7 @@ final class AppModel: ObservableObject {
         syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.cameraDisabled)
         syncCaptureOptionsMirror()
+        cancelFacecamPrewarm()
     }
 
     var selectedMicrophoneDeviceName: String {
@@ -1439,21 +1469,61 @@ final class AppModel: ObservableObject {
         }
 
         if options.includeCamera {
-            let status = AVCaptureDevice.authorizationStatus(for: .video)
-            if status == .notDetermined {
-                let granted = await AVCaptureDevice.requestAccess(for: .video)
-                if !granted {
-                    statusMessage = "Camera permission is required for facecam."
-                    return false
-                }
-            } else if status == .denied || status == .restricted {
-                statusMessage = "Camera permission is denied."
-                openCameraSettings()
-                return false
-            }
+            guard await prepareCameraPermissionForFacecam() else { return false }
         }
 
         return true
+    }
+
+    private func prepareCameraPermissionForFacecam() async -> Bool {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        if status == .notDetermined {
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            if !granted {
+                statusMessage = "Camera permission is required for facecam."
+                return false
+            }
+        } else if status == .denied || status == .restricted {
+            statusMessage = "Camera permission is denied."
+            openCameraSettings()
+            return false
+        }
+        return true
+    }
+
+    private func prewarmSelectedFacecamIfNeeded() {
+        let options = currentCaptureOptions
+        guard options.includeCamera else {
+            cancelFacecamPrewarm()
+            return
+        }
+
+        facecamPrewarmTask?.cancel()
+        facecamPrewarmTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard await self.prepareCameraPermissionForFacecam() else { return }
+            do {
+                try await self.facecamRecorder.prepare(cameraDeviceID: options.cameraDeviceID)
+                if !Task.isCancelled {
+                    self.facecamPrewarmTask = nil
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.statusMessage = "Camera warmup failed: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func prepareFacecam(cameraDeviceID: String?) async throws {
+        facecamPrewarmTask?.cancel()
+        facecamPrewarmTask = nil
+        try await facecamRecorder.prepare(cameraDeviceID: cameraDeviceID)
+    }
+
+    private func cancelFacecamPrewarm() {
+        facecamPrewarmTask?.cancel()
+        facecamPrewarmTask = nil
+        facecamRecorder.cancel()
     }
 
     private func facecamOutputURL(for screenURL: URL) -> URL {

--- a/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
@@ -25,6 +25,7 @@ enum FacecamRecorderError: LocalizedError {
 final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     private var session: AVCaptureSession?
     private var movieOutput: AVCaptureMovieFileOutput?
+    private var preparedCameraDeviceID: String?
     private var outputURL: URL?
     private var startedAt: Date?
     private var startContinuation: CheckedContinuation<Date, Error>?
@@ -35,9 +36,59 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         movieOutput?.isRecording == true
     }
 
-    func start(outputURL: URL, cameraDeviceID: String?) async throws -> Date {
-        cleanup()
+    var isPrepared: Bool {
+        session?.isRunning == true && movieOutput != nil
+    }
 
+    func prepare(cameraDeviceID: String?) async throws {
+        if preparedCameraDeviceID == cameraDeviceID,
+           let session,
+           let movieOutput,
+           session.isRunning,
+           !movieOutput.isRecording {
+            return
+        }
+
+        cleanup()
+        let (session, output) = try buildSession(cameraDeviceID: cameraDeviceID)
+        self.session = session
+        self.movieOutput = output
+        self.preparedCameraDeviceID = cameraDeviceID
+        self.finishResult = nil
+
+        session.startRunning()
+    }
+
+    func start(outputURL: URL, cameraDeviceID: String?) async throws -> Date {
+        if preparedCameraDeviceID != cameraDeviceID || session == nil || movieOutput == nil {
+            try await prepare(cameraDeviceID: cameraDeviceID)
+        } else if session?.isRunning != true {
+            session?.startRunning()
+        }
+
+        guard let output = movieOutput else {
+            throw FacecamRecorderError.cannotAddMovieOutput
+        }
+
+        if output.isRecording, let startedAt {
+            return startedAt
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        self.outputURL = outputURL
+        self.finishResult = nil
+
+        return try await withCheckedThrowingContinuation { continuation in
+            startContinuation = continuation
+            output.startRecording(to: outputURL, recordingDelegate: self)
+        }
+    }
+
+    private func buildSession(cameraDeviceID: String?) throws -> (AVCaptureSession, AVCaptureMovieFileOutput) {
         let device = try cameraDevice(cameraDeviceID)
         let input = try AVCaptureDeviceInput(device: device)
         let session = AVCaptureSession()
@@ -54,22 +105,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         }
         session.addOutput(output)
 
-        try FileManager.default.createDirectory(
-            at: outputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-
-        self.session = session
-        self.movieOutput = output
-        self.outputURL = outputURL
-        self.finishResult = nil
-
-        session.startRunning()
-
-        return try await withCheckedThrowingContinuation { continuation in
-            startContinuation = continuation
-            output.startRecording(to: outputURL, recordingDelegate: self)
-        }
+        return (session, output)
     }
 
     func stop() async throws -> URL? {
@@ -89,6 +125,10 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         if movieOutput?.isRecording == true {
             movieOutput?.stopRecording()
         }
+        startContinuation?.resume(throwing: CancellationError())
+        startContinuation = nil
+        finishContinuation?.resume(throwing: CancellationError())
+        finishContinuation = nil
         cleanup()
     }
 
@@ -161,6 +201,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         }
         session = nil
         movieOutput = nil
+        preparedCameraDeviceID = nil
         startedAt = nil
         if !keepOutputURL {
             outputURL = nil

--- a/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
@@ -449,7 +449,7 @@ struct TimelineEditState: Equatable {
     var selectedID: TimelineRegionID?
     var selectedClipIndex: Int?
     var selectedCameraClipID: TimelineRegionID?
-    var statusMessage = "Use shortcuts to edit. Space plays, Z zooms, S cycles clip speed, T splits clips."
+    var statusMessage = "Use shortcuts to edit. Space plays, Z zooms, S cycles clip speed, T splits clips, C splits camera."
 
     static let empty = TimelineEditState()
 
@@ -467,9 +467,11 @@ enum TimelineEditEvent: Equatable {
     case addClipSplit(currentTime: Double, duration: Double)
     case ensureCameraClips(duration: Double, fallback: FacecamSettings?)
     case splitCameraClip(currentTime: Double, duration: Double, fallback: FacecamSettings?)
+    case deleteRecordingClip(index: Int, duration: Double)
     case selectCameraClip(TimelineRegionID)
     case updateCameraClipSettings(id: TimelineRegionID, settings: FacecamSettings)
     case mergeCameraClip(id: TimelineRegionID, direction: TimelineCameraMergeDirection)
+    case deleteCameraClip(id: TimelineRegionID, duration: Double, fallback: FacecamSettings?)
     case select(TimelineRegionKind?, TimelineRegionID?)
     case selectClip(index: Int)
     case clearSelection
@@ -531,6 +533,10 @@ extension TimelineEditState {
             splitCameraClip(at: currentTime, duration: duration, fallback: fallback)
             return []
 
+        case .deleteRecordingClip(let index, let duration):
+            deleteRecordingClip(index: index, duration: duration)
+            return []
+
         case .selectCameraClip(let id):
             selectCameraClip(id: id)
             return []
@@ -541,6 +547,10 @@ extension TimelineEditState {
 
         case .mergeCameraClip(let id, let direction):
             mergeCameraClip(id: id, direction: direction)
+            return []
+
+        case .deleteCameraClip(let id, let duration, let fallback):
+            deleteCameraClip(id: id, duration: duration, fallback: fallback)
             return []
 
         case .select(let kind, let id):
@@ -607,6 +617,24 @@ extension TimelineEditState {
     func selectedCameraClip(duration: Double, fallback: FacecamSettings?) -> TimelineCameraClip? {
         guard let selectedCameraClipID else { return nil }
         return snapshot.resolvedCameraClips(duration: duration, fallback: fallback).first { $0.id == selectedCameraClipID }
+    }
+
+    func canDeleteRecordingClip(index: Int, duration: Double) -> Bool {
+        guard let candidate = recordingClipDeletionCandidate(index: index, duration: duration),
+              !isClipOmitted(candidate.segment, trimRegions: snapshot.trimRegions) else {
+            return false
+        }
+        return !TimelineExportEditPlan.build(duration: duration, edits: candidate.snapshot).segments.isEmpty
+    }
+
+    func canDeleteCameraClip(id: TimelineRegionID, duration: Double, fallback: FacecamSettings?) -> Bool {
+        guard duration.isFinite, duration > 0 else { return false }
+        let clips = snapshot.resolvedCameraClips(duration: duration, fallback: fallback)
+        guard clips.count > 1,
+              let clip = clips.first(where: { $0.id == id }) else {
+            return false
+        }
+        return clip.settings.clamped.enabled
     }
 
     func clipSpeed(index: Int) -> Double {
@@ -781,6 +809,11 @@ extension TimelineEditState {
             return
         }
 
+        if let selectedCameraClipID, let duration {
+            deleteCameraClip(id: selectedCameraClipID, duration: duration, fallback: nil)
+            return
+        }
+
         guard let selectedKind, let selectedID else { return }
         switch selectedKind {
         case .zoom: snapshot.zoomRegions.removeAll { $0.id == selectedID }
@@ -799,6 +832,15 @@ extension TimelineEditState {
             return
         }
 
+        deleteRecordingClip(index: selectedClipIndex, duration: duration)
+    }
+
+    private mutating func deleteRecordingClip(index selectedClipIndex: Int, duration: Double) {
+        guard duration.isFinite, duration > 0 else {
+            statusMessage = "Open a video before deleting a clip."
+            return
+        }
+
         let segments = snapshot.clipSegments(duration: duration)
         guard segments.indices.contains(selectedClipIndex) else {
             clearSelection()
@@ -807,11 +849,16 @@ extension TimelineEditState {
         }
 
         let segment = segments[selectedClipIndex]
-        let deleteRegion = TimelineTrimRegion(span: segment.span.normalized(duration: duration))
-        var candidate = snapshot
-        candidate.trimRegions.append(deleteRegion)
-        candidate.trimRegions = mergedTrimRegions(candidate.trimRegions, duration: duration)
+        guard !isClipOmitted(segment, trimRegions: snapshot.trimRegions) else {
+            statusMessage = "Clip \(segment.index + 1) is already deleted."
+            return
+        }
 
+        guard let candidate = recordingClipDeletionCandidate(index: selectedClipIndex, duration: duration)?.snapshot else {
+            clearSelection()
+            statusMessage = "Selected clip is no longer available."
+            return
+        }
         guard !TimelineExportEditPlan.build(duration: duration, edits: candidate).segments.isEmpty else {
             statusMessage = "Cannot delete the only playable clip."
             return
@@ -820,6 +867,25 @@ extension TimelineEditState {
         snapshot = candidate
         clearSelection()
         statusMessage = "Deleted clip \(segment.index + 1)."
+    }
+
+    private func recordingClipDeletionCandidate(index selectedClipIndex: Int, duration: Double) -> (segment: TimelineClipSegment, snapshot: TimelineEditSnapshot)? {
+        guard duration.isFinite, duration > 0 else { return nil }
+        let segments = snapshot.clipSegments(duration: duration)
+        guard segments.indices.contains(selectedClipIndex) else { return nil }
+
+        let segment = segments[selectedClipIndex]
+        let deleteRegion = TimelineTrimRegion(span: segment.span.normalized(duration: duration))
+        var candidate = snapshot
+        candidate.trimRegions.append(deleteRegion)
+        candidate.trimRegions = mergedTrimRegions(candidate.trimRegions, duration: duration)
+        return (segment, candidate)
+    }
+
+    private func isClipOmitted(_ segment: TimelineClipSegment, trimRegions: [TimelineTrimRegion]) -> Bool {
+        trimRegions.contains { region in
+            region.span.start <= segment.start + 0.001 && region.span.end >= segment.end - 0.001
+        }
     }
 
     private mutating func updateSpan(kind: TimelineRegionKind, id: TimelineRegionID, span: TimelineSpan, duration: Double) {
@@ -946,6 +1012,37 @@ extension TimelineEditState {
         snapshot.cameraClips = next.sorted { $0.span.start < $1.span.start }
         selectCameraClip(id: selected.id)
         statusMessage = "Merged camera clips."
+    }
+
+    private mutating func deleteCameraClip(id: TimelineRegionID, duration: Double, fallback: FacecamSettings?) {
+        guard duration.isFinite, duration > 0 else {
+            statusMessage = "Open a video before deleting a camera clip."
+            return
+        }
+
+        var clips = snapshot.resolvedCameraClips(duration: duration, fallback: fallback)
+        guard clips.count > 1 else {
+            statusMessage = "Cannot delete the only camera clip."
+            return
+        }
+
+        guard let index = clips.firstIndex(where: { $0.id == id }) else {
+            clearSelection()
+            statusMessage = "Selected camera clip is no longer available."
+            return
+        }
+
+        guard clips[index].settings.clamped.enabled else {
+            statusMessage = "Camera clip is already deleted."
+            return
+        }
+
+        var settings = clips[index].settings.clamped
+        settings.enabled = false
+        clips[index].settings = settings
+        snapshot.cameraClips = clips
+        selectCameraClip(id: id)
+        statusMessage = "Deleted camera clip."
     }
 
     private mutating func removeClipSplit(at splitTime: Double, duration: Double) {
@@ -1159,6 +1256,14 @@ final class TimelineEditDriver {
         send(.splitCameraClip(currentTime: currentTime, duration: duration, fallback: fallback))
     }
 
+    func deleteRecordingClip(index: Int, duration: Double) {
+        send(.deleteRecordingClip(index: index, duration: duration))
+    }
+
+    func canDeleteRecordingClip(index: Int, duration: Double) -> Bool {
+        state.canDeleteRecordingClip(index: index, duration: duration)
+    }
+
     func selectCameraClip(id: TimelineRegionID) {
         send(.selectCameraClip(id), recordsUndo: false)
     }
@@ -1237,6 +1342,14 @@ final class TimelineEditDriver {
 
     func mergeCameraClip(id: TimelineRegionID, direction: TimelineCameraMergeDirection) {
         send(.mergeCameraClip(id: id, direction: direction))
+    }
+
+    func deleteCameraClip(id: TimelineRegionID, duration: Double, fallback: FacecamSettings?) {
+        send(.deleteCameraClip(id: id, duration: duration, fallback: fallback))
+    }
+
+    func canDeleteCameraClip(id: TimelineRegionID, duration: Double, fallback: FacecamSettings?) -> Bool {
+        state.canDeleteCameraClip(id: id, duration: duration, fallback: fallback)
     }
 
     func removeClipSplit(at splitTime: Double, duration: Double) {

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -71,7 +71,25 @@ struct TimelineSelectionSidebar: View {
                 edits.clearSelection()
             }
 
-            if edits.selectedKind != nil || edits.selectedClipIndex != nil {
+            if let cameraID = edits.selectedCameraClipID {
+                TimelineSelectionActionButton(
+                    title: "Delete",
+                    symbolName: "trash",
+                    isDestructive: true,
+                    isEnabled: edits.canDeleteCameraClip(id: cameraID, duration: playback.duration, fallback: defaultCameraSettings)
+                ) {
+                    edits.deleteCameraClip(id: cameraID, duration: playback.duration, fallback: defaultCameraSettings)
+                }
+            } else if let clipIndex = edits.selectedClipIndex {
+                TimelineSelectionActionButton(
+                    title: "Delete",
+                    symbolName: "trash",
+                    isDestructive: true,
+                    isEnabled: edits.canDeleteRecordingClip(index: clipIndex, duration: playback.duration)
+                ) {
+                    edits.deleteSelection(duration: playback.duration)
+                }
+            } else if edits.selectedKind != nil {
                 TimelineSelectionActionButton(title: "Delete", symbolName: "trash", isDestructive: true) {
                     edits.deleteSelection(duration: playback.duration)
                 }
@@ -402,6 +420,7 @@ private struct TimelineSelectionActionButton: View {
     var title: String
     var symbolName: String
     var isDestructive = false
+    var isEnabled = true
     var action: () -> Void
 
     var body: some View {
@@ -410,13 +429,14 @@ private struct TimelineSelectionActionButton: View {
                 .font(.system(size: 11, weight: .semibold))
                 .frame(maxWidth: .infinity)
                 .frame(height: 34)
-                .foregroundStyle(isDestructive ? Color.red.opacity(0.92) : Color.secondary)
+                .foregroundStyle(isDestructive ? Color.red.opacity(isEnabled ? 0.92 : 0.36) : Color.secondary.opacity(isEnabled ? 1 : 0.45))
                 .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
                 .overlay {
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(isDestructive ? Color.red.opacity(0.18) : Theme.overlay)
+                        .stroke(isDestructive ? Color.red.opacity(isEnabled ? 0.18 : 0.08) : Theme.overlay)
                 }
         }
+        .disabled(!isEnabled)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -73,6 +73,7 @@ struct TimelinePanel: View {
             case "z": edits.add(.zoom, at: playback.currentTime, duration: playback.duration); return .handled
             case "s": edits.cycleClipSpeed(at: playback.currentTime, duration: playback.duration); return .handled
             case "t": edits.addClipSplit(at: playback.currentTime, duration: playback.duration); return .handled
+            case "c": edits.splitCameraClip(at: playback.currentTime, duration: playback.duration, fallback: defaultCameraSettings); return .handled
             default: return .ignored
             }
         }
@@ -184,12 +185,14 @@ struct TimelineTrackContent: View {
                 .onTapGesture {
                     edits.clearSelection()
                 }
-            TimelineClipRow(videoURL: videoURL, duration: playback.duration, viewport: viewport, splitTimes: edits.clipSplitTimes, trimRegions: edits.trimRegions, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
+            TimelineClipRow(videoURL: videoURL, duration: playback.duration, currentTime: playback.currentTime, viewport: viewport, splitTimes: edits.clipSplitTimes, trimRegions: edits.trimRegions, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
             TimelineLayerRow(kind: .zoom, duration: playback.duration, viewport: viewport, regions: edits.zoomRegions.map(TimelineRegionRenderData.zoom), selectedID: edits.selectedKind == .zoom ? edits.selectedID : nil, edits: edits)
             TimelineCameraLayerRow(
                 duration: playback.duration,
+                currentTime: playback.currentTime,
                 viewport: viewport,
                 hasRecordedCamera: hasRecordedCamera,
+                fallbackSettings: defaultCameraSettings,
                 cameraClips: edits.resolvedCameraClips(duration: playback.duration, fallback: defaultCameraSettings),
                 selectedID: edits.selectedCameraClipID,
                 edits: edits
@@ -662,6 +665,7 @@ enum TimelineSeekMapper {
 struct TimelineClipRow: View {
     var videoURL: URL?
     var duration: Double
+    var currentTime: Double
     var viewport: TimelineViewport
     var splitTimes: [Double]
     var trimRegions: [TimelineTrimRegion]
@@ -712,6 +716,21 @@ struct TimelineClipRow: View {
                 let endX = x(for: segment.end, width: width)
                 let segmentWidth = max(1, endX - startX - (segments.count > 1 ? 3 : 0))
                 clipBody(segment: segment, width: segmentWidth, isSelected: selectedClipIndex == segment.index, isDeleted: isDeleted(segment))
+                    .contextMenu {
+                        Button {
+                            edits.addClipSplit(at: currentTime, duration: duration)
+                        } label: {
+                            Label("Split at Playhead", systemImage: "scissors")
+                        }
+                        .disabled(!canSplitAtPlayhead(segment: segment, isDeleted: isDeleted(segment)))
+
+                        Button(role: .destructive) {
+                            edits.deleteRecordingClip(index: segment.index, duration: duration)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .disabled(isDeleted(segment) || !edits.canDeleteRecordingClip(index: segment.index, duration: duration))
+                    }
                     .frame(width: segmentWidth, height: TimelineMetrics.clipHeight)
                     .position(x: startX + (endX - startX) / 2, y: TimelineMetrics.clipHeight / 2)
             }
@@ -755,6 +774,12 @@ struct TimelineClipRow: View {
         trimRegions.contains { region in
             region.span.start <= segment.start + 0.001 && region.span.end >= segment.end - 0.001
         }
+    }
+
+    private func canSplitAtPlayhead(segment: TimelineClipSegment, isDeleted: Bool) -> Bool {
+        guard !isDeleted, duration.isFinite, duration > 0 else { return false }
+        let minimumDistance = min(0.05, duration / 4)
+        return currentTime > segment.start + minimumDistance && currentTime < segment.end - minimumDistance
     }
 
     private func seek(to x: CGFloat, width: CGFloat) {
@@ -954,8 +979,10 @@ struct TimelineLayerRow: View {
 
 struct TimelineCameraLayerRow: View {
     var duration: Double
+    var currentTime: Double
     var viewport: TimelineViewport
     var hasRecordedCamera: Bool
+    var fallbackSettings: FacecamSettings?
     var cameraClips: [TimelineCameraClip]
     var selectedID: TimelineRegionID?
     var edits: TimelineEditDriver
@@ -985,9 +1012,11 @@ struct TimelineCameraLayerRow: View {
                     TimelineCameraClipItem(
                         clip: clip,
                         duration: duration,
+                        currentTime: currentTime,
                         viewport: viewport,
                         width: proxy.size.width,
                         isSelected: clip.id == selectedID,
+                        fallbackSettings: fallbackSettings,
                         edits: edits
                     )
                 }
@@ -1023,9 +1052,11 @@ struct TimelineCameraLayerRow: View {
 private struct TimelineCameraClipItem: View {
     var clip: TimelineCameraClip
     var duration: Double
+    var currentTime: Double
     var viewport: TimelineViewport
     var width: CGFloat
     var isSelected: Bool
+    var fallbackSettings: FacecamSettings?
     var edits: TimelineEditDriver
 
     private var accent: Color {
@@ -1046,6 +1077,21 @@ private struct TimelineCameraClipItem: View {
             .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
             .position(x: startX + itemWidth / 2, y: TimelineMetrics.layerHeight / 2)
             .onTapGesture { edits.selectCameraClip(id: clip.id) }
+            .contextMenu {
+                Button {
+                    edits.splitCameraClip(at: currentTime, duration: duration, fallback: fallbackSettings)
+                } label: {
+                    Label("Split at Playhead", systemImage: "scissors")
+                }
+                .disabled(!canSplitAtPlayhead)
+
+                Button(role: .destructive) {
+                    edits.deleteCameraClip(id: clip.id, duration: duration, fallback: fallbackSettings)
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                .disabled(!edits.canDeleteCameraClip(id: clip.id, duration: duration, fallback: fallbackSettings))
+            }
     }
 
     private func label(width: CGFloat) -> some View {
@@ -1065,6 +1111,12 @@ private struct TimelineCameraClipItem: View {
 
     private func x(for time: Double) -> CGFloat {
         viewport.x(for: time, width: width, clamped: true) ?? 0
+    }
+
+    private var canSplitAtPlayhead: Bool {
+        guard duration.isFinite, duration > 0 else { return false }
+        let minimumDistance = min(0.05, duration / 4)
+        return currentTime > clip.span.start + minimumDistance && currentTime < clip.span.end - minimumDistance
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -659,6 +659,45 @@ final class TimelineEditStateMachineTests: XCTestCase {
         XCTAssertFalse(state.snapshot.cameraClips[0].settings.enabled)
         XCTAssertEqual(state.selectedCameraClipID, selectedID)
     }
+
+    func testTimelineReducerDeletesNonFinalCameraClipByHidingIt() {
+        var state = TimelineEditState()
+        let fallback = defaultFacecamSettings(enabled: true)
+
+        _ = state.applying(.ensureCameraClips(duration: 8, fallback: fallback))
+        _ = state.applying(.splitCameraClip(currentTime: 3, duration: 8, fallback: fallback))
+        let firstID = state.snapshot.cameraClips[0].id
+
+        XCTAssertTrue(state.canDeleteCameraClip(id: firstID, duration: 8, fallback: fallback))
+
+        _ = state.applying(.deleteCameraClip(id: firstID, duration: 8, fallback: fallback))
+
+        XCTAssertEqual(state.snapshot.cameraClips.count, 2)
+        XCTAssertEqual(state.snapshot.cameraClips.map(\.span), [
+            TimelineSpan(start: 0, end: 3),
+            TimelineSpan(start: 3, end: 8)
+        ])
+        XCTAssertFalse(state.snapshot.cameraClips[0].settings.enabled)
+        XCTAssertTrue(state.snapshot.cameraClips[1].settings.enabled)
+        XCTAssertEqual(state.selectedCameraClipID, firstID)
+        XCTAssertEqual(state.statusMessage, "Deleted camera clip.")
+    }
+
+    func testTimelineReducerBlocksDeletingOnlyCameraClip() {
+        var state = TimelineEditState()
+        let fallback = defaultFacecamSettings(enabled: true)
+
+        _ = state.applying(.ensureCameraClips(duration: 8, fallback: fallback))
+        let onlyID = state.snapshot.cameraClips[0].id
+
+        XCTAssertFalse(state.canDeleteCameraClip(id: onlyID, duration: 8, fallback: fallback))
+
+        _ = state.applying(.deleteCameraClip(id: onlyID, duration: 8, fallback: fallback))
+
+        XCTAssertEqual(state.snapshot.cameraClips.count, 1)
+        XCTAssertTrue(state.snapshot.cameraClips[0].settings.enabled)
+        XCTAssertEqual(state.statusMessage, "Cannot delete the only camera clip.")
+    }
 }
 
 final class EditorWorkspaceStateMachineTests: XCTestCase {

--- a/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
@@ -28,6 +28,26 @@ final class RecordingSessionBuilderTests: XCTestCase {
         XCTAssertEqual(session.facecamSettings?.enabled, true)
     }
 
+    func testBuildRecordingSessionPreservesEarlyFacecamOffset() {
+        let screenURL = URL(fileURLWithPath: "/tmp/screen.mp4")
+        let facecamURL = URL(fileURLWithPath: "/tmp/facecam.mov")
+        let screenStartedAt = Date(timeIntervalSince1970: 10)
+        let facecamStartedAt = Date(timeIntervalSince1970: 9.75)
+
+        let session = RecordingSessionBuilder.build(
+            screenVideoURL: screenURL,
+            facecamURL: facecamURL,
+            sourceName: nil,
+            showCursor: true,
+            cursorTelemetryURL: nil,
+            screenStartedAt: screenStartedAt,
+            facecamStartedAt: facecamStartedAt
+        )
+
+        XCTAssertEqual(session.facecamOffsetMs, -250)
+        XCTAssertEqual(session.facecamVideoPath, facecamURL.path)
+    }
+
     func testRecordingSessionHasRecordedCameraRequiresFacecamPath() {
         var session = RecordingSession(
             screenVideoPath: "/tmp/screen.mp4",

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -333,6 +333,34 @@ final class TimelineEditingPlanTests: XCTestCase {
     }
 
     @MainActor
+    func testContextDeletingRecordingClipAddsExactTrimRegion() {
+        let edits = TimelineEditDriver()
+        edits.clipSplitTimes = [2, 5]
+
+        XCTAssertTrue(edits.canDeleteRecordingClip(index: 1, duration: 8))
+
+        edits.deleteRecordingClip(index: 1, duration: 8)
+
+        XCTAssertEqual(edits.trimRegions.map(\.span), [TimelineSpan(start: 2, end: 5)])
+        XCTAssertEqual(edits.statusMessage, "Deleted clip 2.")
+        XCTAssertFalse(edits.canDeleteRecordingClip(index: 1, duration: 8))
+    }
+
+    @MainActor
+    func testContextDeletingOnlyPlayableRecordingClipIsBlocked() {
+        let edits = TimelineEditDriver()
+        edits.clipSplitTimes = [2]
+        edits.trimRegions = [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 8))]
+
+        XCTAssertFalse(edits.canDeleteRecordingClip(index: 0, duration: 8))
+
+        edits.deleteRecordingClip(index: 0, duration: 8)
+
+        XCTAssertEqual(edits.trimRegions.map(\.span), [TimelineSpan(start: 2, end: 8)])
+        XCTAssertEqual(edits.statusMessage, "Cannot delete the only playable clip.")
+    }
+
+    @MainActor
     func testDeletingSelectedClipIsUndoableAndRedoable() {
         let edits = TimelineEditDriver()
         edits.clipSplitTimes = [2, 5]


### PR DESCRIPTION
## Summary
- add right-click Split at Playhead and Delete actions for recording and camera timeline clips
- add the C shortcut for splitting camera clips while keeping T for recording clips
- prewarm the selected camera before recording starts, then begin facecam file writing alongside screen capture start

## Details
- Recording clip deletion now routes through the trim/export path and refuses to remove the final playable clip.
- Camera clip deletion hides the selected camera segment by setting its clip settings to disabled, and refuses to hide the only camera clip.
- Facecam recording now has prepared and recording phases so the AVCaptureSession can be running before file output begins. If screen capture start fails after facecam startup, the partial facecam file is removed.

## Validation
- `swift test --package-path apps/macos --filter TimelineEditingPlanTests`
- `swift test --package-path apps/macos --filter TimelineEditStateMachineTests`
- `swift test --package-path apps/macos --filter RecordingSessionBuilderTests`
- `swift build --package-path apps/macos`