### PR TITLE
Handle non-finite crop selections

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -113,6 +113,13 @@ struct VideoCropSelection: Equatable, Hashable, Codable {
     }
 
     static func clampedNormalizedRect(_ rect: CGRect) -> CGRect {
+        guard rect.origin.x.isFinite,
+              rect.origin.y.isFinite,
+              rect.size.width.isFinite,
+              rect.size.height.isFinite else {
+            return CGRect(x: 0, y: 0, width: 1, height: 1)
+        }
+
         let standardized = rect.standardized
         let width = min(max(standardized.width, 0.0001), 1)
         let height = min(max(standardized.height, 0.0001), 1)

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -32,6 +32,15 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(rect.height, 8, accuracy: 0.001)
     }
 
+    func testNonFiniteNormalizedCropFallsBackToFullFrame() {
+        let selection = VideoCropSelection(
+            normalizedRect: CGRect(x: .nan, y: 0.2, width: 0.5, height: 0.5)
+        )
+
+        XCTAssertEqual(selection.normalizedRect, CGRect(x: 0, y: 0, width: 1, height: 1))
+        XCTAssertTrue(selection.isFullFrame)
+    }
+
     func testDisplayAndPixelCropMappingUseFittedVideoFrame() {
         let sourceSize = CGSize(width: 1920, height: 1080)
         let availableSize = CGSize(width: 960, height: 720)


### PR DESCRIPTION
## Summary
- Fall back to full-frame crop selection when normalized crop values are non-finite
- Add a regression test for non-finite normalized crop input

## Tests
- `swift test --filter VideoCropSelectionTests`