### PR TITLE
[codex] Add explicit Foundation import to privacy test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 
 final class PrivacyUsageDescriptionTests: XCTestCase {


### PR DESCRIPTION
## Summary

- Add an explicit `Foundation` import to `PrivacyUsageDescriptionTests`.
- Keep the test independent of transitive Foundation exposure from XCTest while it directly uses `URL`, `Data`, and `PropertyListSerialization`.

## Validation

- `swift test --filter PrivacyUsageDescriptionTests` from `apps/macos` passed with 1 test and 0 failures.