### PR TITLE
[codex] Harden crop rect clamping

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -102,7 +102,12 @@ struct VideoCropSelection: Equatable, Hashable, Codable {
 
     static func clampedPixelRect(_ rect: CGRect, in sourceSize: CGSize) -> CGRect {
         let safeSize = safeSourceSize(sourceSize)
-        let standardized = rect.standardized
+        let standardized = CGRect(
+            x: rect.origin.x.isFinite ? rect.origin.x : 0,
+            y: rect.origin.y.isFinite ? rect.origin.y : 0,
+            width: rect.size.width.isFinite ? rect.size.width : safeSize.width,
+            height: rect.size.height.isFinite ? rect.size.height : safeSize.height
+        ).standardized
         let minWidth = min(Self.minimumPixelLength, safeSize.width)
         let minHeight = min(Self.minimumPixelLength, safeSize.height)
         let width = min(max(standardized.width, minWidth), safeSize.width)
@@ -113,7 +118,12 @@ struct VideoCropSelection: Equatable, Hashable, Codable {
     }
 
     static func clampedNormalizedRect(_ rect: CGRect) -> CGRect {
-        let standardized = rect.standardized
+        let standardized = CGRect(
+            x: rect.origin.x.isFinite ? rect.origin.x : 0,
+            y: rect.origin.y.isFinite ? rect.origin.y : 0,
+            width: rect.size.width.isFinite ? rect.size.width : 1,
+            height: rect.size.height.isFinite ? rect.size.height : 1
+        ).standardized
         let width = min(max(standardized.width, 0.0001), 1)
         let height = min(max(standardized.height, 0.0001), 1)
         let x = min(max(standardized.minX, 0), 1 - width)

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -32,6 +32,19 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(rect.height, 8, accuracy: 0.001)
     }
 
+    func testClampsNonFiniteCropRectsToFiniteBounds() {
+        let pixelRect = VideoCropSelection.clampedPixelRect(
+            CGRect(x: CGFloat.nan, y: CGFloat.infinity, width: CGFloat.infinity, height: CGFloat.nan),
+            in: CGSize(width: 100, height: 80)
+        )
+        let normalizedRect = VideoCropSelection.clampedNormalizedRect(
+            CGRect(x: CGFloat.nan, y: CGFloat.infinity, width: CGFloat.infinity, height: CGFloat.nan)
+        )
+
+        XCTAssertEqual(pixelRect, CGRect(x: 0, y: 0, width: 100, height: 80))
+        XCTAssertEqual(normalizedRect, CGRect(x: 0, y: 0, width: 1, height: 1))
+    }
+
     func testDisplayAndPixelCropMappingUseFittedVideoFrame() {
         let sourceSize = CGSize(width: 1920, height: 1080)
         let availableSize = CGSize(width: 960, height: 720)


### PR DESCRIPTION
## Summary
- Clamp non-finite crop rect origins and dimensions before applying crop bounds
- Add coverage for NaN and infinite crop rect inputs

## Impact
This keeps crop geometry helpers returning finite bounded rectangles for malformed inputs without changing normal crop behavior.

## Validation
- `swift test --filter VideoCropSelectionTests`
- `swift test` in `apps/macos` (345 tests, 0 failures)