### PR TITLE
[codex] Avoid force unwrap in shell routing test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class AppShellStateMachineTests: XCTestCase {
-    func testShellRoutesEditorSessionAndWindowCommand() {
+    func testShellRoutesEditorSessionAndWindowCommand() throws {
         var state = AppShellState()
         let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/demo.mp4"), title: "Demo")
 
@@ -16,7 +16,8 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(state.lastEditorSession, session)
         XCTAssertEqual(state.windowCommand?.action, .showStudio)
         XCTAssertEqual(state.windowCommand?.editorSession, session)
-        XCTAssertEqual(effects, [.openEditorSession(session), .emitWindowCommand(state.windowCommand!)])
+        let windowCommand = try XCTUnwrap(state.windowCommand)
+        XCTAssertEqual(effects, [.openEditorSession(session), .emitWindowCommand(windowCommand)])
     }
 
     func testShellConsumesWindowCommandOnce() {


### PR DESCRIPTION
## Summary
- Replaces a force unwrap in `AppShellStateMachineTests.testShellRoutesEditorSessionAndWindowCommand` with `XCTUnwrap`.
- Marks the test as `throws` so an unexpected nil command reports as a normal XCTest failure instead of crashing the test process.

## Impact
This is a test-only maintenance cleanup. It does not change production behavior.

## Validation
- `swift test --filter AppShellStateMachineTests/testShellRoutesEditorSessionAndWindowCommand`
- `swift test --filter AppShellStateMachineTests`