### PR TITLE
[codex] Fix video compositor memory growth

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -193,19 +193,25 @@ private struct CursorGlyphCacheKey: Hashable {
 }
 
 final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked Sendable {
+    private let renderingQueueKey = DispatchSpecificKey<Bool>()
     private let renderingQueue = DispatchQueue(label: "com.openrecorder.video.compositor", qos: .userInitiated)
     private let ciContext: CIContext
     private var renderContext: AVVideoCompositionRenderContext?
     private let renderContextLock = NSLock()
     private var cursorGlyphCache: [CursorGlyphCacheKey: CursorGlyphImage] = [:]
 
+    nonisolated static func ciContextOptions() -> [CIContextOption: Any] {
+        [.cacheIntermediates: false]
+    }
+
     override init() {
         if let device = MTLCreateSystemDefaultDevice() {
-            ciContext = CIContext(mtlDevice: device, options: [.cacheIntermediates: true])
+            ciContext = CIContext(mtlDevice: device, options: Self.ciContextOptions())
         } else {
-            ciContext = CIContext(options: [.cacheIntermediates: true])
+            ciContext = CIContext(options: Self.ciContextOptions())
         }
         super.init()
+        renderingQueue.setSpecific(key: renderingQueueKey, value: true)
     }
 
     var sourcePixelBufferAttributes: [String: any Sendable]? {
@@ -229,23 +235,35 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     }
 
     func startRequest(_ request: AVAsynchronousVideoCompositionRequest) {
-        renderingQueue.async { [weak self] in
-            guard let self else {
-                request.finish(with: VideoCompositorError.renderFailed)
-                return
+        let renderRequest = {
+            autoreleasepool {
+                // Backpressure is intentional: queued requests retain decoded pixel buffers.
+                // Finish each frame before AVFoundation can hand us an unbounded backlog.
+                self.finishRequest(request)
             }
+        }
 
-            do {
-                let composedBuffer = try self.composeFrame(for: request)
-                request.finish(withComposedVideoFrame: composedBuffer)
-            } catch {
-                request.finish(with: error)
-            }
+        if DispatchQueue.getSpecific(key: renderingQueueKey) == true {
+            renderRequest()
+        } else {
+            renderingQueue.sync(execute: renderRequest)
+        }
+    }
+
+    private func finishRequest(_ request: AVAsynchronousVideoCompositionRequest) {
+        do {
+            let composedBuffer = try self.composeFrame(for: request)
+            request.finish(withComposedVideoFrame: composedBuffer)
+        } catch {
+            request.finish(with: error)
         }
     }
 
     func cancelAllPendingVideoCompositionRequests() {
-        renderingQueue.sync(flags: .barrier) {}
+        if DispatchQueue.getSpecific(key: renderingQueueKey) == true {
+            return
+        }
+        renderingQueue.sync {}
     }
 
     private func composeFrame(for request: AVAsynchronousVideoCompositionRequest) throws -> CVPixelBuffer {

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -1,9 +1,16 @@
 import CoreGraphics
+import CoreImage
 import SwiftUI
 import XCTest
 @testable import OpenRecorderMac
 
 final class VideoPreviewLayoutTests: XCTestCase {
+    func testVideoCompositorDoesNotCacheStreamingIntermediates() {
+        let options = VideoBackgroundCompositor.ciContextOptions()
+
+        XCTAssertEqual(options[.cacheIntermediates] as? Bool, false)
+    }
+
     func testAutoPreviewAspectUsesCropSelectionAspect() {
         let selection = VideoCropSelection(
             normalizedRect: CGRect(x: 0, y: 0, width: 0.5, height: 1),


### PR DESCRIPTION
## Summary
- Apply backpressure in `VideoBackgroundCompositor` so AVFoundation composition requests cannot build up an unbounded queue of decoded pixel buffers.
- Disable Core Image intermediate caching for streaming video export frames.
- Add a regression check that the compositor uses non-caching CI context options.

## Root Cause
Facecam/styled exports route through the custom video compositor. The compositor previously accepted requests asynchronously on its own serial queue, so export could retain many decoded 32BGRA frame buffers if rendering fell behind decoding/encoding. On high-resolution recordings this could drive memory into tens of GB and hang the app.

## Validation
- `swift test` in `apps/macos`: 313 tests passed, 0 failed
- `cargo test` in `apps/rust-service`: 7 tests passed, 0 failed