### PR TITLE
[codex] Fix export timing sync

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -881,6 +881,7 @@ final class AppModel: ObservableObject {
 
             cursorTelemetryRecorder.start(for: selectedSource)
             let screenStartedAt = try await startRecordingCapture(selectedSource, outputURL, options)
+            cursorTelemetryRecorder.alignStart(to: screenStartedAt)
             activeScreenStartedAt = screenStartedAt
 
             currentVideoURL = outputURL
@@ -1296,6 +1297,10 @@ final class AppModel: ObservableObject {
     }
 
     private func recordingSession(for document: ProjectDocument, recordingURL: URL) -> RecordingSession {
+        if let recordingSession = document.recordingSession {
+            return recordingSession
+        }
+
         let facecamURL = facecamOutputURL(for: recordingURL)
         let existingFacecamURL = FileManager.default.fileExists(atPath: facecamURL.path) ? facecamURL : nil
         let telemetryURL = CursorTelemetryRecorder.telemetryURL(for: recordingURL)

--- a/apps/macos/Sources/OpenRecorderMac/CursorTelemetryRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CursorTelemetryRecorder.swift
@@ -41,6 +41,30 @@ struct CursorTelemetryPayload: Codable, Equatable {
         self.clicks = clicks
     }
 
+    func offsetTimestamps(byMilliseconds offset: Int) -> CursorTelemetryPayload {
+        CursorTelemetryPayload(
+            width: width,
+            height: height,
+            samples: samples.map {
+                CursorTelemetrySample(
+                    x: $0.x,
+                    y: $0.y,
+                    timestamp: $0.timestamp + offset,
+                    cursorType: $0.cursorType
+                )
+            },
+            clicks: clicks.map {
+                CursorTelemetryClick(
+                    x: $0.x,
+                    y: $0.y,
+                    timestamp: $0.timestamp + offset,
+                    button: $0.button,
+                    clickCount: $0.clickCount
+                )
+            }
+        )
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         width = try container.decode(Int.self, forKey: .width)
@@ -214,6 +238,29 @@ final class CursorTelemetryRecorder {
                 self?.sample()
             }
         }
+    }
+
+    func alignStart(to mediaStartedAt: Date) {
+        guard let previousStartedAt = startedAt else { return }
+        let offset = Int(previousStartedAt.timeIntervalSince(mediaStartedAt) * 1000)
+        samples = samples.map {
+            CursorTelemetrySample(
+                x: $0.x,
+                y: $0.y,
+                timestamp: $0.timestamp + offset,
+                cursorType: $0.cursorType
+            )
+        }
+        clicks = clicks.map {
+            CursorTelemetryClick(
+                x: $0.x,
+                y: $0.y,
+                timestamp: $0.timestamp + offset,
+                button: $0.button,
+                clickCount: $0.clickCount
+            )
+        }
+        startedAt = mediaStartedAt
     }
 
     @discardableResult

--- a/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
@@ -119,7 +119,8 @@ struct VideoEditorState: Equatable {
             recordingPath: videoURL.path,
             screenshotPath: nil,
             sourceName: recordingSession?.sourceName,
-            editorState: ProjectEditorState(timelineEdits: timelineEdits, video: video)
+            editorState: ProjectEditorState(timelineEdits: timelineEdits, video: video),
+            recordingSession: recordingSession
         )
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -142,6 +142,7 @@ struct ProjectDocument: Codable {
     var createdAt: String
     var updatedAt: String
     var editorState: ProjectEditorState?
+    var recordingSession: RecordingSession?
 
     var mediaKind: EditorMediaKind? {
         if screenshotPath != nil {

--- a/apps/macos/Sources/OpenRecorderMac/ProjectAutosave.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectAutosave.swift
@@ -7,6 +7,7 @@ struct ProjectAutosaveSnapshot: Equatable {
     var screenshotPath: String?
     var sourceName: String?
     var editorState: ProjectEditorState
+    var recordingSession: RecordingSession?
 }
 
 enum ProjectAutosaveStatus: Equatable {
@@ -22,6 +23,7 @@ struct ProjectUpdateRequest: Encodable {
     var screenshotPath: String?
     var sourceName: String?
     var editorState: ProjectEditorState
+    var recordingSession: RecordingSession?
 
     init(snapshot: ProjectAutosaveSnapshot) {
         path = snapshot.projectPath
@@ -30,6 +32,7 @@ struct ProjectUpdateRequest: Encodable {
         screenshotPath = snapshot.screenshotPath
         sourceName = snapshot.sourceName
         editorState = snapshot.editorState
+        recordingSession = snapshot.recordingSession
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorState.swift
@@ -67,7 +67,8 @@ struct ScreenshotEditorMachineState: Equatable {
             recordingPath: nil,
             screenshotPath: screenshotURL.path,
             sourceName: nil,
-            editorState: ProjectEditorState(screenshot: screenshot)
+            editorState: ProjectEditorState(screenshot: screenshot),
+            recordingSession: nil
         )
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
@@ -270,10 +270,15 @@ enum TimelineAudioWaveformLoader {
             }
 
             let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+            let bufferFrameOffset = frameOffsetForSampleBuffer(
+                sampleBuffer,
+                sampleRate: sampleRate,
+                fallback: frameOffset
+            )
             try addSampleBuffer(
                 sampleBuffer,
                 channelCount: channelCount,
-                frameOffset: frameOffset,
+                frameOffset: bufferFrameOffset,
                 totalFrames: totalFrames,
                 to: &accumulator
             )
@@ -297,6 +302,26 @@ enum TimelineAudioWaveformLoader {
         return AudioTrackFormat(
             channelCount: streamDescription.pointee.mChannelsPerFrame,
             sampleRate: streamDescription.pointee.mSampleRate
+        )
+    }
+
+    static func frameOffsetForPresentationTime(_ time: CMTime, sampleRate: Double, fallback: Int64) -> Int64 {
+        let seconds = time.seconds
+        guard seconds.isFinite, sampleRate.isFinite, sampleRate > 0 else {
+            return fallback
+        }
+        return max(0, Int64((seconds * sampleRate).rounded()))
+    }
+
+    private static func frameOffsetForSampleBuffer(
+        _ sampleBuffer: CMSampleBuffer,
+        sampleRate: Double,
+        fallback: Int64
+    ) -> Int64 {
+        frameOffsetForPresentationTime(
+            CMSampleBufferGetPresentationTimeStamp(sampleBuffer),
+            sampleRate: sampleRate,
+            fallback: fallback
         )
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
@@ -410,18 +410,17 @@ enum TimelineZoomCanvasTransform {
         cursorTrack: CursorTelemetryTrack? = nil
     ) -> TimelineZoomEffect? {
         guard outputTime.isFinite else { return nil }
-        let activeZoom = edits.zoomRegions
+        let active = edits.zoomRegions
             .sorted { $0.span.start < $1.span.start }
-            .last { zoom in
-                let start = editPlan.outputTime(forSourceTime: zoom.span.start) ?? zoom.span.start
-                let end = editPlan.outputTime(forSourceTime: zoom.span.end) ?? zoom.span.end
-                return outputTime >= start && outputTime < end
+            .compactMap { zoom -> (TimelineZoomRegion, TimelineSpan)? in
+                guard let outputSpan = editPlan.outputSpans(forSourceSpan: zoom.span).last(where: { $0.contains(outputTime) }) else {
+                    return nil
+                }
+                return (zoom, outputSpan)
             }
-        guard let zoom = activeZoom else { return nil }
+            .last
+        guard let (zoom, outputSpan) = active else { return nil }
 
-        let start = editPlan.outputTime(forSourceTime: zoom.span.start) ?? zoom.span.start
-        let end = editPlan.outputTime(forSourceTime: zoom.span.end) ?? zoom.span.end
-        let outputSpan = TimelineSpan(start: start, end: end)
         let progress = TimelineZoomAnimator.animationProgress(for: outputSpan, preset: zoom.animationPreset, at: outputTime)
         let depth = 1 + (max(1, zoom.depth) - 1) * progress
         let sourceTime = editPlan.sourceTime(forOutputTime: outputTime) ?? outputTime
@@ -1532,6 +1531,21 @@ struct TimelineExportEditPlan: Equatable {
             return segment.outputStart + (sourceTime - segment.sourceStart) / max(0.05, segment.speed)
         }
         return nil
+    }
+
+    func outputSpans(forSourceSpan sourceSpan: TimelineSpan) -> [TimelineSpan] {
+        guard sourceSpan.duration > 0 else { return [] }
+        return segments.compactMap { segment in
+            let clippedStart = max(sourceSpan.start, segment.sourceStart)
+            let clippedEnd = min(sourceSpan.end, segment.sourceEnd)
+            guard clippedEnd - clippedStart > 0.001 else { return nil }
+
+            let speed = max(0.05, segment.speed)
+            let outputStart = segment.outputStart + (clippedStart - segment.sourceStart) / speed
+            let outputEnd = segment.outputStart + (clippedEnd - segment.sourceStart) / speed
+            guard outputEnd - outputStart > 0.001 else { return nil }
+            return TimelineSpan(start: outputStart, end: outputEnd)
+        }
     }
 
     func sourceTime(forOutputTime outputTime: Double) -> Double? {

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -358,7 +358,9 @@ enum VideoExportRenderer {
 
         let naturalSize = try await videoTrack.load(.naturalSize)
         let preferredTransform = try await videoTrack.load(.preferredTransform)
-        let duration = try await asset.load(.duration)
+        let assetDuration = try await asset.load(.duration)
+        let videoTrackTimeRange = try await videoTrack.load(.timeRange)
+        let sourceDuration = exportSourceDuration(assetDuration: assetDuration, videoTrackTimeRange: videoTrackTimeRange)
         let frameDuration = try await options.frameRate.frameDuration(for: videoTrack)
         let normalizedSourceSize = normalizedSize(for: naturalSize, preferredTransform: preferredTransform)
         let cropRect = normalizedCropRect(for: options.cropSelection, sourceSize: normalizedSourceSize)
@@ -369,7 +371,7 @@ enum VideoExportRenderer {
 
         let exportAsset = try await makeEditedAsset(
             from: asset,
-            duration: duration,
+            sourceDuration: sourceDuration,
             edits: edits,
             facecamURL: options.facecamVideoURL,
             facecamOffsetMs: options.facecamOffsetMs
@@ -382,6 +384,10 @@ enum VideoExportRenderer {
         exportSession.outputURL = targetURL
         exportSession.outputFileType = options.format.avFileType
         exportSession.shouldOptimizeForNetworkUse = true
+        exportSession.timeRange = CMTimeRange(
+            start: .zero,
+            duration: CMTime(seconds: max(0.001, exportAsset.duration), preferredTimescale: 600)
+        )
         exportSession.videoComposition = makeVideoComposition(
             for: exportAsset.videoTrack ?? videoTrack,
             sourceSize: naturalSize,
@@ -459,14 +465,53 @@ enum VideoExportRenderer {
         var plan: TimelineExportEditPlan
     }
 
+    struct MediaTrackInsertion: Equatable {
+        var sourceRange: CMTimeRange
+        var outputStart: CMTime
+        var scaledDuration: CMTime
+    }
+
+    nonisolated static func mediaInsertion(
+        for segment: TimelineExportEditPlan.Segment,
+        availableSourceRange: CMTimeRange,
+        sourceOffsetSeconds: Double = 0,
+        preferredTimescale: CMTimeScale = 600
+    ) -> MediaTrackInsertion? {
+        let segmentSourceStart = segment.sourceStart - sourceOffsetSeconds
+        let segmentSourceEnd = segment.sourceEnd - sourceOffsetSeconds
+        let availableStart = availableSourceRange.start.seconds
+        let availableEnd = availableSourceRange.end.seconds
+        guard segmentSourceStart.isFinite,
+              segmentSourceEnd.isFinite,
+              availableStart.isFinite,
+              availableEnd.isFinite else {
+            return nil
+        }
+
+        let clippedStart = max(availableStart, segmentSourceStart)
+        let clippedEnd = min(availableEnd, segmentSourceEnd)
+        guard clippedEnd - clippedStart > 0.001 else { return nil }
+
+        let speed = max(0.05, segment.speed)
+        let outputStartSeconds = segment.outputStart + (clippedStart - segmentSourceStart) / speed
+        let outputDurationSeconds = (clippedEnd - clippedStart) / speed
+        return MediaTrackInsertion(
+            sourceRange: CMTimeRange(
+                start: CMTime(seconds: clippedStart, preferredTimescale: preferredTimescale),
+                end: CMTime(seconds: clippedEnd, preferredTimescale: preferredTimescale)
+            ),
+            outputStart: CMTime(seconds: outputStartSeconds, preferredTimescale: preferredTimescale),
+            scaledDuration: CMTime(seconds: outputDurationSeconds, preferredTimescale: preferredTimescale)
+        )
+    }
+
     private static func makeEditedAsset(
         from asset: AVAsset,
-        duration: CMTime,
+        sourceDuration: Double,
         edits: TimelineEditSnapshot,
         facecamURL: URL?,
         facecamOffsetMs: Int?
     ) async throws -> EditedAsset {
-        let sourceDuration = max(0, duration.seconds)
         let plan = TimelineExportEditPlan.build(duration: sourceDuration, edits: edits)
         let facecamAsset = facecamURL.map { AVURLAsset(url: $0) }
         let facecamTracks = try await facecamAsset?.loadTracks(withMediaType: .video) ?? []
@@ -490,17 +535,20 @@ enum VideoExportRenderer {
                 if mediaType == .video, compositionVideoTrack == nil {
                     compositionVideoTrack = compositionTrack
                 }
+                let sourceTrackTimeRange = try await sourceTrack.load(.timeRange)
                 for segment in plan.segments {
-                    let sourceRange = CMTimeRange(
-                        start: CMTime(seconds: segment.sourceStart, preferredTimescale: 600),
-                        end: CMTime(seconds: segment.sourceEnd, preferredTimescale: 600)
-                    )
-                    let outputStart = CMTime(seconds: segment.outputStart, preferredTimescale: 600)
-                    try compositionTrack.insertTimeRange(sourceRange, of: sourceTrack, at: outputStart)
-                    let outputRange = CMTimeRange(start: outputStart, duration: sourceRange.duration)
+                    guard let insertion = mediaInsertion(
+                        for: segment,
+                        availableSourceRange: sourceTrackTimeRange
+                    ) else {
+                        continue
+                    }
+
+                    try compositionTrack.insertTimeRange(insertion.sourceRange, of: sourceTrack, at: insertion.outputStart)
+                    let outputRange = CMTimeRange(start: insertion.outputStart, duration: insertion.sourceRange.duration)
                     compositionTrack.scaleTimeRange(
                         outputRange,
-                        toDuration: CMTime(seconds: segment.outputEnd - segment.outputStart, preferredTimescale: 600)
+                        toDuration: insertion.scaledDuration
                     )
                     compositionTrack.preferredTransform = try await sourceTrack.load(.preferredTransform)
                 }
@@ -510,9 +558,8 @@ enum VideoExportRenderer {
         var compositionFacecamTrack: AVMutableCompositionTrack?
         var facecamPreferredTransform = CGAffineTransform.identity
         var facecamNormalizedSize = CGSize.zero
-        if let facecamAsset,
-           let facecamSourceTrack {
-            let facecamDuration = max(0, (try? await facecamAsset.load(.duration).seconds) ?? 0)
+        if let facecamSourceTrack {
+            let facecamTrackTimeRange = try await facecamSourceTrack.load(.timeRange)
             facecamPreferredTransform = (try? await facecamSourceTrack.load(.preferredTransform)) ?? .identity
             let facecamNaturalSize = (try? await facecamSourceTrack.load(.naturalSize)) ?? .zero
             facecamNormalizedSize = normalizedSize(for: facecamNaturalSize, preferredTransform: facecamPreferredTransform)
@@ -522,24 +569,19 @@ enum VideoExportRenderer {
             facecamTrack?.preferredTransform = facecamPreferredTransform
 
             for segment in plan.segments {
-                let sourceFaceStart = segment.sourceStart - offsetSeconds
-                let sourceFaceEnd = segment.sourceEnd - offsetSeconds
-                let clippedStart = max(0, sourceFaceStart)
-                let clippedEnd = min(facecamDuration, sourceFaceEnd)
-                guard clippedEnd - clippedStart > 0.001 else { continue }
+                guard let insertion = mediaInsertion(
+                    for: segment,
+                    availableSourceRange: facecamTrackTimeRange,
+                    sourceOffsetSeconds: offsetSeconds
+                ) else {
+                    continue
+                }
 
-                let speed = max(0.05, segment.speed)
-                let outputStartSeconds = segment.outputStart + (clippedStart - sourceFaceStart) / speed
-                let sourceRange = CMTimeRange(
-                    start: CMTime(seconds: clippedStart, preferredTimescale: 600),
-                    end: CMTime(seconds: clippedEnd, preferredTimescale: 600)
-                )
-                let outputStart = CMTime(seconds: outputStartSeconds, preferredTimescale: 600)
-                try facecamTrack?.insertTimeRange(sourceRange, of: facecamSourceTrack, at: outputStart)
-                let outputRange = CMTimeRange(start: outputStart, duration: sourceRange.duration)
+                try facecamTrack?.insertTimeRange(insertion.sourceRange, of: facecamSourceTrack, at: insertion.outputStart)
+                let outputRange = CMTimeRange(start: insertion.outputStart, duration: insertion.sourceRange.duration)
                 facecamTrack?.scaleTimeRange(
                     outputRange,
-                    toDuration: CMTime(seconds: (clippedEnd - clippedStart) / speed, preferredTimescale: 600)
+                    toDuration: insertion.scaledDuration
                 )
             }
         }
@@ -577,6 +619,14 @@ enum VideoExportRenderer {
             height: sourceHeight,
             aspectRatio: aspectRatio
         )
+    }
+
+    nonisolated static func exportSourceDuration(assetDuration: CMTime, videoTrackTimeRange: CMTimeRange) -> Double {
+        let assetSeconds = assetDuration.seconds
+        let videoEndSeconds = videoTrackTimeRange.end.seconds
+        let candidates = [assetSeconds, videoEndSeconds].filter { $0.isFinite && $0 > 0 }
+        guard let shortest = candidates.min() else { return 0 }
+        return shortest
     }
 
     private static func outputSize(forAspectRatio aspectRatio: CGFloat, targetShortEdge: CGFloat) -> CGSize {
@@ -764,30 +814,30 @@ enum VideoExportRenderer {
         contentLayer.addSublayer(videoLayer)
 
         for annotation in edits.annotationRegions {
-            let textLayer = CATextLayer()
-            textLayer.string = annotation.text
-            textLayer.fontSize = annotation.fontSize
-            textLayer.alignmentMode = .center
-            textLayer.foregroundColor = NSColor.white.cgColor
-            textLayer.backgroundColor = NSColor.black.withAlphaComponent(0.62).cgColor
-            textLayer.cornerRadius = 10
-            textLayer.masksToBounds = true
-            let width = min(outputSize.width * 0.72, max(180, CGFloat(annotation.text.count * 18)))
-            let height = annotation.fontSize + 24
-            textLayer.frame = CGRect(x: outputSize.width * annotation.x - width / 2, y: outputSize.height * (1 - annotation.y) - height / 2, width: width, height: height)
-            textLayer.opacity = 0
+            for outputSpan in editPlan.outputSpans(forSourceSpan: annotation.span) {
+                let textLayer = CATextLayer()
+                textLayer.string = annotation.text
+                textLayer.fontSize = annotation.fontSize
+                textLayer.alignmentMode = .center
+                textLayer.foregroundColor = NSColor.white.cgColor
+                textLayer.backgroundColor = NSColor.black.withAlphaComponent(0.62).cgColor
+                textLayer.cornerRadius = 10
+                textLayer.masksToBounds = true
+                let width = min(outputSize.width * 0.72, max(180, CGFloat(annotation.text.count * 18)))
+                let height = annotation.fontSize + 24
+                textLayer.frame = CGRect(x: outputSize.width * annotation.x - width / 2, y: outputSize.height * (1 - annotation.y) - height / 2, width: width, height: height)
+                textLayer.opacity = 0
 
-            let start = editPlan.outputTime(forSourceTime: annotation.span.start) ?? annotation.span.start
-            let end = editPlan.outputTime(forSourceTime: annotation.span.end) ?? annotation.span.end
-            let animation = CAKeyframeAnimation(keyPath: "opacity")
-            animation.values = [0, 1, 1, 0]
-            animation.keyTimes = [0, 0.08, 0.92, 1]
-            animation.beginTime = AVCoreAnimationBeginTimeAtZero + start
-            animation.duration = max(0.05, end - start)
-            animation.isRemovedOnCompletion = false
-            animation.fillMode = .both
-            textLayer.add(animation, forKey: "visible")
-            contentLayer.addSublayer(textLayer)
+                let animation = CAKeyframeAnimation(keyPath: "opacity")
+                animation.values = [0, 1, 1, 0]
+                animation.keyTimes = [0, 0.08, 0.92, 1]
+                animation.beginTime = AVCoreAnimationBeginTimeAtZero + outputSpan.start
+                animation.duration = max(0.05, outputSpan.duration)
+                animation.isRemovedOnCompletion = false
+                animation.fillMode = .both
+                textLayer.add(animation, forKey: "visible")
+                contentLayer.addSublayer(textLayer)
+            }
         }
 
         if let cursorTrack, cursorSettings.clamped.isVisible {

--- a/apps/macos/Tests/OpenRecorderMacTests/CursorTelemetryTrackTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CursorTelemetryTrackTests.swift
@@ -3,6 +3,26 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class CursorTelemetryTrackTests: XCTestCase {
+    func testPayloadOffsetTimestampsShiftsSamplesAndClicks() {
+        let payload = CursorTelemetryPayload(
+            width: 100,
+            height: 80,
+            samples: [
+                CursorTelemetrySample(x: 10, y: 20, timestamp: 100, cursorType: "arrow"),
+                CursorTelemetrySample(x: 20, y: 30, timestamp: 300, cursorType: "beam")
+            ],
+            clicks: [
+                CursorTelemetryClick(x: 10, y: 20, timestamp: 150, button: "left", clickCount: 1)
+            ]
+        )
+
+        let shifted = payload.offsetTimestamps(byMilliseconds: 250)
+
+        XCTAssertEqual(shifted.samples.map(\.timestamp), [350, 550])
+        XCTAssertEqual(shifted.samples.map(\.cursorType), ["arrow", "beam"])
+        XCTAssertEqual(shifted.clicks.map(\.timestamp), [400])
+    }
+
     func testCursorTrackInterpolatesBetweenSamples() {
         let track = CursorTelemetryTrack(payload: CursorTelemetryPayload(
             width: 100,

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -50,7 +50,8 @@ final class VideoEditorStateMachineTests: XCTestCase {
                 recordingPath: videoURL.path,
                 screenshotPath: nil,
                 sourceName: "Display 1",
-                editorState: ProjectEditorState(timelineEdits: timeline, video: initialVideo)
+                editorState: ProjectEditorState(timelineEdits: timeline, video: initialVideo),
+                recordingSession: context.recordingSession
             ))
         ])
 
@@ -164,7 +165,8 @@ final class VideoEditorStateMachineTests: XCTestCase {
             recordingPath: recordingURL.path,
             screenshotPath: nil,
             sourceName: nil,
-            editorState: ProjectEditorState(timelineEdits: edits, video: state.video)
+            editorState: ProjectEditorState(timelineEdits: edits, video: state.video),
+            recordingSession: nil
         )
         _ = state.applying(.exportRequested)
 
@@ -202,7 +204,8 @@ final class VideoEditorStateMachineTests: XCTestCase {
             recordingPath: "/tmp/autosave.mp4",
             screenshotPath: nil,
             sourceName: nil,
-            editorState: ProjectEditorState(video: .default)
+            editorState: ProjectEditorState(video: .default),
+            recordingSession: nil
         )
 
         XCTAssertEqual(state.applying(.autosaveSnapshotChanged(snapshot)), [.scheduleAutosave(snapshot)])
@@ -448,7 +451,8 @@ final class ScreenshotEditorStateMachineTests: XCTestCase {
                 recordingPath: nil,
                 screenshotPath: screenshotURL.path,
                 sourceName: nil,
-                editorState: ProjectEditorState(screenshot: initialState)
+                editorState: ProjectEditorState(screenshot: initialState),
+                recordingSession: nil
             ))
         ])
         XCTAssertTrue(state.applying(.sessionChanged(context)).isEmpty)
@@ -495,7 +499,8 @@ final class ScreenshotEditorStateMachineTests: XCTestCase {
             recordingPath: nil,
             screenshotPath: "/tmp/shot.png",
             sourceName: nil,
-            editorState: ProjectEditorState(screenshot: .default)
+            editorState: ProjectEditorState(screenshot: .default),
+            recordingSession: nil
         )
         let exportURL = URL(fileURLWithPath: "/tmp/exported-shot.png")
 

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -88,6 +88,41 @@ final class ProjectEditorStateCodableTests: XCTestCase {
 
         XCTAssertEqual(document.editorState?.timelineEdits.clipSplitTimes, [1.5])
         XCTAssertNil(document.editorState?.video)
+        XCTAssertNil(document.recordingSession)
+    }
+
+    func testProjectDocumentRoundTripsRecordingSessionTimingMetadata() throws {
+        let session = makeProjectRecordingSession()
+        let document = ProjectDocument(
+            schemaVersion: 2,
+            title: "Demo",
+            recordingPath: session.screenVideoPath,
+            screenshotPath: nil,
+            sourceName: "Display 1",
+            createdAt: "100",
+            updatedAt: "200",
+            editorState: ProjectEditorState(timelineEdits: .empty, video: .default),
+            recordingSession: session
+        )
+
+        let data = try JSONEncoder().encode(document)
+        let decoded = try JSONDecoder().decode(ProjectDocument.self, from: data)
+
+        XCTAssertEqual(decoded.recordingSession, session)
+        XCTAssertEqual(decoded.recordingSession?.facecamOffsetMs, -375)
+        XCTAssertEqual(decoded.recordingSession?.cursorTelemetryPath, "/tmp/demo.cursor.json")
+    }
+
+    func testProjectUpdateRequestEncodesRecordingSession() throws {
+        let session = makeProjectRecordingSession()
+        let snapshot = makeAutosaveSnapshot(title: "Demo", splitTime: 1.5, recordingSession: session)
+
+        let data = try JSONEncoder().encode(ProjectUpdateRequest(snapshot: snapshot))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let encodedSession = try XCTUnwrap(json["recordingSession"] as? [String: Any])
+
+        XCTAssertEqual(encodedSession["facecamOffsetMs"] as? Int, -375)
+        XCTAssertEqual(encodedSession["cursorTelemetryPath"] as? String, "/tmp/demo.cursor.json")
     }
 
     func testProjectEditorStateRoundTripsVideoState() throws {
@@ -155,7 +190,11 @@ final class ProjectEditorStateCodableTests: XCTestCase {
     }
 }
 
-private func makeAutosaveSnapshot(title: String, splitTime: Double) -> ProjectAutosaveSnapshot {
+private func makeAutosaveSnapshot(
+    title: String,
+    splitTime: Double,
+    recordingSession: RecordingSession? = nil
+) -> ProjectAutosaveSnapshot {
     var timeline = TimelineEditSnapshot.empty
     timeline.clipSplitTimes = [splitTime]
     return ProjectAutosaveSnapshot(
@@ -164,7 +203,20 @@ private func makeAutosaveSnapshot(title: String, splitTime: Double) -> ProjectAu
         recordingPath: "/tmp/\(title).mp4",
         screenshotPath: nil,
         sourceName: "Display 1",
-        editorState: ProjectEditorState(timelineEdits: timeline, video: .default)
+        editorState: ProjectEditorState(timelineEdits: timeline, video: .default),
+        recordingSession: recordingSession
+    )
+}
+
+private func makeProjectRecordingSession() -> RecordingSession {
+    RecordingSession(
+        screenVideoPath: "/tmp/demo.mp4",
+        facecamVideoPath: "/tmp/demo.facecam.mov",
+        facecamOffsetMs: -375,
+        facecamSettings: defaultFacecamSettings(enabled: true),
+        sourceName: "Display 1",
+        showCursorOverlay: true,
+        cursorTelemetryPath: "/tmp/demo.cursor.json"
     )
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 @testable import OpenRecorderMac
 
@@ -81,6 +82,26 @@ final class TimelineAudioWaveformTests: XCTestCase {
         )
 
         XCTAssertEqual(samples.count, 12)
+    }
+
+    func testWaveformFrameOffsetUsesPresentationTimestamp() {
+        let offset = TimelineAudioWaveformLoader.frameOffsetForPresentationTime(
+            CMTime(seconds: 2.5, preferredTimescale: 600),
+            sampleRate: 48_000,
+            fallback: 12
+        )
+
+        XCTAssertEqual(offset, 120_000)
+    }
+
+    func testWaveformFrameOffsetFallsBackForInvalidPresentationTimestamp() {
+        let offset = TimelineAudioWaveformLoader.frameOffsetForPresentationTime(
+            CMTime.invalid,
+            sampleRate: 48_000,
+            fallback: 12
+        )
+
+        XCTAssertEqual(offset, 12)
     }
 
     func testShortTimelineTicksUseSecondLabels() {
@@ -269,6 +290,45 @@ final class TimelineEditingPlanTests: XCTestCase {
         XCTAssertEqual(plan.outputDuration, 5, accuracy: 0.001)
         XCTAssertEqual(plan.segments.map(\.sourceStart), [0, 5])
         XCTAssertEqual(plan.segments.map(\.sourceEnd), [2, 8])
+    }
+
+    func testExportPlanMapsSourceSpanToEditedOutputSpans() {
+        let edits = TimelineEditSnapshot(
+            trimRegions: [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 3))],
+            clipSplitTimes: [4, 6],
+            clipSpeeds: [1: 2]
+        )
+        let plan = TimelineExportEditPlan.build(duration: 8, edits: edits)
+
+        let spans = plan.outputSpans(forSourceSpan: TimelineSpan(start: 1, end: 6))
+
+        XCTAssertEqual(spans.count, 3)
+        XCTAssertEqual(spans[0].start, 1, accuracy: 0.001)
+        XCTAssertEqual(spans[0].end, 2, accuracy: 0.001)
+        XCTAssertEqual(spans[1].start, 2, accuracy: 0.001)
+        XCTAssertEqual(spans[1].end, 3, accuracy: 0.001)
+        XCTAssertEqual(spans[2].start, 3, accuracy: 0.001)
+        XCTAssertEqual(spans[2].end, 4, accuracy: 0.001)
+    }
+
+    func testExportPlanDropsFullyTrimmedSourceSpan() {
+        let edits = TimelineEditSnapshot(
+            trimRegions: [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 5))]
+        )
+        let plan = TimelineExportEditPlan.build(duration: 8, edits: edits)
+
+        XCTAssertTrue(plan.outputSpans(forSourceSpan: TimelineSpan(start: 3, end: 4)).isEmpty)
+    }
+
+    func testExportZoomEffectIgnoresFullyTrimmedRegion() {
+        let zoom = TimelineZoomRegion(span: TimelineSpan(start: 3, end: 4), depth: 2)
+        let edits = TimelineEditSnapshot(
+            zoomRegions: [zoom],
+            trimRegions: [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 5))]
+        )
+        let plan = TimelineExportEditPlan.build(duration: 8, edits: edits)
+
+        XCTAssertNil(TimelineZoomCanvasTransform.activeEffect(edits: edits, editPlan: plan, outputTime: 2.5))
     }
 
     @MainActor

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoExportRendererTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoExportRendererTests.swift
@@ -1,0 +1,120 @@
+import AVFoundation
+import XCTest
+@testable import OpenRecorderMac
+
+final class VideoExportRendererTests: XCTestCase {
+    func testMediaInsertionPreservesDelayedSourceTrackStart() {
+        let segment = TimelineExportEditPlan.Segment(
+            sourceStart: 0,
+            sourceEnd: 10,
+            outputStart: 0,
+            outputEnd: 10,
+            speed: 1
+        )
+        let availableRange = CMTimeRange(
+            start: CMTime(seconds: 0.35, preferredTimescale: 600),
+            end: CMTime(seconds: 10, preferredTimescale: 600)
+        )
+
+        let insertion = VideoExportRenderer.mediaInsertion(
+            for: segment,
+            availableSourceRange: availableRange
+        )
+
+        XCTAssertEqual(insertion?.sourceRange.start.seconds ?? -1, 0.35, accuracy: 0.001)
+        XCTAssertEqual(insertion?.sourceRange.end.seconds ?? -1, 10, accuracy: 0.001)
+        XCTAssertEqual(insertion?.outputStart.seconds ?? -1, 0.35, accuracy: 0.001)
+        XCTAssertEqual(insertion?.scaledDuration.seconds ?? -1, 9.65, accuracy: 0.001)
+    }
+
+    func testMediaInsertionAppliesFacecamOffsetAndSpeed() {
+        let segment = TimelineExportEditPlan.Segment(
+            sourceStart: 4,
+            sourceEnd: 8,
+            outputStart: 2,
+            outputEnd: 4,
+            speed: 2
+        )
+        let availableRange = CMTimeRange(
+            start: .zero,
+            end: CMTime(seconds: 6, preferredTimescale: 600)
+        )
+
+        let insertion = VideoExportRenderer.mediaInsertion(
+            for: segment,
+            availableSourceRange: availableRange,
+            sourceOffsetSeconds: 1.5
+        )
+
+        XCTAssertEqual(insertion?.sourceRange.start.seconds ?? -1, 2.5, accuracy: 0.001)
+        XCTAssertEqual(insertion?.sourceRange.end.seconds ?? -1, 6, accuracy: 0.001)
+        XCTAssertEqual(insertion?.outputStart.seconds ?? -1, 2, accuracy: 0.001)
+        XCTAssertEqual(insertion?.scaledDuration.seconds ?? -1, 1.75, accuracy: 0.001)
+    }
+
+    func testMediaInsertionOffsetsOutputWhenOffsetTrackStartsInsideSegment() {
+        let segment = TimelineExportEditPlan.Segment(
+            sourceStart: 0,
+            sourceEnd: 5,
+            outputStart: 3,
+            outputEnd: 8,
+            speed: 1
+        )
+        let availableRange = CMTimeRange(
+            start: CMTime(seconds: 2, preferredTimescale: 600),
+            end: CMTime(seconds: 9, preferredTimescale: 600)
+        )
+
+        let insertion = VideoExportRenderer.mediaInsertion(
+            for: segment,
+            availableSourceRange: availableRange
+        )
+
+        XCTAssertEqual(insertion?.sourceRange.start.seconds ?? -1, 2, accuracy: 0.001)
+        XCTAssertEqual(insertion?.sourceRange.end.seconds ?? -1, 5, accuracy: 0.001)
+        XCTAssertEqual(insertion?.outputStart.seconds ?? -1, 5, accuracy: 0.001)
+        XCTAssertEqual(insertion?.scaledDuration.seconds ?? -1, 3, accuracy: 0.001)
+    }
+
+    func testMediaInsertionReturnsNilWhenTrackDoesNotOverlapSegment() {
+        let segment = TimelineExportEditPlan.Segment(
+            sourceStart: 0,
+            sourceEnd: 2,
+            outputStart: 0,
+            outputEnd: 2,
+            speed: 1
+        )
+        let availableRange = CMTimeRange(
+            start: CMTime(seconds: 3, preferredTimescale: 600),
+            end: CMTime(seconds: 5, preferredTimescale: 600)
+        )
+
+        let insertion = VideoExportRenderer.mediaInsertion(
+            for: segment,
+            availableSourceRange: availableRange
+        )
+
+        XCTAssertNil(insertion)
+    }
+
+    func testExportSourceDurationUsesVideoTrackEndWhenContainerRunsLonger() {
+        let duration = VideoExportRenderer.exportSourceDuration(
+            assetDuration: CMTime(seconds: 12, preferredTimescale: 600),
+            videoTrackTimeRange: CMTimeRange(
+                start: .zero,
+                end: CMTime(seconds: 10, preferredTimescale: 600)
+            )
+        )
+
+        XCTAssertEqual(duration, 10, accuracy: 0.001)
+    }
+
+    func testExportSourceDurationFallsBackToAssetDurationWhenTrackDurationIsInvalid() {
+        let duration = VideoExportRenderer.exportSourceDuration(
+            assetDuration: CMTime(seconds: 8, preferredTimescale: 600),
+            videoTrackTimeRange: CMTimeRange(start: .invalid, duration: .invalid)
+        )
+
+        XCTAssertEqual(duration, 8, accuracy: 0.001)
+    }
+}

--- a/apps/rust-service/src/main.rs
+++ b/apps/rust-service/src/main.rs
@@ -69,6 +69,8 @@ struct ProjectDocument {
     updated_at: String,
     #[serde(default)]
     editor_state: Value,
+    #[serde(default)]
+    recording_session: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,6 +205,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
                 .get("editorState")
                 .cloned()
                 .unwrap_or_else(|| json!({ "timelineEdits": { "zoomRegions": [], "trimRegions": [], "annotationRegions": [], "clipSplitTimes": [], "clipSpeeds": {} } }));
+            let recording_session = params.get("recordingSession").cloned();
             let summary = save_project_document(
                 &paths,
                 &title,
@@ -210,6 +213,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
                 None,
                 source_name,
                 editor_state,
+                recording_session,
             )?;
             Ok(serde_json::to_value(summary).map_err(|err| err.to_string())?)
         }
@@ -238,6 +242,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
                 Some(screenshot_path.clone()),
                 source_name,
                 editor_state,
+                None,
             )?;
             remember_screenshot(&paths, &screenshot_path)?;
             Ok(serde_json::to_value(summary).map_err(|err| err.to_string())?)
@@ -252,6 +257,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
                 .get("editorState")
                 .cloned()
                 .unwrap_or_else(|| json!({ "timeline": [], "annotations": [] }));
+            let recording_session = params.get("recordingSession").cloned();
             let summary = save_project_document(
                 &paths,
                 &title,
@@ -259,6 +265,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
                 screenshot_path,
                 source_name,
                 editor_state,
+                recording_session,
             )?;
             Ok(serde_json::to_value(summary).map_err(|err| err.to_string())?)
         }
@@ -267,6 +274,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
             let path = string_param(&params, "path")
                 .ok_or_else(|| "updateProject requires path".to_string())?;
             let editor_state = params.get("editorState").cloned();
+            let recording_session = params.get("recordingSession").cloned();
             let summary = update_project_document(
                 &paths,
                 Path::new(&path),
@@ -275,6 +283,7 @@ fn handle_method(method: &str, params: Value) -> Result<Value, String> {
                 string_param(&params, "screenshotPath"),
                 string_param(&params, "sourceName"),
                 editor_state,
+                recording_session,
             )?;
             Ok(serde_json::to_value(summary).map_err(|err| err.to_string())?)
         }
@@ -384,6 +393,7 @@ fn save_project_document(
     screenshot_path: Option<String>,
     source_name: Option<String>,
     editor_state: Value,
+    recording_session: Option<Value>,
 ) -> Result<ProjectSummary, String> {
     let now = timestamp_string();
     let id = format!("project-{}", unix_timestamp_millis());
@@ -402,6 +412,7 @@ fn save_project_document(
         created_at: now.clone(),
         updated_at: now.clone(),
         editor_state,
+        recording_session,
     };
 
     write_json_pretty(
@@ -438,6 +449,7 @@ fn update_project_document(
     screenshot_path: Option<String>,
     source_name: Option<String>,
     editor_state: Option<Value>,
+    recording_session: Option<Value>,
 ) -> Result<ProjectSummary, String> {
     let data = fs::read_to_string(project_path).map_err(|err| err.to_string())?;
     let existing_document: ProjectDocument =
@@ -450,6 +462,7 @@ fn update_project_document(
     let screenshot_path = screenshot_path.or_else(|| existing_document.screenshot_path.clone());
     let source_name = source_name.or_else(|| existing_document.source_name.clone());
     let editor_state = editor_state.unwrap_or_else(|| existing_document.editor_state.clone());
+    let recording_session = recording_session.or(existing_document.recording_session);
 
     let document = ProjectDocument {
         schema_version: existing_document.schema_version.max(2),
@@ -460,6 +473,7 @@ fn update_project_document(
         created_at: existing_document.created_at.clone(),
         updated_at: now.clone(),
         editor_state,
+        recording_session,
     };
 
     write_json_pretty(
@@ -739,6 +753,7 @@ mod tests {
             None,
             Some("Display 1".to_string()),
             Some(json!({ "timelineEdits": { "clipSplitTimes": [1.25] } })),
+            None,
         )
         .unwrap();
 
@@ -790,6 +805,7 @@ mod tests {
                 None,
                 Some("Display 1".to_string()),
                 Some(json!({ "timelineEdits": { "clipSplitTimes": [index] } })),
+                None,
             )
             .unwrap();
         }
@@ -844,6 +860,7 @@ mod tests {
             Some(screenshot_path.clone()),
             Some("Display 1".to_string()),
             json!({ "screenshot": { "padding": 72 } }),
+            None,
         )
         .unwrap();
         remember_screenshot(&paths, &screenshot_path).unwrap();
@@ -856,6 +873,56 @@ mod tests {
         assert_eq!(saved.screenshot_path, Some(screenshot_path.clone()));
         assert_eq!(saved.editor_state["screenshot"]["padding"], 72);
         assert_eq!(recent[0].path, screenshot_path);
+    }
+
+    #[test]
+    fn saves_and_preserves_recording_session_metadata() {
+        let paths = test_paths("recording-session");
+        paths.ensure().unwrap();
+        let recording_path = paths
+            .recordings_dir
+            .join("demo.mp4")
+            .to_string_lossy()
+            .to_string();
+        let session = json!({
+            "screenVideoPath": recording_path,
+            "facecamVideoPath": "/tmp/demo.facecam.mov",
+            "facecamOffsetMs": -375,
+            "sourceName": "Display 1",
+            "showCursorOverlay": true,
+            "cursorTelemetryPath": "/tmp/demo.cursor.json"
+        });
+
+        let summary = save_project_document(
+            &paths,
+            "Demo",
+            Some(recording_path.clone()),
+            None,
+            Some("Display 1".to_string()),
+            json!({ "timelineEdits": { "clipSplitTimes": [] } }),
+            Some(session.clone()),
+        )
+        .unwrap();
+
+        let updated = update_project_document(
+            &paths,
+            Path::new(&summary.path),
+            Some("Demo Edited".to_string()),
+            Some(recording_path),
+            None,
+            Some("Display 1".to_string()),
+            Some(json!({ "timelineEdits": { "clipSplitTimes": [1.5] } })),
+            None,
+        )
+        .unwrap();
+
+        let saved: ProjectDocument =
+            serde_json::from_str(&fs::read_to_string(&updated.path).unwrap()).unwrap();
+        assert_eq!(saved.recording_session, Some(session));
+        assert_eq!(
+            saved.editor_state["timelineEdits"]["clipSplitTimes"][0],
+            1.5
+        );
     }
 
     #[test]
@@ -890,6 +957,7 @@ mod tests {
             Some(screenshot_path.clone()),
             Some("Display 1".to_string()),
             Some(json!({ "screenshot": { "padding": 96 } })),
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
## Summary
- fix exported track sync by mapping screen, audio, and facecam media through source track time ranges
- preserve recording session timing metadata, including facecamOffsetMs, across project autosave/service updates
- align cursor telemetry with the actual screen media start and retime export overlays/waveforms using media timestamps

## Root cause
Export timing used a mix of container durations, raw source seconds, and track-zero assumptions. Reopened projects could also lose the saved facecam offset, and cursor telemetry began before the native screen recorder reported its real media start.

## Validation
- swift test --package-path apps/macos
- cargo test --manifest-path apps/rust-service/Cargo.toml
- git diff --check
- cargo fmt --manifest-path apps/rust-service/Cargo.toml --check
