### PR TITLE
[codex] Remove HUD surface shadow

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -493,8 +493,6 @@ struct HUDSurface<Content: View>: View {
                         )
                 }
             }
-            .shadow(color: Color.black.opacity(0.40), radius: 26, y: 18)
-            .shadow(color: Color.black.opacity(0.20), radius: 5, y: 1)
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove the two SwiftUI shadow modifiers from the shared HUD surface.
- Keep the HUD material fill, capsule gradient, and stroke styling unchanged.

## Why
The HUD window already disables AppKit shadowing, but the shared SwiftUI HUD surface still drew a small drop shadow below the control. Removing the surface-level shadows makes the HUD sit cleanly over the screen.

## Validation
- `swift test --package-path apps/macos`