### PR TITLE
[codex] Scope recording hotkey registration

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -47,7 +47,7 @@ struct CaptureHUD: View {
                     title: model.capture.isRecording ? "Stop" : startStopTitle,
                     symbolName: model.capture.isRecording ? "stop.fill" : "record.circle",
                     isDestructive: model.capture.isRecording,
-                    shortcutText: "⌘R"
+                    shortcutText: recordingShortcutText
                 ) {
                     toggleRecording()
                 }
@@ -71,7 +71,7 @@ struct CaptureHUD: View {
                     title: model.capture.isRecording ? "Stop" : startStopTitle,
                     symbolName: model.capture.isRecording ? "stop.fill" : "record.circle",
                     isDestructive: model.capture.isRecording,
-                    shortcutText: "⌘R"
+                    shortcutText: recordingShortcutText
                 ) {
                     toggleRecording()
                 }
@@ -404,7 +404,13 @@ struct CaptureHUD: View {
     }
 
     private var recordingShortcutHelpTitle: String {
-        "\(model.capture.isRecording ? "Stop" : startStopTitle) (⌘R)"
+        let title = model.capture.isRecording ? "Stop" : startStopTitle
+        guard recordingShortcutText != nil else { return title }
+        return "\(title) (⌘R)"
+    }
+
+    private var recordingShortcutText: String? {
+        model.captureState.shouldRegisterRecordingHotKey(runtimeIsRecording: model.capture.isRecording) ? "⌘R" : nil
     }
 
     private func toggleRecording() {

--- a/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
@@ -344,6 +344,28 @@ struct CaptureState: Hashable {
         }
     }
 
+    func shouldRegisterRecordingHotKey(runtimeIsRecording: Bool) -> Bool {
+        guard !runtimeIsRecording else { return true }
+
+        switch phase {
+        case .ready(.recording, _),
+             .countingDownRecording,
+             .startingRecording,
+             .recording:
+            return true
+        case .idle,
+             .choosingMode,
+             .choosingSourceType,
+             .screenSelecting,
+             .selectingSource,
+             .ready,
+             .areaSelecting,
+             .stoppingRecording,
+             .capturingScreenshot:
+            return false
+        }
+    }
+
     func applying(_ event: CaptureEvent) -> CaptureTransition {
         var next = self
         var effects: [CaptureEffect] = []

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -177,7 +177,6 @@ struct OpenRecorderApp: App {
                 Button("Toggle Recording") {
                     model.toggleRecordingShortcut()
                 }
-                .keyboardShortcut("r", modifiers: [.command])
 
                 Button("Open Project...") {
                     model.openProjectFile()
@@ -547,35 +546,47 @@ private final class GlobalRecordingHotKeyController {
     private weak var model: AppModel?
     private var hotKeyRef: EventHotKeyRef?
     private var eventHandlerRef: EventHandlerRef?
+    private var cancellables: Set<AnyCancellable> = []
 
     func attach(model: AppModel) {
+        if self.model === model {
+            syncRegistration(captureState: model.captureState, runtimeIsRecording: model.capture.isRecording)
+            return
+        }
+
+        unregister()
+        cancellables.removeAll()
         self.model = model
-        registerIfNeeded()
+
+        model.$captureState
+            .sink { [weak self, weak model] state in
+                guard let model else { return }
+                self?.syncRegistration(captureState: state, runtimeIsRecording: model.capture.isRecording)
+            }
+            .store(in: &cancellables)
+
+        model.capture.$isRecording
+            .sink { [weak self, weak model] isRecording in
+                guard let model else { return }
+                self?.syncRegistration(captureState: model.captureState, runtimeIsRecording: isRecording)
+            }
+            .store(in: &cancellables)
+
+        syncRegistration(captureState: model.captureState, runtimeIsRecording: model.capture.isRecording)
+    }
+
+    private func syncRegistration(captureState: CaptureState, runtimeIsRecording: Bool) {
+        if captureState.shouldRegisterRecordingHotKey(runtimeIsRecording: runtimeIsRecording) {
+            registerIfNeeded()
+        } else {
+            unregister()
+        }
     }
 
     private func registerIfNeeded() {
-        guard hotKeyRef == nil, eventHandlerRef == nil else { return }
+        guard hotKeyRef == nil else { return }
 
-        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-        let callback: EventHandlerUPP = { _, _, userData in
-            guard let userData else { return noErr }
-            let controller = Unmanaged<GlobalRecordingHotKeyController>
-                .fromOpaque(userData)
-                .takeUnretainedValue()
-            Task { @MainActor in
-                controller.model?.toggleRecordingShortcut()
-            }
-            return noErr
-        }
-
-        InstallEventHandler(
-            GetApplicationEventTarget(),
-            callback,
-            1,
-            &eventType,
-            UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()),
-            &eventHandlerRef
-        )
+        guard installEventHandlerIfNeeded() else { return }
 
         let hotKeyID = EventHotKeyID(signature: fourCharCode("ORcd"), id: 1)
         let status = RegisterEventHotKey(
@@ -589,6 +600,50 @@ private final class GlobalRecordingHotKeyController {
 
         if status != noErr {
             hotKeyRef = nil
+            unregister()
+        }
+    }
+
+    private func installEventHandlerIfNeeded() -> Bool {
+        guard eventHandlerRef == nil else { return true }
+
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        let callback: EventHandlerUPP = { _, _, userData in
+            guard let userData else { return noErr }
+            let controller = Unmanaged<GlobalRecordingHotKeyController>
+                .fromOpaque(userData)
+                .takeUnretainedValue()
+            Task { @MainActor in
+                controller.model?.toggleRecordingShortcut()
+            }
+            return noErr
+        }
+
+        let status = InstallEventHandler(
+            GetApplicationEventTarget(),
+            callback,
+            1,
+            &eventType,
+            UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()),
+            &eventHandlerRef
+        )
+
+        if status != noErr {
+            eventHandlerRef = nil
+        }
+
+        return status == noErr
+    }
+
+    private func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+
+        if let eventHandlerRef {
+            RemoveEventHandler(eventHandlerRef)
+            self.eventHandlerRef = nil
         }
     }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
@@ -22,6 +22,44 @@ final class CaptureStateReducerTests: XCTestCase {
         XCTAssertEqual(transition.statusMessage, "Finish or cancel the current capture before starting another.")
     }
 
+    func testRecordingHotKeyRegistersOnlyForRecordingReadyAndActiveStates() {
+        let source = makeSource()
+
+        let enabledStates = [
+            CaptureState.ready(.recording, source),
+            .countingDownRecording(source),
+            .startingRecording(source),
+            .recording(source)
+        ]
+
+        for state in enabledStates {
+            XCTAssertTrue(state.shouldRegisterRecordingHotKey(runtimeIsRecording: false), "\(state.phase) should register Cmd-R")
+        }
+
+        let disabledStates = [
+            CaptureState.idle,
+            .choosingMode,
+            .choosingSourceType(.recording),
+            .screenSelecting(.recording),
+            .selectingSource(.recording),
+            .ready(.screenshot, source),
+            .areaSelecting(.recording),
+            .stoppingRecording(source),
+            .capturingScreenshot(source)
+        ]
+
+        for state in disabledStates {
+            XCTAssertFalse(state.shouldRegisterRecordingHotKey(runtimeIsRecording: false), "\(state.phase) should not register Cmd-R")
+        }
+    }
+
+    func testRecordingHotKeyStaysRegisteredWhenRuntimeIsRecording() {
+        let source = makeSource()
+
+        XCTAssertTrue(CaptureState.choosingMode.shouldRegisterRecordingHotKey(runtimeIsRecording: true))
+        XCTAssertTrue(CaptureState.stoppingRecording(source).shouldRegisterRecordingHotKey(runtimeIsRecording: true))
+    }
+
     func testChoosingSourceTypesMovesToDeclarativeSelectionStates() {
         let screen = CaptureState.choosingSourceType(.screenshot).applying(.chooseSourceType(.screen))
         XCTAssertEqual(screen.state.phase, .screenSelecting(.screenshot))


### PR DESCRIPTION
## Summary
- Register the global Cmd-R recording hotkey only while recording is ready, counting down, starting, active, or the runtime reports an active recording.
- Unregister the Carbon hotkey and event handler outside that lifecycle so other apps keep their normal Cmd-R behavior.
- Hide the Cmd-R label from the capture HUD when the shortcut is not actually registered.

## Root Cause
Open Recorder registered Cmd-R globally as soon as the app delegate attached the model, and the app command menu also claimed Cmd-R. That let Open Recorder intercept browser reload shortcuts even when no recording could be started or stopped.

## Validation
- `swift test --package-path apps/macos --filter CaptureStateReducerTests`
- `swift test --package-path apps/macos --filter AppModelStateTests`