### PR TITLE
Make privacy plist test path stable

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -15,7 +15,10 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
     }
 
     private func loadInfoPlist() throws -> [String: Any] {
-        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
         let plist = try PropertyListSerialization.propertyList(from: data, format: nil)


### PR DESCRIPTION
## Summary
- Resolve `Resources/Info.plist` in `PrivacyUsageDescriptionTests` relative to the test source file instead of the process current directory.
- Keeps the test stable when launched from a different working directory.

## Tests
- `swift test --filter PrivacyUsageDescriptionTests`
- `make test-macos`