### PR TITLE
[codex] Modernize export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 
 ### Export
 
-- Export styled video projects as MOV files.
-- Choose 480p, 720p, 1080p, or 4K output presets.
-- Choose 15 FPS, 24 FPS, 30 FPS, or 60 FPS output presets.
-- Exported videos include the selected crop, background styling, inset styling, cursor overlay, timeline speed/deletion edits, zoom effects, and camera clip settings.
+- Export styled video projects as MOV or MP4 files, or as animated GIFs.
+- Choose 480p, 720p, 1080p, or 4K output presets for movie exports.
+- Choose Low, Medium, or High MP4 quality presets.
+- Choose Medium, Large, or Original GIF sizing, 15/20/25/30 FPS, and looping behavior.
+- Exported videos and GIFs include the selected crop, background styling, inset styling, cursor overlay, timeline speed/deletion edits, zoom effects, and camera clip settings.
 
 ## Repository Layout
 

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -1365,15 +1365,8 @@ final class AppModel: ObservableObject {
 
     private func suggestedVideoExportFileName(for sourceURL: URL, options: VideoExportOptions) -> String {
         let baseName = sourceURL.deletingPathExtension().lastPathComponent
-        let resolutionSuffix: String
-        if options.resolution == .custom, let customOutputSize = options.customOutputSize {
-            resolutionSuffix = "\(Int(customOutputSize.width.rounded()))x\(Int(customOutputSize.height.rounded()))"
-        } else {
-            resolutionSuffix = options.resolution.fileSuffix
-        }
         let cropSuffix = options.cropSelection == nil ? "" : "-crop"
-        let suffix = "\(resolutionSuffix)\(cropSuffix)-\(options.frameRate.fileSuffix)"
-        return "\(baseName)-\(suffix).\(options.format.fileExtension)"
+        return "\(baseName)-\(options.fileNameSuffix)\(cropSuffix).\(options.format.fileExtension)"
     }
 
     func openPrivacySettings() {

--- a/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
@@ -35,6 +35,9 @@ struct VideoExportDraftState: Equatable {
     var resolution: VideoExportResolution = VideoExportResolution.defaultExportOption
     var format: VideoExportFormat = .mov
     var frameRate: VideoExportFrameRate = VideoExportFrameRate.defaultExportOption
+    var quality: VideoExportQuality = VideoExportQuality.defaultExportOption
+    var gifSize: VideoExportGIFSize = VideoExportGIFSize.defaultExportOption
+    var gifLoops = true
     var baseOptions: VideoExportOptions = .default
 
     init(options: VideoExportOptions = .default) {
@@ -46,6 +49,9 @@ struct VideoExportDraftState: Equatable {
             resolution: resolution,
             format: format,
             frameRate: frameRate,
+            quality: quality,
+            gifSize: gifSize,
+            gifLoops: gifLoops,
             aspectPreset: baseOptions.aspectPreset,
             styling: .none,
             cropSelection: baseOptions.cropSelection,
@@ -61,9 +67,21 @@ struct VideoExportDraftState: Equatable {
             ? options.resolution
             : VideoExportResolution.defaultExportOption
         format = options.format
-        frameRate = VideoExportFrameRate.exportOptions.contains(options.frameRate)
+        frameRate = VideoExportFrameRate.exportOptions(for: options.format).contains(options.frameRate)
             ? options.frameRate
-            : VideoExportFrameRate.defaultExportOption
+            : VideoExportFrameRate.defaultExportOption(for: options.format)
+        quality = options.quality
+        gifSize = options.gifSize
+        gifLoops = options.gifLoops
+    }
+
+    mutating func setFormat(_ nextFormat: VideoExportFormat) {
+        guard format != nextFormat else { return }
+        format = nextFormat
+        let validFrameRates = VideoExportFrameRate.exportOptions(for: nextFormat)
+        if !validFrameRates.contains(frameRate) {
+            frameRate = VideoExportFrameRate.defaultExportOption(for: nextFormat)
+        }
     }
 }
 
@@ -133,8 +151,12 @@ enum VideoEditorEvent: Equatable {
     case cropConfirmed(VideoCropSelection)
     case cropCanceled
     case exportRequested
+    case exportFormatChanged(VideoExportFormat)
     case exportResolutionChanged(VideoExportResolution)
     case exportFrameRateChanged(VideoExportFrameRate)
+    case exportQualityChanged(VideoExportQuality)
+    case exportGIFSizeChanged(VideoExportGIFSize)
+    case exportGIFLoopChanged(Bool)
     case exportConfirmed(
         recordingURL: URL?,
         edits: TimelineEditSnapshot,
@@ -202,6 +224,11 @@ extension VideoEditorState {
             presentedSheet = .export
             return []
 
+        case .exportFormatChanged(let format):
+            guard exportDraft.format != format else { return [] }
+            exportDraft.setFormat(format)
+            return []
+
         case .exportResolutionChanged(let resolution):
             guard exportDraft.resolution != resolution else { return [] }
             exportDraft.resolution = resolution
@@ -210,6 +237,21 @@ extension VideoEditorState {
         case .exportFrameRateChanged(let frameRate):
             guard exportDraft.frameRate != frameRate else { return [] }
             exportDraft.frameRate = frameRate
+            return []
+
+        case .exportQualityChanged(let quality):
+            guard exportDraft.quality != quality else { return [] }
+            exportDraft.quality = quality
+            return []
+
+        case .exportGIFSizeChanged(let gifSize):
+            guard exportDraft.gifSize != gifSize else { return [] }
+            exportDraft.gifSize = gifSize
+            return []
+
+        case .exportGIFLoopChanged(let gifLoops):
+            guard exportDraft.gifLoops != gifLoops else { return [] }
+            exportDraft.gifLoops = gifLoops
             return []
 
         case .exportConfirmed(let recordingURL, let edits, let snapshot, let cursorTelemetryURL, let facecamVideoURL, let facecamOffsetMs, let cameraFallback):
@@ -366,10 +408,38 @@ final class VideoEditorDriver {
         )
     }
 
+    var exportFormatBinding: Binding<VideoExportFormat> {
+        Binding(
+            get: { self.state.exportDraft.format },
+            set: { self.send(.exportFormatChanged($0)) }
+        )
+    }
+
     var exportFrameRateBinding: Binding<VideoExportFrameRate> {
         Binding(
             get: { self.state.exportDraft.frameRate },
             set: { self.send(.exportFrameRateChanged($0)) }
+        )
+    }
+
+    var exportQualityBinding: Binding<VideoExportQuality> {
+        Binding(
+            get: { self.state.exportDraft.quality },
+            set: { self.send(.exportQualityChanged($0)) }
+        )
+    }
+
+    var exportGIFSizeBinding: Binding<VideoExportGIFSize> {
+        Binding(
+            get: { self.state.exportDraft.gifSize },
+            set: { self.send(.exportGIFSizeChanged($0)) }
+        )
+    }
+
+    var exportGIFLoopsBinding: Binding<Bool> {
+        Binding(
+            get: { self.state.exportDraft.gifLoops },
+            set: { self.send(.exportGIFLoopChanged($0)) }
         )
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -280,8 +280,11 @@ struct VideoEditorStudioView: View {
             exportedFileName: videoExport.state.exportedFileName,
             isExporting: videoExport.state.isExporting,
             resolution: editor.exportResolutionBinding,
-            format: editor.state.exportDraft.format,
+            format: editor.exportFormatBinding,
             frameRate: editor.exportFrameRateBinding,
+            quality: editor.exportQualityBinding,
+            gifSize: editor.exportGIFSizeBinding,
+            gifLoops: editor.exportGIFLoopsBinding,
             onExport: {
                 editor.send(.exportConfirmed(
                     recordingURL: exportRequest?.url ?? videoURL,

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
@@ -7,8 +7,11 @@ struct VideoExportDialog: View {
     var exportedFileName: String?
     var isExporting: Bool
     @Binding var resolution: VideoExportResolution
-    var format: VideoExportFormat
+    @Binding var format: VideoExportFormat
     @Binding var frameRate: VideoExportFrameRate
+    @Binding var quality: VideoExportQuality
+    @Binding var gifSize: VideoExportGIFSize
+    @Binding var gifLoops: Bool
     var onExport: () -> Void
     var onRetrySave: () -> Void
     var onShowInFinder: () -> Void
@@ -81,10 +84,10 @@ struct VideoExportDialog: View {
                 .background(Theme.accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
 
             VStack(alignment: .leading, spacing: 3) {
-                Text("Movie export")
+                Text(format == .gif ? "GIF export" : "Movie export")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Optimized for screen recordings")
+                Text(format == .gif ? "Animated for quick sharing" : "Optimized for screen recordings")
                     .font(.system(size: 10))
                     .foregroundStyle(.secondary)
             }
@@ -92,7 +95,7 @@ struct VideoExportDialog: View {
             Spacer(minLength: 0)
 
             HStack(spacing: 6) {
-                ExportSummaryMetric(title: "Size", value: resolution.title)
+                ExportSummaryMetric(title: "Size", value: selectedSizeTitle)
                 ExportSummaryMetric(title: "Rate", value: frameRate.title)
                 ExportSummaryMetric(title: "Type", value: format.title)
             }
@@ -216,6 +219,31 @@ struct VideoExportDialog: View {
     private var settingsPanel: some View {
         VStack(spacing: 0) {
             ExportPickerSettingRow(
+                symbolName: "doc.badge.gearshape",
+                title: "Format",
+                detail: format.detail,
+                selection: $format,
+                options: VideoExportFormat.allCases,
+                optionTitle: \.title,
+                isDisabled: !canEditOptions
+            )
+            ExportDivider()
+            if format == .gif {
+                gifSettings
+            } else {
+                movieSettings
+            }
+        }
+        .background(Theme.surfaceRaised.opacity(0.82), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .stroke(Theme.borderStrong.opacity(0.56))
+        }
+    }
+
+    private var movieSettings: some View {
+        VStack(spacing: 0) {
+            ExportPickerSettingRow(
                 symbolName: "rectangle.arrowtriangle.2.inward",
                 title: "Resolution",
                 detail: resolution.detail,
@@ -230,22 +258,54 @@ struct VideoExportDialog: View {
                 title: "Frame Rate",
                 detail: frameRate.detail,
                 selection: $frameRate,
-                options: VideoExportFrameRate.exportOptions,
+                options: frameRateOptions,
+                optionTitle: \.title,
+                isDisabled: !canEditOptions
+            )
+            if format == .mp4 {
+                ExportDivider()
+                ExportPickerSettingRow(
+                    symbolName: "slider.horizontal.3",
+                    title: "Quality",
+                    detail: quality.detail,
+                    selection: $quality,
+                    options: VideoExportQuality.allCases,
+                    optionTitle: \.title,
+                    isDisabled: !canEditOptions
+                )
+            }
+        }
+    }
+
+    private var gifSettings: some View {
+        VStack(spacing: 0) {
+            ExportPickerSettingRow(
+                symbolName: "rectangle.resize",
+                title: "Size",
+                detail: gifSize.detail,
+                selection: $gifSize,
+                options: VideoExportGIFSize.allCases,
                 optionTitle: \.title,
                 isDisabled: !canEditOptions
             )
             ExportDivider()
-            ExportStaticSettingRow(
-                symbolName: "doc.badge.gearshape",
-                title: "Format",
-                detail: "QuickTime movie (.mov)",
-                value: format.title
+            ExportPickerSettingRow(
+                symbolName: "speedometer",
+                title: "Frame Rate",
+                detail: frameRate.detail,
+                selection: $frameRate,
+                options: frameRateOptions,
+                optionTitle: \.title,
+                isDisabled: !canEditOptions
             )
-        }
-        .background(Theme.surfaceRaised.opacity(0.82), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .stroke(Theme.borderStrong.opacity(0.56))
+            ExportDivider()
+            ExportToggleSettingRow(
+                symbolName: "repeat",
+                title: "Loop",
+                detail: gifLoops ? "Repeat continuously." : "Play once.",
+                isOn: $gifLoops,
+                isDisabled: !canEditOptions
+            )
         }
     }
 
@@ -274,7 +334,18 @@ struct VideoExportDialog: View {
     }
 
     private var selectedExportSummary: String {
-        "\(resolution.title) \(format.title) · \(frameRate.title)"
+        switch format {
+        case .gif:
+            "\(gifSize.title) \(format.title) · \(frameRate.title)"
+        case .mp4:
+            "\(resolution.title) \(format.title) · \(frameRate.title) · \(quality.title)"
+        case .mov:
+            "\(resolution.title) \(format.title) · \(frameRate.title)"
+        }
+    }
+
+    private var selectedSizeTitle: String {
+        format == .gif ? gifSize.title : resolution.title
     }
 
     private var displayedProgress: Double {
@@ -313,6 +384,10 @@ struct VideoExportDialog: View {
         VideoExportResolution.exportOptions
     }
 
+    private var frameRateOptions: [VideoExportFrameRate] {
+        VideoExportFrameRate.exportOptions(for: format)
+    }
+
     private var headerTitle: String {
         switch phase {
         case .exporting: "Exporting Video"
@@ -327,9 +402,9 @@ struct VideoExportDialog: View {
     private var headerSubtitle: String {
         switch phase {
         case .exporting: "\(VideoExportProgressPresentation.percentText(for: displayedProgress)) · \(selectedExportSummary)"
-        case .saving: "Choose where to save the completed MOV."
+        case .saving: "Choose where to save the completed \(format.title)."
         case .savePending: "Save without rendering again."
-        case .success: "Your MOV export is ready."
+        case .success: "Your \(format.title) export is ready."
         case .failed: "Adjust settings and try again."
         case .idle: selectedExportSummary
         }
@@ -452,6 +527,41 @@ private struct ExportStaticSettingRow: View {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .stroke(Theme.borderSubtle)
                 }
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 12)
+    }
+}
+
+private struct ExportToggleSettingRow: View {
+    var symbolName: String
+    var title: String
+    var detail: String
+    @Binding var isOn: Bool
+    var isDisabled = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            Image(systemName: symbolName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 30, height: 30)
+                .background(Theme.accent.opacity(0.10), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(detail)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 12)
+
+            Toggle(title, isOn: $isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .disabled(isDisabled)
         }
         .padding(.horizontal, 13)
         .padding(.vertical, 12)

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import AppKit
 import CoreGraphics
 import Foundation
+import ImageIO
 import UniformTypeIdentifiers
 
 enum VideoExportResolution: String, CaseIterable, Identifiable, Codable, Hashable {
@@ -82,30 +83,136 @@ enum VideoExportResolution: String, CaseIterable, Identifiable, Codable, Hashabl
 
 enum VideoExportFormat: String, CaseIterable, Identifiable {
     case mov
+    case mp4
+    case gif
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
         case .mov: "MOV"
+        case .mp4: "MP4"
+        case .gif: "GIF"
         }
     }
 
     var fileExtension: String {
         switch self {
         case .mov: "mov"
+        case .mp4: "mp4"
+        case .gif: "gif"
         }
     }
 
     var contentType: UTType {
         switch self {
         case .mov: .quickTimeMovie
+        case .mp4: .mpeg4Movie
+        case .gif: .gif
         }
     }
 
-    var avFileType: AVFileType {
+    var avFileType: AVFileType? {
         switch self {
         case .mov: .mov
+        case .mp4: .mp4
+        case .gif: nil
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .mov: "QuickTime movie (.mov)"
+        case .mp4: "MPEG-4 movie (.mp4)"
+        case .gif: "Animated GIF (.gif)"
+        }
+    }
+
+    var isAnimatedImage: Bool {
+        self == .gif
+    }
+}
+
+enum VideoExportQuality: String, CaseIterable, Identifiable, Codable, Hashable {
+    case low
+    case medium
+    case highSource
+
+    var id: String { rawValue }
+
+    static let defaultExportOption: VideoExportQuality = .highSource
+
+    var title: String {
+        switch self {
+        case .low: "Low"
+        case .medium: "Medium"
+        case .highSource: "High"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .low: "Smallest MP4 file."
+        case .medium: "Balanced MP4 size and clarity."
+        case .highSource: "Best MP4 quality from the source."
+        }
+    }
+
+    var fileSuffix: String {
+        switch self {
+        case .low: "low"
+        case .medium: "medium"
+        case .highSource: "high"
+        }
+    }
+
+    var exportPresetName: String {
+        switch self {
+        case .low: AVAssetExportPresetLowQuality
+        case .medium: AVAssetExportPresetMediumQuality
+        case .highSource: AVAssetExportPresetHighestQuality
+        }
+    }
+}
+
+enum VideoExportGIFSize: String, CaseIterable, Identifiable, Codable, Hashable {
+    case medium
+    case large
+    case original
+
+    var id: String { rawValue }
+
+    static let defaultExportOption: VideoExportGIFSize = .medium
+
+    var title: String {
+        switch self {
+        case .medium: "Medium"
+        case .large: "Large"
+        case .original: "Original"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .medium: "Scale the short edge to 480 px."
+        case .large: "Scale the short edge to 720 px."
+        case .original: "Keep the source dimensions."
+        }
+    }
+
+    var fileSuffix: String {
+        switch self {
+        case .medium: "medium"
+        case .large: "large"
+        case .original: "original"
+        }
+    }
+
+    var resolution: VideoExportResolution {
+        switch self {
+        case .medium: .p480
+        case .large: .p720
+        case .original: .source
         }
     }
 }
@@ -113,21 +220,35 @@ enum VideoExportFormat: String, CaseIterable, Identifiable {
 enum VideoExportFrameRate: String, CaseIterable, Identifiable {
     case source
     case fps15
+    case fps20
     case fps24
+    case fps25
     case fps30
     case fps60
 
     var id: String { rawValue }
 
     static let exportOptions: [VideoExportFrameRate] = [.fps15, .fps24, .fps30, .fps60]
+    static let gifExportOptions: [VideoExportFrameRate] = [.fps15, .fps20, .fps25, .fps30]
 
     static let defaultExportOption: VideoExportFrameRate = .fps30
+    static let defaultGIFExportOption: VideoExportFrameRate = .fps15
+
+    static func exportOptions(for format: VideoExportFormat) -> [VideoExportFrameRate] {
+        format == .gif ? gifExportOptions : exportOptions
+    }
+
+    static func defaultExportOption(for format: VideoExportFormat) -> VideoExportFrameRate {
+        format == .gif ? defaultGIFExportOption : defaultExportOption
+    }
 
     var title: String {
         switch self {
         case .source: "Source"
         case .fps15: "15 FPS"
+        case .fps20: "20 FPS"
         case .fps24: "24 FPS"
+        case .fps25: "25 FPS"
         case .fps30: "30 FPS"
         case .fps60: "60 FPS"
         }
@@ -137,7 +258,9 @@ enum VideoExportFrameRate: String, CaseIterable, Identifiable {
         switch self {
         case .source: "Keep the recording frame rate."
         case .fps15: "Smallest file size."
+        case .fps20: "Compact GIF motion."
         case .fps24: "Cinematic motion."
+        case .fps25: "Smooth GIF playback."
         case .fps30: "Smaller file, smooth playback."
         case .fps60: "Best for fast cursor movement."
         }
@@ -147,17 +270,21 @@ enum VideoExportFrameRate: String, CaseIterable, Identifiable {
         switch self {
         case .source: "source-fps"
         case .fps15: "15fps"
+        case .fps20: "20fps"
         case .fps24: "24fps"
+        case .fps25: "25fps"
         case .fps30: "30fps"
         case .fps60: "60fps"
         }
     }
 
-    private var fixedFramesPerSecond: Double? {
+    var fixedFramesPerSecond: Double? {
         switch self {
         case .source: nil
         case .fps15: 15
+        case .fps20: 20
         case .fps24: 24
+        case .fps25: 25
         case .fps30: 30
         case .fps60: 60
         }
@@ -186,6 +313,9 @@ struct VideoExportOptions: Equatable {
     var resolution: VideoExportResolution
     var format: VideoExportFormat
     var frameRate: VideoExportFrameRate
+    var quality: VideoExportQuality = .defaultExportOption
+    var gifSize: VideoExportGIFSize = .defaultExportOption
+    var gifLoops = true
     var aspectPreset: VideoPreviewAspectPreset = .auto
     var styling: VideoBackgroundStyling
     var cropSelection: VideoCropSelection?
@@ -200,6 +330,9 @@ struct VideoExportOptions: Equatable {
         resolution: VideoExportResolution.defaultExportOption,
         format: .mov,
         frameRate: VideoExportFrameRate.defaultExportOption,
+        quality: .defaultExportOption,
+        gifSize: .defaultExportOption,
+        gifLoops: true,
         aspectPreset: .auto,
         styling: .none,
         cropSelection: nil,
@@ -275,6 +408,35 @@ struct VideoExportOptions: Equatable {
         copy.facecamFallbackSettings = fallbackSettings?.clamped
         return copy
     }
+
+    var summaryTitle: String {
+        switch format {
+        case .gif:
+            "\(gifSize.title) \(format.title) at \(frameRate.title)"
+        case .mp4:
+            "\(resolution.title) \(quality.title) \(format.title) at \(frameRate.title)"
+        case .mov:
+            "\(resolution.title) \(format.title) at \(frameRate.title)"
+        }
+    }
+
+    var fileNameSuffix: String {
+        let sizeSuffix: String
+        switch format {
+        case .gif:
+            sizeSuffix = gifSize.fileSuffix
+        case .mov, .mp4:
+            if resolution == .custom, let customOutputSize {
+                sizeSuffix = "\(Int(customOutputSize.width.rounded()))x\(Int(customOutputSize.height.rounded()))"
+            } else {
+                sizeSuffix = resolution.fileSuffix
+            }
+        }
+
+        let qualitySuffix = format == .mp4 ? "-\(quality.fileSuffix)" : ""
+        let loopSuffix = format == .gif && gifLoops ? "-loop" : ""
+        return "\(sizeSuffix)\(qualitySuffix)-\(frameRate.fileSuffix)\(loopSuffix)"
+    }
 }
 
 enum VideoExportPhase: Equatable {
@@ -297,24 +459,10 @@ enum VideoExportPhase: Equatable {
 
 @MainActor
 final class VideoExportCancellationToken {
-    private var exportSession: AVAssetExportSession?
     private(set) var isCancelled = false
-
-    func attach(_ exportSession: AVAssetExportSession) {
-        if isCancelled {
-            exportSession.cancelExport()
-        } else {
-            self.exportSession = exportSession
-        }
-    }
 
     func cancel() {
         isCancelled = true
-        exportSession?.cancelExport()
-    }
-
-    func detach() {
-        exportSession = nil
     }
 }
 
@@ -323,6 +471,9 @@ enum VideoExportRendererError: LocalizedError {
     case exportSessionUnavailable
     case exportCancelled
     case emptyTimeline
+    case unsupportedFormat
+    case gifDestinationUnavailable
+    case gifFrameGenerationFailed
     case exportFailed
 
     var errorDescription: String? {
@@ -331,6 +482,9 @@ enum VideoExportRendererError: LocalizedError {
         case .exportSessionUnavailable: "This Mac cannot create the requested export session."
         case .exportCancelled: "Export canceled."
         case .emptyTimeline: "Timeline edits remove the entire recording."
+        case .unsupportedFormat: "This export format is not supported."
+        case .gifDestinationUnavailable: "This Mac cannot create the GIF export file."
+        case .gifFrameGenerationFailed: "GIF frame rendering failed."
         case .exportFailed: "Video export failed."
         }
     }
@@ -338,6 +492,14 @@ enum VideoExportRendererError: LocalizedError {
 
 @MainActor
 enum VideoExportRenderer {
+    private struct RenderContext {
+        var asset: AVAsset
+        var videoComposition: AVMutableVideoComposition
+        var duration: Double
+        var outputSize: CGSize
+        var frameDuration: CMTime
+    }
+
     static func export(
         sourceURL: URL,
         targetURL: URL,
@@ -350,6 +512,19 @@ enum VideoExportRenderer {
             try FileManager.default.removeItem(at: targetURL)
         }
 
+        let context = try await makeRenderContext(sourceURL: sourceURL, options: options, edits: edits)
+        if options.format.isAnimatedImage {
+            try await exportGIF(context: context, targetURL: targetURL, options: options, cancellationToken: cancellationToken, progressHandler: progressHandler)
+        } else {
+            try await exportMovie(context: context, targetURL: targetURL, options: options, cancellationToken: cancellationToken, progressHandler: progressHandler)
+        }
+    }
+
+    private static func makeRenderContext(
+        sourceURL: URL,
+        options: VideoExportOptions,
+        edits: TimelineEditSnapshot
+    ) async throws -> RenderContext {
         let asset = AVURLAsset(url: sourceURL)
         let tracks = try await asset.loadTracks(withMediaType: .video)
         guard let videoTrack = tracks.first else {
@@ -377,24 +552,14 @@ enum VideoExportRenderer {
             facecamOffsetMs: options.facecamOffsetMs
         )
 
-        guard let exportSession = AVAssetExportSession(asset: exportAsset.asset, presetName: AVAssetExportPresetHighestQuality) else {
-            throw VideoExportRendererError.exportSessionUnavailable
-        }
-
-        exportSession.outputURL = targetURL
-        exportSession.outputFileType = options.format.avFileType
-        exportSession.shouldOptimizeForNetworkUse = true
-        exportSession.timeRange = CMTimeRange(
-            start: .zero,
-            duration: CMTime(seconds: max(0.001, exportAsset.duration), preferredTimescale: 600)
-        )
-        exportSession.videoComposition = makeVideoComposition(
+        let duration = max(0.001, exportAsset.duration)
+        let videoComposition = makeVideoComposition(
             for: exportAsset.videoTrack ?? videoTrack,
             sourceSize: naturalSize,
             preferredTransform: preferredTransform,
             cropRect: cropRect,
             outputSize: outputSize,
-            duration: CMTime(seconds: max(0.001, exportAsset.duration), preferredTimescale: 600),
+            duration: CMTime(seconds: duration, preferredTimescale: 600),
             frameDuration: frameDuration,
             styling: options.styling,
             edits: edits,
@@ -407,29 +572,54 @@ enum VideoExportRenderer {
             facecamFallbackSettings: options.facecamFallbackSettings
         )
 
+        return RenderContext(
+            asset: exportAsset.asset,
+            videoComposition: videoComposition,
+            duration: duration,
+            outputSize: outputSize,
+            frameDuration: frameDuration
+        )
+    }
+
+    private static func exportMovie(
+        context: RenderContext,
+        targetURL: URL,
+        options: VideoExportOptions,
+        cancellationToken: VideoExportCancellationToken?,
+        progressHandler: @escaping @MainActor (Double) -> Void
+    ) async throws {
+        guard let fileType = options.format.avFileType else {
+            throw VideoExportRendererError.unsupportedFormat
+        }
+        guard let exportSession = AVAssetExportSession(asset: context.asset, presetName: exportPresetName(for: options)) else {
+            throw VideoExportRendererError.exportSessionUnavailable
+        }
+
+        exportSession.shouldOptimizeForNetworkUse = true
+        exportSession.timeRange = CMTimeRange(
+            start: .zero,
+            duration: CMTime(seconds: context.duration, preferredTimescale: 600)
+        )
+        exportSession.videoComposition = context.videoComposition
+
         if Task.isCancelled {
             throw VideoExportRendererError.exportCancelled
         }
 
-        if let cancellationToken {
-            cancellationToken.attach(exportSession)
-        }
-
         progressHandler(0.02)
         let progressTask = Task { @MainActor in
-            while !Task.isCancelled {
+            for await state in exportSession.states(updateInterval: 0.12) {
+                if Task.isCancelled {
+                    return
+                }
                 if cancellationToken?.isCancelled == true {
                     return
                 }
-                let progress = Double(exportSession.progress)
-                if progress.isFinite {
-                    progressHandler(min(max(progress, 0.02), 0.99))
-                }
-
-                do {
-                    try await Task.sleep(nanoseconds: 120_000_000)
-                } catch {
-                    return
+                if case .exporting(let progress) = state {
+                    let fraction = progress.fractionCompleted
+                    if fraction.isFinite {
+                        progressHandler(min(max(fraction, 0.02), 0.99))
+                    }
                 }
             }
         }
@@ -437,21 +627,99 @@ enum VideoExportRenderer {
             progressTask.cancel()
         }
 
-        await exportSession.export()
-        if let cancellationToken {
-            cancellationToken.detach()
+        do {
+            try await exportSession.export(to: targetURL, as: fileType)
+            if cancellationToken?.isCancelled == true || Task.isCancelled {
+                throw VideoExportRendererError.exportCancelled
+            }
+            progressHandler(1)
+        } catch is CancellationError {
+            throw VideoExportRendererError.exportCancelled
+        } catch {
+            if cancellationToken?.isCancelled == true || Task.isCancelled {
+                throw VideoExportRendererError.exportCancelled
+            }
+            throw error
+        }
+    }
+
+    private static func exportGIF(
+        context: RenderContext,
+        targetURL: URL,
+        options: VideoExportOptions,
+        cancellationToken: VideoExportCancellationToken?,
+        progressHandler: @escaping @MainActor (Double) -> Void
+    ) async throws {
+        let framesPerSecond = options.frameRate.fixedFramesPerSecond ?? Double(VideoExportFrameRate.defaultGIFExportOption.fixedFramesPerSecond ?? 15)
+        let frameDelay = 1 / max(framesPerSecond, 1)
+        let frameCount = max(1, Int(ceil(context.duration * framesPerSecond)))
+        guard let destination = CGImageDestinationCreateWithURL(
+            targetURL as CFURL,
+            UTType.gif.identifier as CFString,
+            frameCount,
+            nil
+        ) else {
+            throw VideoExportRendererError.gifDestinationUnavailable
         }
 
-        switch exportSession.status {
-        case .completed:
-            progressHandler(1)
-            return
-        case .cancelled:
-            throw VideoExportRendererError.exportCancelled
-        case .failed:
-            throw exportSession.error ?? VideoExportRendererError.exportFailed
-        default:
-            throw VideoExportRendererError.exportFailed
+        let fileProperties: [CFString: Any] = [
+            kCGImagePropertyGIFDictionary: [
+                kCGImagePropertyGIFLoopCount: options.gifLoops ? 0 : 1
+            ]
+        ]
+        CGImageDestinationSetProperties(destination, fileProperties as CFDictionary)
+
+        let frameProperties: [CFString: Any] = [
+            kCGImagePropertyGIFDictionary: [
+                kCGImagePropertyGIFDelayTime: frameDelay
+            ]
+        ]
+
+        nonisolated(unsafe) let generator = AVAssetImageGenerator(asset: context.asset)
+        generator.videoComposition = context.videoComposition
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+
+        for frameIndex in 0..<frameCount {
+            if Task.isCancelled || cancellationToken?.isCancelled == true {
+                throw VideoExportRendererError.exportCancelled
+            }
+
+            let seconds = min(Double(frameIndex) * frameDelay, max(0, context.duration - 0.001))
+            let time = CMTime(seconds: seconds, preferredTimescale: 600)
+            do {
+                let image = try await generator.image(at: time).image
+                CGImageDestinationAddImage(destination, image, frameProperties as CFDictionary)
+            } catch is CancellationError {
+                throw VideoExportRendererError.exportCancelled
+            } catch {
+                throw VideoExportRendererError.gifFrameGenerationFailed
+            }
+
+            progressHandler(min(max(Double(frameIndex + 1) / Double(frameCount), 0.02), 0.99))
+        }
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw VideoExportRendererError.gifDestinationUnavailable
+        }
+        progressHandler(1)
+    }
+
+    private static func exportPresetName(for options: VideoExportOptions) -> String {
+        switch options.format {
+        case .mp4:
+            options.quality.exportPresetName
+        case .mov, .gif:
+            AVAssetExportPresetHighestQuality
+        }
+    }
+
+    private static func effectiveResolution(for options: VideoExportOptions) -> VideoExportResolution {
+        switch options.format {
+        case .gif:
+            options.gifSize.resolution
+        case .mov, .mp4:
+            options.resolution
         }
     }
 
@@ -598,7 +866,8 @@ enum VideoExportRenderer {
     }
 
     static func resolvedOutputSize(for sourceSize: CGSize, options: VideoExportOptions) -> CGSize {
-        if options.resolution == .custom, let customOutputSize = options.customOutputSize {
+        let resolution = effectiveResolution(for: options)
+        if resolution == .custom, let customOutputSize = options.customOutputSize {
             return evenSize(width: customOutputSize.width, height: customOutputSize.height)
         }
 
@@ -607,10 +876,10 @@ enum VideoExportRenderer {
         let aspectRatio = resolvedAspectRatio(
             options.aspectPreset.aspectRatio(forExportSourceSize: CGSize(width: sourceWidth, height: sourceHeight))
         )
-        if let targetShortEdge = options.resolution.targetShortEdge {
+        if let targetShortEdge = resolution.targetShortEdge {
             return outputSize(forAspectRatio: aspectRatio, targetShortEdge: targetShortEdge)
         }
-        if let targetLongEdge = options.resolution.targetLongEdge {
+        if let targetLongEdge = resolution.targetLongEdge {
             return outputSize(forAspectRatio: aspectRatio, targetLongEdge: targetLongEdge)
         }
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
@@ -65,7 +65,7 @@ extension VideoExportState {
             errorMessage = nil
             progress = 0
             phase = .exporting
-            effects.append(.setStatusMessage("Exporting \(options.resolution.title) \(options.format.title) at \(options.frameRate.title)..."))
+            effects.append(.setStatusMessage("Exporting \(options.summaryTitle)..."))
             effects.append(.render(sourceURL: sourceURL, targetURL: targetURL, options: options, edits: edits))
             return effects
 
@@ -86,7 +86,7 @@ extension VideoExportState {
             phase = .saving
             errorMessage = nil
             return [
-                .setStatusMessage("Choose where to save \(options.resolution.title) \(options.format.title) at \(options.frameRate.title)."),
+                .setStatusMessage("Choose where to save \(options.summaryTitle)."),
                 .presentSavePanel(sourceURL: sourceURL, tempURL: tempURL, options: options)
             ]
 

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -243,6 +243,65 @@ final class VideoEditorStateMachineTests: XCTestCase {
         XCTAssertEqual(options.frameRate, .fps60)
         XCTAssertEqual(options.cropSelection, state.video.cropSelection)
     }
+
+    func testExportDraftNormalizesFormatSpecificOptions() {
+        var state = VideoEditorState()
+
+        _ = state.applying(.exportRequested)
+        XCTAssertEqual(state.exportDraft.format, .mov)
+        XCTAssertEqual(state.exportDraft.frameRate, .fps30)
+
+        XCTAssertTrue(state.applying(.exportFrameRateChanged(.fps60)).isEmpty)
+        XCTAssertTrue(state.applying(.exportFormatChanged(.gif)).isEmpty)
+        XCTAssertEqual(state.exportDraft.format, .gif)
+        XCTAssertEqual(state.exportDraft.frameRate, .fps15)
+
+        XCTAssertTrue(state.applying(.exportFrameRateChanged(.fps25)).isEmpty)
+        XCTAssertTrue(state.applying(.exportGIFSizeChanged(.large)).isEmpty)
+        XCTAssertTrue(state.applying(.exportGIFLoopChanged(false)).isEmpty)
+
+        let effects = state.applying(.exportConfirmed(
+            recordingURL: URL(fileURLWithPath: "/tmp/export.mov"),
+            edits: .empty,
+            snapshot: nil,
+            cursorTelemetryURL: nil,
+            facecamVideoURL: nil,
+            facecamOffsetMs: nil,
+            cameraFallback: nil
+        ))
+
+        guard case .startVideoExport(_, let options, _, _) = effects.first else {
+            return XCTFail("Expected export effect.")
+        }
+        XCTAssertEqual(options.format, .gif)
+        XCTAssertEqual(options.frameRate, .fps25)
+        XCTAssertEqual(options.gifSize, .large)
+        XCTAssertFalse(options.gifLoops)
+    }
+
+    func testExportDraftCarriesMP4Quality() {
+        var state = VideoEditorState()
+
+        _ = state.applying(.exportRequested)
+        XCTAssertTrue(state.applying(.exportFormatChanged(.mp4)).isEmpty)
+        XCTAssertTrue(state.applying(.exportQualityChanged(.medium)).isEmpty)
+
+        let effects = state.applying(.exportConfirmed(
+            recordingURL: URL(fileURLWithPath: "/tmp/export.mov"),
+            edits: .empty,
+            snapshot: nil,
+            cursorTelemetryURL: nil,
+            facecamVideoURL: nil,
+            facecamOffsetMs: nil,
+            cameraFallback: nil
+        ))
+
+        guard case .startVideoExport(_, let options, _, _) = effects.first else {
+            return XCTFail("Expected export effect.")
+        }
+        XCTAssertEqual(options.format, .mp4)
+        XCTAssertEqual(options.quality, .medium)
+    }
 }
 
 @MainActor

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -165,8 +165,49 @@ final class VideoCropSelectionTests: XCTestCase {
     func testExportOptionModelsExposeRequestedPresets() {
         XCTAssertEqual(VideoExportResolution.exportOptions.map(\.title), ["480p", "720p", "1080p", "4K"])
         XCTAssertEqual(VideoExportFrameRate.exportOptions.map(\.title), ["15 FPS", "24 FPS", "30 FPS", "60 FPS"])
+        XCTAssertEqual(VideoExportFrameRate.gifExportOptions.map(\.title), ["15 FPS", "20 FPS", "25 FPS", "30 FPS"])
+        XCTAssertEqual(VideoExportFormat.allCases.map(\.title), ["MOV", "MP4", "GIF"])
+        XCTAssertEqual(VideoExportQuality.allCases.map(\.title), ["Low", "Medium", "High"])
+        XCTAssertEqual(VideoExportGIFSize.allCases.map(\.title), ["Medium", "Large", "Original"])
         XCTAssertFalse(VideoExportResolution.exportOptions.contains(.source))
         XCTAssertFalse(VideoExportFrameRate.exportOptions.contains(.source))
+    }
+
+    func testGIFSizeControlsRenderedOutputSize() {
+        let sourceSize = CGSize(width: 1920, height: 1080)
+        var options = VideoExportOptions.default
+        options.format = .gif
+
+        options.gifSize = .medium
+        var outputSize = VideoExportRenderer.resolvedOutputSize(for: sourceSize, options: options)
+        XCTAssertEqual(outputSize.width, 852, accuracy: 0.001)
+        XCTAssertEqual(outputSize.height, 480, accuracy: 0.001)
+
+        options.gifSize = .large
+        outputSize = VideoExportRenderer.resolvedOutputSize(for: sourceSize, options: options)
+        XCTAssertEqual(outputSize.width, 1280, accuracy: 0.001)
+        XCTAssertEqual(outputSize.height, 720, accuracy: 0.001)
+
+        options.gifSize = .original
+        outputSize = VideoExportRenderer.resolvedOutputSize(for: sourceSize, options: options)
+        XCTAssertEqual(outputSize.width, 1920, accuracy: 0.001)
+        XCTAssertEqual(outputSize.height, 1080, accuracy: 0.001)
+    }
+
+    func testExportOptionsDescribeFormatSpecificSummariesAndFileSuffixes() {
+        var mp4Options = VideoExportOptions.default
+        mp4Options.format = .mp4
+        mp4Options.quality = .medium
+        XCTAssertEqual(mp4Options.summaryTitle, "1080p Medium MP4 at 30 FPS")
+        XCTAssertEqual(mp4Options.fileNameSuffix, "1080p-medium-30fps")
+
+        var gifOptions = VideoExportOptions.default
+        gifOptions.format = .gif
+        gifOptions.gifSize = .large
+        gifOptions.frameRate = .fps20
+        gifOptions.gifLoops = false
+        XCTAssertEqual(gifOptions.summaryTitle, "Large GIF at 20 FPS")
+        XCTAssertEqual(gifOptions.fileNameSuffix, "large-20fps")
     }
 
     func testRendererUsesNormalizedCropRectInSourcePixels() {

--- a/docs/export-dialog-gap-analysis.md
+++ b/docs/export-dialog-gap-analysis.md
@@ -5,19 +5,14 @@ Compared against the Electron editor from commit `c4882a1` (`apps/desktop/src/co
 ## Restored in this change
 
 - Video export now opens a Swift export dialog instead of immediately exporting.
-- MOV is the currently supported video format.
-- Resolution choices are available for 480p, 720p, 1080p, and 4K exports.
-- Frame-rate choices are available for Source, 24 FPS, 30 FPS, and 60 FPS MOV exports.
-- Export progress is shown while the MOV render runs.
+- MOV, MP4, and GIF export formats are available.
+- Resolution choices are available for 480p, 720p, 1080p, and 4K movie exports.
+- Frame-rate choices are available for 15, 24, 30, and 60 FPS movie exports.
+- MP4 quality choices are available for Low, Medium, and High/source exports.
+- GIF size choices are available for Medium, Large, and Original exports.
+- GIF frame-rate choices are available for 15, 20, 25, and 30 FPS.
+- GIF looping can be toggled per export.
+- Export progress is shown while the render runs.
 - Rendering exports can be canceled from the progress UI.
 - Completed exports can be revealed in Finder.
 - If the save panel is canceled after rendering, the completed temporary export is retained and can be saved again without re-exporting.
-
-## Still missing from the legacy Electron export experience
-
-- MP4 output format selection.
-- GIF output format selection.
-- MP4 quality presets from the old quick settings popover: Low, Medium, and High/source.
-- GIF frame-rate choices: 15, 20, 25, and 30 FPS.
-- GIF size presets: Medium, Large, and Original.
-- GIF loop toggle.


### PR DESCRIPTION
## Summary
- replace deprecated AVAssetExportSession export/status/error usage with the modern async export(to:as:) flow and states(updateInterval:) progress updates
- add MP4 and GIF export options, including MP4 quality presets and GIF size/FPS/loop controls
- update export filenames, docs, and state-machine tests for format-specific behavior

## Validation
- swift test --package-path apps/macos
- cargo test --manifest-path apps/rust-service/Cargo.toml --quiet
- pnpm --dir apps/landing lint
- pnpm --dir apps/landing build
- git diff --check

Note: landing build still emits the existing Next.js workspace-root warning, but completes successfully.