### PR TITLE
Refresh landing copy and timeline actions

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -5,26 +5,26 @@ const sourceUrl = "https://github.com/imbhargav5/open-recorder";
 
 const proofPoints = [
   ["Native macOS", "Swift capture UI with system privacy flows"],
-  ["Local-first", "Recordings stay under your Movies folder"],
+  ["Local-first", "Recordings and projects stay on your Mac"],
   ["Open source", "Apache 2.0 with a small Swift + Rust stack"],
-  ["Editor included", "Trim, preview, organize, and export"],
+  ["Editor included", "Zooms, camera clips, cursor overlays, and exports"],
 ];
 
 const featureHighlights = [
   {
     title: "Capture exactly what matters",
     eyebrow: "Display, window, or region",
-    copy: "Choose a full display, a single app window, or draw a precise area before recording or taking a screenshot.",
+    copy: "Choose a full display, a single app window, or draw a precise area with microphone, system audio, camera, cursor, and click controls.",
   },
   {
-    title: "Polish without a cloud detour",
-    eyebrow: "Native editing flow",
-    copy: "Preview recordings, keep project metadata organized, and move from rough capture to clean handoff on the same Mac.",
+    title: "Shape the story on the timeline",
+    eyebrow: "Zooms, clips, cursor, camera",
+    copy: "Add manual or automatic zoom sections, split clips, tune playback speed, style cursor motion, and place facecam segments independently.",
   },
   {
-    title: "Export work you can trust",
-    eyebrow: "Rust-backed bookkeeping",
-    copy: "A durable local service handles paths, project registration, screenshot indexing, and export state behind the scenes.",
+    title: "Compose the final handoff",
+    eyebrow: "Crop, aspect, screenshot, export",
+    copy: "Crop and reframe videos for fixed aspect layouts, compose screenshots on styled backgrounds, and export MOV, MP4, GIF, or PNG outputs.",
   },
 ];
 
@@ -41,20 +41,20 @@ const workflow = [
   },
   {
     step: "03",
-    title: "Preview and refine",
-    copy: "Review captures in the native library, trim what is noisy, and keep the useful version close.",
+    title: "Edit the timeline",
+    copy: "Refine clips with trims, speed changes, zoom effects, cursor overlays, and independently controlled camera segments.",
   },
   {
     step: "04",
-    title: "Export the handoff",
-    copy: "Let the Rust service handle export bookkeeping so your final files stay clean and findable.",
+    title: "Export or compose",
+    copy: "Export MOV, MP4, GIF, or PNG assets with crop and aspect controls, styled backgrounds, and screenshot composition.",
   },
 ];
 
 const architectureNotes = [
   {
     label: "Swift app",
-    value: "Capture UI, AVKit playback, Finder integration, privacy prompts",
+    value: "Capture UI, editor timeline, screenshot composition, Finder integration",
   },
   {
     label: "Rust service",
@@ -62,7 +62,7 @@ const architectureNotes = [
   },
   {
     label: "Local paths",
-    value: "~/Movies/Open Recorder and ~/Pictures/Open Recorder",
+    value: "~/Movies/Open Recorder, ~/Pictures/Open Recorder, and local project files",
   },
 ];
 
@@ -113,9 +113,9 @@ export default function Home() {
           <p className="eyebrow">Native macOS capture studio</p>
           <h1>Open Recorder</h1>
           <p className="hero-lede">
-            Record your screen, capture screenshots, trim the useful parts, and
-            export clean handoffs without sending your work through a cloud
-            pipeline.
+            Record your screen, capture screenshots, shape zooms, cursor, and
+            camera on a native timeline, then export polished MOV, MP4, GIF, or
+            PNG handoffs without a cloud pipeline.
           </p>
           <div className="hero-actions">
             <a className="primary-action" href={docsUrl} target="_blank" rel="noreferrer">
@@ -154,7 +154,7 @@ export default function Home() {
         <div className="section-inner">
           <div className="section-heading">
             <p className="eyebrow">Capture, edit, export</p>
-            <h2>A small native toolchain for polished demos and documentation.</h2>
+            <h2>A native capture studio for polished demos, docs, and share-ready clips.</h2>
           </div>
 
           <div className="feature-grid">

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -41,12 +41,16 @@ struct TimelinePanel: View {
             Rectangle().fill(Theme.border).frame(height: 1)
 
             ZStack(alignment: .top) {
-                Color.clear
-                    .rectangularHitTarget()
-                    .onTapGesture {
-                        edits.clearSelection()
-                        isTimelineFocused = true
-                    }
+                Button {
+                    edits.clearSelection()
+                    isTimelineFocused = true
+                } label: {
+                    Color.clear
+                        .rectangularHitTarget()
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear timeline selection")
+                .accessibilityHint("Clears the selected timeline item.")
 
                 TimelineTrackContent(
                     videoURL: videoURL,
@@ -181,11 +185,15 @@ struct TimelineTrackContent: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TimelineRuler(viewport: viewport)
-                .rectangularHitTarget()
-                .onTapGesture {
-                    edits.clearSelection()
-                }
+            Button {
+                edits.clearSelection()
+            } label: {
+                TimelineRuler(viewport: viewport)
+                    .rectangularHitTarget()
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Clear timeline selection")
+            .accessibilityHint("Clears the selected timeline item.")
             TimelineClipRow(videoURL: videoURL, duration: playback.duration, currentTime: playback.currentTime, viewport: viewport, splitTimes: edits.clipSplitTimes, trimRegions: edits.trimRegions, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
             TimelineLayerRow(kind: .zoom, duration: playback.duration, viewport: viewport, regions: edits.zoomRegions.map(TimelineRegionRenderData.zoom), selectedID: edits.selectedKind == .zoom ? edits.selectedID : nil, edits: edits)
             TimelineCameraLayerRow(
@@ -1127,31 +1135,39 @@ private struct TimelineCameraClipItem: View {
         let startX = x(for: clip.span.start)
         let itemWidth = max(1, x(for: clip.span.end) - startX)
 
-        RoundedRectangle(cornerRadius: 7, style: .continuous)
-            .fill(accent.opacity(clip.settings.clamped.enabled ? (isSelected ? 0.55 : 0.34) : 0.18))
-            .overlay {
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .stroke(accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1)
-            }
-            .overlay { label(width: itemWidth) }
-            .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
-            .position(x: startX + itemWidth / 2, y: TimelineMetrics.layerHeight / 2)
-            .onTapGesture { edits.selectCameraClip(id: clip.id) }
-            .contextMenu {
-                Button {
-                    edits.splitCameraClip(at: currentTime, duration: duration, fallback: fallbackSettings)
-                } label: {
-                    Label("Split at Playhead", systemImage: "scissors")
+        Button {
+            edits.selectCameraClip(id: clip.id)
+        } label: {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(accent.opacity(clip.settings.clamped.enabled ? (isSelected ? 0.55 : 0.34) : 0.18))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1)
                 }
-                .disabled(!canSplitAtPlayhead)
+                .overlay { label(width: itemWidth) }
+        }
+        .buttonStyle(.plain)
+        .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
+        .position(x: startX + itemWidth / 2, y: TimelineMetrics.layerHeight / 2)
+        .accessibilityLabel(clip.settings.clamped.enabled ? "Camera clip" : "Hidden camera clip")
+        .accessibilityValue(timeRangeDescription)
+        .accessibilityHint("Selects this camera clip.")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .contextMenu {
+            Button {
+                edits.splitCameraClip(at: currentTime, duration: duration, fallback: fallbackSettings)
+            } label: {
+                Label("Split at Playhead", systemImage: "scissors")
+            }
+            .disabled(!canSplitAtPlayhead)
 
-                Button(role: .destructive) {
-                    edits.deleteCameraClip(id: clip.id, duration: duration, fallback: fallbackSettings)
-                } label: {
-                    Label("Delete", systemImage: "trash")
-                }
-                .disabled(!edits.canDeleteCameraClip(id: clip.id, duration: duration, fallback: fallbackSettings))
+            Button(role: .destructive) {
+                edits.deleteCameraClip(id: clip.id, duration: duration, fallback: fallbackSettings)
+            } label: {
+                Label("Delete", systemImage: "trash")
             }
+            .disabled(!edits.canDeleteCameraClip(id: clip.id, duration: duration, fallback: fallbackSettings))
+        }
     }
 
     private func label(width: CGFloat) -> some View {
@@ -1178,6 +1194,10 @@ private struct TimelineCameraClipItem: View {
         let minimumDistance = min(0.05, duration / 4)
         return currentTime > clip.span.start + minimumDistance && currentTime < clip.span.end - minimumDistance
     }
+
+    private var timeRangeDescription: String {
+        "\(clip.span.start.formatted(.number.precision(.fractionLength(1)))) to \(clip.span.end.formatted(.number.precision(.fractionLength(1)))) seconds"
+    }
 }
 
 struct TimelineRegionItem: View {
@@ -1193,10 +1213,28 @@ struct TimelineRegionItem: View {
     var body: some View {
         let startX = x(for: region.span.start)
         let itemWidth = max(1, x(for: region.span.end) - startX)
+
+        Button {
+            edits.select(kind, id: region.id)
+        } label: {
+            regionBody(width: itemWidth)
+        }
+        .buttonStyle(.plain)
+        .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
+        .position(x: startX + itemWidth / 2, y: TimelineMetrics.layerHeight / 2)
+        .simultaneousGesture(TapGesture(count: 2).onEnded { performPrimaryEdit() })
+        .gesture(moveGesture())
+        .accessibilityLabel("\(kind.title) region")
+        .accessibilityValue(regionAccessibilityValue)
+        .accessibilityHint(regionAccessibilityHint)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func regionBody(width: CGFloat) -> some View {
         RoundedRectangle(cornerRadius: 7, style: .continuous)
             .fill(kind.accent.opacity(isSelected ? 0.55 : 0.34))
             .overlay { RoundedRectangle(cornerRadius: 7, style: .continuous).stroke(kind.accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1) }
-            .overlay { regionLabel(width: itemWidth) }
+            .overlay { regionLabel(width: width) }
             .overlay(alignment: .leading) {
                 if showsLeadingHandle {
                     TimelineResizeHandle().offset(x: -9).gesture(resizeGesture(edge: .leading))
@@ -1207,11 +1245,6 @@ struct TimelineRegionItem: View {
                     TimelineResizeHandle().offset(x: 9).gesture(resizeGesture(edge: .trailing))
                 }
             }
-            .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
-            .position(x: startX + itemWidth / 2, y: TimelineMetrics.layerHeight / 2)
-            .onTapGesture(count: 2) { performPrimaryEdit() }
-            .onTapGesture { edits.select(kind, id: region.id) }
-            .gesture(moveGesture())
     }
 
     private func regionLabel(width: CGFloat) -> some View {
@@ -1302,5 +1335,13 @@ struct TimelineRegionItem: View {
     private func time(forDeltaX deltaX: CGFloat) -> Double {
         guard width > 0, viewport.visibleDuration.isFinite else { return 0 }
         return Double(deltaX / width) * viewport.visibleDuration
+    }
+
+    private var regionAccessibilityValue: String {
+        "\(region.label), \(region.span.start.formatted(.number.precision(.fractionLength(1)))) to \(region.span.end.formatted(.number.precision(.fractionLength(1)))) seconds"
+    }
+
+    private var regionAccessibilityHint: String {
+        kind == .zoom ? "Selects this timeline region. Press twice to increase zoom depth." : "Selects this timeline region."
     }
 }


### PR DESCRIPTION
## Summary
- Refresh landing page copy to reflect current editor capabilities: zooms, camera clips, cursor overlays, crop/aspect export, MP4/GIF/PNG handoffs, and screenshot composition.
- Replace action-like timeline tap gestures with plain SwiftUI buttons for clear-selection, ruler selection clearing, camera clip selection, and region selection while preserving drag, resize, context menu, and double-press zoom behavior.
- Add accessible labels, values, hints, and selected traits for timeline clip/region controls.

## Validation
- swift test --package-path apps/macos
- pnpm --dir apps/landing lint
- pnpm --dir apps/landing build
- cargo test --manifest-path apps/rust-service/Cargo.toml --quiet
- git diff --check

Note: `pnpm --dir apps/landing build` still emits the existing Next.js workspace-root warning about multiple lockfiles, but the production build completes successfully.