### PR TITLE
[codex] Add project delete actions

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -78,6 +78,8 @@ final class AppModel: ObservableObject {
     private let screenshotCapture: @MainActor (CaptureSource, URL) throws -> Void
     private let stopRecordingCapture: @MainActor () async throws -> URL
     private let rememberScreenshot: @Sendable (URL) throws -> Void
+    private let trashProjectFile: @MainActor (URL) throws -> Void
+    private let forgetProject: @Sendable (String) throws -> Void
     private let facecamRecorder = FacecamRecorder()
     private let cursorTelemetryRecorder = CursorTelemetryRecorder()
     private let captureDeviceProvider = CaptureDeviceProvider()
@@ -92,7 +94,9 @@ final class AppModel: ObservableObject {
         captureUIHideDelayNanoseconds: UInt64 = 180_000_000,
         screenshotCapture: (@MainActor (CaptureSource, URL) throws -> Void)? = nil,
         stopRecording: (@MainActor () async throws -> URL)? = nil,
-        rememberScreenshot: (@Sendable (URL) throws -> Void)? = nil
+        rememberScreenshot: (@Sendable (URL) throws -> Void)? = nil,
+        trashProjectFile: (@MainActor (URL) throws -> Void)? = nil,
+        forgetProject: (@Sendable (String) throws -> Void)? = nil
     ) {
         let service = RustServiceClient()
         let capture = CaptureController(screenRecordingPermission: screenRecordingPermission)
@@ -115,6 +119,17 @@ final class AppModel: ObservableObject {
                 "rememberScreenshot",
                 params: ["path": outputURL.path],
                 as: PreparedFile.self
+            )
+        }
+        self.trashProjectFile = trashProjectFile ?? { projectURL in
+            var trashedURL: NSURL?
+            try FileManager.default.trashItem(at: projectURL, resultingItemURL: &trashedURL)
+        }
+        self.forgetProject = forgetProject ?? { path in
+            let _: ForgetProjectResult = try service.call(
+                "forgetProject",
+                params: ["path": path],
+                as: ForgetProjectResult.self
             )
         }
         self.screenRecordingPermissionState = screenRecordingPermission.currentState()
@@ -1081,6 +1096,20 @@ final class AppModel: ObservableObject {
 
     func openProject(_ project: ProjectSummary) {
         openProjectFile(at: URL(fileURLWithPath: project.path))
+    }
+
+    func deleteProject(_ project: ProjectSummary) {
+        let projectURL = URL(fileURLWithPath: project.path)
+        do {
+            if FileManager.default.fileExists(atPath: project.path) {
+                try trashProjectFile(projectURL)
+            }
+            try forgetProject(project.path)
+            sendAppShell(.projectSummaryRemoved(path: project.path))
+            statusMessage = "Deleted \(project.title)"
+        } catch {
+            statusMessage = "Could not delete \(project.title): \(error.localizedDescription)"
+        }
     }
 
     func openProjectFile() {

--- a/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
@@ -51,6 +51,7 @@ enum AppShellEvent: Equatable {
     case editorSessionShown(EditorSession)
     case editorMediaOpened(EditorMediaKind, URL)
     case projectSummaryUpserted(ProjectSummary)
+    case projectSummaryRemoved(path: String)
     case projectsReplaced([ProjectSummary])
 }
 
@@ -129,6 +130,10 @@ extension AppShellState {
         case .projectSummaryUpserted(let summary):
             projects.removeAll { $0.path == summary.path }
             projects.insert(summary, at: 0)
+            return []
+
+        case .projectSummaryRemoved(let path):
+            projects.removeAll { $0.path == path }
             return []
 
         case .projectsReplaced(let projects):

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -108,6 +108,10 @@ struct PreparedFile: Codable {
     var path: String
 }
 
+struct ForgetProjectResult: Codable {
+    var removed: Bool
+}
+
 struct ProjectSummary: Codable, Identifiable, Hashable, Sendable {
     var id: String
     var title: String

--- a/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 struct ProjectsStudioView: View {
     @EnvironmentObject private var model: AppModel
     @State private var selectedTab: ProjectLibraryTab = .screenRecordings
+    @State private var projectPendingDeletion: ProjectSummary?
 
     var body: some View {
         ScrollView {
@@ -112,7 +113,9 @@ struct ProjectsStudioView: View {
                     } else {
                         VStack(spacing: 0) {
                             ForEach(selectedProjects) { project in
-                                ProjectListRow(project: project)
+                                ProjectListRow(project: project) { project in
+                                    projectPendingDeletion = project
+                                }
                                 if project.id != selectedProjects.last?.id {
                                     Rectangle()
                                         .fill(Theme.border)
@@ -133,6 +136,23 @@ struct ProjectsStudioView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Theme.appBgMuted)
+        .confirmationDialog(
+            "Delete Project?",
+            isPresented: deleteConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            if let projectPendingDeletion {
+                Button("Move to Trash", role: .destructive) {
+                    model.deleteProject(projectPendingDeletion)
+                    self.projectPendingDeletion = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                projectPendingDeletion = nil
+            }
+        } message: {
+            Text("This moves the .openrecorder project file to Trash. The recording or screenshot media file will not be deleted.")
+        }
     }
 
     private var recordingProjects: [ProjectSummary] {
@@ -150,6 +170,17 @@ struct ProjectsStudioView: View {
         case .screenshots:
             screenshotProjects
         }
+    }
+
+    private var deleteConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { projectPendingDeletion != nil },
+            set: { isPresented in
+                if !isPresented {
+                    projectPendingDeletion = nil
+                }
+            }
+        )
     }
 }
 
@@ -277,6 +308,7 @@ struct ProjectActionCard: View {
 struct ProjectListRow: View {
     @EnvironmentObject private var model: AppModel
     var project: ProjectSummary
+    var requestDelete: (ProjectSummary) -> Void
 
     var body: some View {
         StudioButton(hitTarget: .rectangle) {
@@ -332,6 +364,20 @@ struct ProjectListRow: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
+        }
+        .contextMenu {
+            Button {
+                model.openProject(project)
+            } label: {
+                Label("Open", systemImage: "folder")
+            }
+            .disabled(project.missing)
+
+            Button(role: .destructive) {
+                requestDelete(project)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
         }
         .opacity(project.missing ? 0.55 : 1)
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -643,6 +643,140 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(session.recordingSession?.cursorTelemetryPath, "/tmp/example-recording.cursor.json")
     }
 
+    func testDeletingRecordingProjectTrashesProjectFileAndRemovesProject() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let projectURL = tempDir.appendingPathComponent("recording.openrecorder")
+        try Data("project".utf8).write(to: projectURL)
+        let project = makeDeleteProjectSummary(
+            title: "Recording",
+            projectPath: projectURL.path,
+            recordingPath: "/tmp/recording.mp4",
+            screenshotPath: nil
+        )
+        let other = makeDeleteProjectSummary(
+            title: "Other",
+            projectPath: tempDir.appendingPathComponent("other.openrecorder").path,
+            recordingPath: "/tmp/other.mp4",
+            screenshotPath: nil
+        )
+        let spy = ProjectDeleteSpy()
+        let model = AppModel(
+            trashProjectFile: { try spy.trash($0) },
+            forgetProject: { try spy.forget($0) }
+        )
+        model.projects = [project, other]
+
+        model.deleteProject(project)
+
+        XCTAssertEqual(spy.trashedURLs, [projectURL])
+        XCTAssertEqual(spy.forgottenPaths, [project.path])
+        XCTAssertEqual(model.projects, [other])
+        XCTAssertEqual(model.statusMessage, "Deleted Recording")
+    }
+
+    func testDeletingScreenshotProjectTrashesProjectFileAndRemovesProject() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let projectURL = tempDir.appendingPathComponent("screenshot.openrecorder")
+        try Data("project".utf8).write(to: projectURL)
+        let project = makeDeleteProjectSummary(
+            title: "Screenshot",
+            projectPath: projectURL.path,
+            recordingPath: nil,
+            screenshotPath: "/tmp/screenshot.png"
+        )
+        let spy = ProjectDeleteSpy()
+        let model = AppModel(
+            trashProjectFile: { try spy.trash($0) },
+            forgetProject: { try spy.forget($0) }
+        )
+        model.projects = [project]
+
+        model.deleteProject(project)
+
+        XCTAssertEqual(spy.trashedURLs, [projectURL])
+        XCTAssertEqual(spy.forgottenPaths, [project.path])
+        XCTAssertTrue(model.projects.isEmpty)
+        XCTAssertEqual(model.statusMessage, "Deleted Screenshot")
+    }
+
+    func testDeletingMissingProjectSkipsTrashAndForgetsProject() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let project = makeDeleteProjectSummary(
+            title: "Missing",
+            projectPath: tempDir.appendingPathComponent("missing.openrecorder").path,
+            recordingPath: "/tmp/missing.mp4",
+            screenshotPath: nil,
+            missing: true
+        )
+        let spy = ProjectDeleteSpy()
+        let model = AppModel(
+            trashProjectFile: { try spy.trash($0) },
+            forgetProject: { try spy.forget($0) }
+        )
+        model.projects = [project]
+
+        model.deleteProject(project)
+
+        XCTAssertTrue(spy.trashedURLs.isEmpty)
+        XCTAssertEqual(spy.forgottenPaths, [project.path])
+        XCTAssertTrue(model.projects.isEmpty)
+        XCTAssertEqual(model.statusMessage, "Deleted Missing")
+    }
+
+    func testDeletingProjectFailureLeavesProjectInList() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let projectURL = tempDir.appendingPathComponent("blocked.openrecorder")
+        try Data("project".utf8).write(to: projectURL)
+        let project = makeDeleteProjectSummary(
+            title: "Blocked",
+            projectPath: projectURL.path,
+            recordingPath: "/tmp/blocked.mp4",
+            screenshotPath: nil
+        )
+        let spy = ProjectDeleteSpy(trashError: TestProjectDeleteError.trashFailed)
+        let model = AppModel(
+            trashProjectFile: { try spy.trash($0) },
+            forgetProject: { try spy.forget($0) }
+        )
+        model.projects = [project]
+
+        model.deleteProject(project)
+
+        XCTAssertEqual(spy.trashedURLs, [projectURL])
+        XCTAssertTrue(spy.forgottenPaths.isEmpty)
+        XCTAssertEqual(model.projects, [project])
+        XCTAssertEqual(model.statusMessage, "Could not delete Blocked: Trash failed")
+    }
+
+    func testForgettingProjectFailureLeavesProjectInList() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let project = makeDeleteProjectSummary(
+            title: "Forget Blocked",
+            projectPath: tempDir.appendingPathComponent("forget-blocked.openrecorder").path,
+            recordingPath: "/tmp/forget-blocked.mp4",
+            screenshotPath: nil,
+            missing: true
+        )
+        let spy = ProjectDeleteSpy(forgetError: TestProjectDeleteError.forgetFailed)
+        let model = AppModel(
+            trashProjectFile: { try spy.trash($0) },
+            forgetProject: { try spy.forget($0) }
+        )
+        model.projects = [project]
+
+        model.deleteProject(project)
+
+        XCTAssertTrue(spy.trashedURLs.isEmpty)
+        XCTAssertEqual(spy.forgottenPaths, [project.path])
+        XCTAssertEqual(model.projects, [project])
+        XCTAssertEqual(model.statusMessage, "Could not delete Forget Blocked: Forget failed")
+    }
+
     func testAreaSelectionUsesInteractiveAreaSource() {
         let model = AppModel()
 
@@ -1204,6 +1338,74 @@ private final class ScreenSelectionPresenterSpy: ScreenSelectionPresenting {
 
     func cancel() {
         onCancel?()
+    }
+}
+
+private final class ProjectDeleteSpy: @unchecked Sendable {
+    private let trashError: Error?
+    private let forgetError: Error?
+    private(set) var trashedURLs: [URL] = []
+    private(set) var forgottenPaths: [String] = []
+
+    init(trashError: Error? = nil, forgetError: Error? = nil) {
+        self.trashError = trashError
+        self.forgetError = forgetError
+    }
+
+    func trash(_ url: URL) throws {
+        trashedURLs.append(url)
+        if let trashError {
+            throw trashError
+        }
+    }
+
+    func forget(_ path: String) throws {
+        forgottenPaths.append(path)
+        if let forgetError {
+            throw forgetError
+        }
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("open-recorder-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func makeDeleteProjectSummary(
+    title: String,
+    projectPath: String,
+    recordingPath: String?,
+    screenshotPath: String?,
+    missing: Bool = false
+) -> ProjectSummary {
+    ProjectSummary(
+        id: projectPath,
+        title: title,
+        path: projectPath,
+        recordingPath: recordingPath,
+        screenshotPath: screenshotPath,
+        sourceName: nil,
+        createdAt: "2026-05-25T00:00:00Z",
+        updatedAt: "2026-05-25T00:00:00Z",
+        lastOpenedAt: "2026-05-25T00:00:00Z",
+        missing: missing
+    )
+}
+
+private enum TestProjectDeleteError: LocalizedError {
+    case trashFailed
+    case forgetFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .trashFailed:
+            "Trash failed"
+        case .forgetFailed:
+            "Forget failed"
+        }
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -46,6 +46,18 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(effects, [.setStatusMessage("Rust service ready")])
     }
 
+    func testShellRemovesProjectSummaryByPath() {
+        var state = AppShellState()
+        let first = makeProjectSummary(path: "/p/first.openrecorder")
+        let second = makeProjectSummary(path: "/p/second.openrecorder")
+        state.projects = [first, second]
+
+        let effects = state.applying(.projectSummaryRemoved(path: first.path))
+
+        XCTAssertEqual(effects, [])
+        XCTAssertEqual(state.projects, [second])
+    }
+
     func testShellDriverOwnsLongLivedChildDrivers() {
         let shell = AppShellDriver()
 

--- a/apps/rust-service/src/main.rs
+++ b/apps/rust-service/src/main.rs
@@ -283,12 +283,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
             let projects = read_index(&paths)?
                 .into_iter()
                 .map(|mut item| {
-                    item.missing = item
-                        .recording_path
-                        .as_ref()
-                        .or(item.screenshot_path.as_ref())
-                        .map(|path| !Path::new(path).exists())
-                        .unwrap_or(false);
+                    item.missing = project_is_missing(&item);
                     item
                 })
                 .collect::<Vec<_>>();
@@ -526,6 +521,17 @@ fn write_index(paths: &InternalPaths, projects: &[ProjectSummary]) -> Result<(),
         &paths.project_index,
         &serde_json::to_value(projects).map_err(|err| err.to_string())?,
     )
+}
+
+fn project_is_missing(project: &ProjectSummary) -> bool {
+    let project_file_missing = !Path::new(&project.path).exists();
+    let media_file_missing = project
+        .recording_path
+        .as_ref()
+        .or(project.screenshot_path.as_ref())
+        .map(|path| !Path::new(path).exists())
+        .unwrap_or(false);
+    project_file_missing || media_file_missing
 }
 
 fn screenshot_index_path(paths: &InternalPaths) -> PathBuf {
@@ -795,6 +801,30 @@ mod tests {
             .count();
         assert_eq!(matching, 1);
         assert_eq!(projects[0].title, "Demo 1");
+    }
+
+    #[test]
+    fn project_is_missing_when_project_document_is_missing() {
+        let paths = test_paths("missing-project-document");
+        paths.ensure().unwrap();
+        let project_path = paths.projects_dir.join("demo.openrecorder");
+        let recording_path = paths.recordings_dir.join("demo.mp4");
+        fs::write(&recording_path, b"recording").unwrap();
+
+        let summary = ProjectSummary {
+            id: "project-existing".to_string(),
+            title: "Demo".to_string(),
+            path: project_path.to_string_lossy().to_string(),
+            recording_path: Some(recording_path.to_string_lossy().to_string()),
+            screenshot_path: None,
+            source_name: Some("Display 1".to_string()),
+            created_at: "100".to_string(),
+            updated_at: "100".to_string(),
+            last_opened_at: "150".to_string(),
+            missing: false,
+        };
+
+        assert!(project_is_missing(&summary));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add right-click project row context menu actions for Open and Delete
- confirm destructive deletes before moving .openrecorder project documents to macOS Trash
- remove deleted/stale project entries from the in-memory shell state and persisted project index
- mark project rows missing when either the project document or underlying media file is gone

## Validation
- swift test --package-path apps/macos --filter 'AppShellStateMachineTests|AppModelStateTests'
- cargo test --manifest-path apps/rust-service/Cargo.toml
- swift build --package-path apps/macos
- git diff --check