### PR TITLE
[codex] Make capture cancellation tests deterministic

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -155,11 +155,8 @@ final class CaptureDriverStateMachineTests: XCTestCase {
                 },
                 runRecordingStart: { _, _ in
                     started += 1
-                    do {
-                        try await Task.sleep(nanoseconds: 5_000_000_000)
-                    } catch {
-                        canceled = true
-                    }
+                    for await _ in AsyncStream<Void>(Void.self, { _ in }) {}
+                    canceled = true
                 }
             )
         )
@@ -191,11 +188,8 @@ final class CaptureDriverStateMachineTests: XCTestCase {
                 },
                 runScreenshotCapture: { _ in
                     started += 1
-                    do {
-                        try await Task.sleep(nanoseconds: 5_000_000_000)
-                    } catch {
-                        canceled = true
-                    }
+                    for await _ in AsyncStream<Void>(Void.self, { _ in }) {}
+                    canceled = true
                 }
             )
         )


### PR DESCRIPTION
## Summary
- Replace 5-second sleep sentinels in CaptureDriver cancellation tests with cancellable never-yielding AsyncStreams.
- Keep the change scoped to test code only, avoiding production behavior changes.

## Why
The cancellation tests were using long wall-clock sleeps as cancellable placeholders. Using an async stream that never yields keeps the same cancellation behavior while making the tests deterministic and fast.

## Validation
- `swift test --filter CaptureDriverStateMachineTests`
- `swift test` from `apps/macos`