### PR TITLE
[codex] Relax Rust service pipe buffer test timeout

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -22,7 +22,7 @@ final class RustServiceClientTests: XCTestCase {
             completed.fulfill()
         }
 
-        let waitResult = XCTWaiter.wait(for: [completed], timeout: 5)
+        let waitResult = XCTWaiter.wait(for: [completed], timeout: 10)
         guard waitResult == .completed else {
             terminateServiceScript(at: serviceURL)
             XCTFail("RustServiceClient deadlocked on a response larger than the stdout pipe buffer.")


### PR DESCRIPTION
## Summary

- Increase the RustServiceClient large stdout pipe-buffer test timeout from 5 seconds to 10 seconds.
- Keep the change test-only so the production client behavior is untouched.

## Why

The test launches a shell script, streams a 70 KB response through stdout, and waits for a background service call to complete. The existing 5 second timeout is enough locally, but leaves little headroom for slower CI runners. The assertion still catches a real deadlock because the subprocess is terminated and the test fails if the call does not complete.

## Validation

- `swift test --filter RustServiceClientTests` from `apps/macos`