### PR TITLE
Clean up temp recording test output

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -539,6 +539,9 @@ final class AppModelStateTests: XCTestCase {
     func testStoppingRecordingWithoutWrittenFileReleasesCaptureState() async throws {
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("missing-recording-\(UUID().uuidString).mp4")
+        defer {
+            try? FileManager.default.removeItem(at: outputURL)
+        }
         let model = AppModel(
             stopRecording: {
                 outputURL


### PR DESCRIPTION
## Summary
- add teardown cleanup for the temporary missing-recording test output URL

## Tests
- `swift test --filter AppModelStateTests`
- `swift test` from `apps/macos` (343 tests, 0 failures)