### PR TITLE
[codex] Stabilize capture cancellation tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -167,9 +167,7 @@ final class CaptureDriverStateMachineTests: XCTestCase {
         XCTAssertEqual(started, 1)
 
         _ = driver.send(.recordingStopRequested)
-        for _ in 0..<20 where !canceled {
-            await Task.yield()
-        }
+        await waitForCondition { canceled }
 
         XCTAssertTrue(cancelEffectRan)
         XCTAssertTrue(canceled)
@@ -205,12 +203,21 @@ final class CaptureDriverStateMachineTests: XCTestCase {
         XCTAssertEqual(started, 1)
 
         _ = driver.send(.cancelCapture)
-        for _ in 0..<20 where !canceled {
-            await Task.yield()
-        }
+        await waitForCondition { canceled }
 
         XCTAssertTrue(cancelEffectRan)
         XCTAssertTrue(canceled)
+    }
+}
+
+@MainActor
+private func waitForCondition(
+    timeout: TimeInterval = 1,
+    condition: () -> Bool
+) async {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition(), Date() < deadline {
+        await Task.yield()
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace fixed scheduler-yield loops in capture cancellation tests with a bounded wait helper.
- Keep the change scoped to `AppPresentationStateMachineTests.swift`.

## Why

The tests only needed to wait for the async cancellation path to observe cancellation. A fixed number of `Task.yield()` calls can be scheduler-sensitive, so a short bounded wait makes the assertions less flaky without changing product behavior.

## Verification

- `swift test --package-path apps/macos --filter CaptureDriverStateMachineTests`
- `swift test --package-path apps/macos` (343 XCTest tests passed)