### PR TITLE
[codex] Tighten screen recording permission test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ScreenRecordingPermissionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreenRecordingPermissionTests.swift
@@ -72,7 +72,11 @@ final class ScreenRecordingPermissionTests: XCTestCase {
         ))
         let controller = CaptureController(screenRecordingPermission: permission)
 
-        XCTAssertThrowsError(try controller.ensureScreenRecordingPermissionForTesting())
+        XCTAssertThrowsError(try controller.ensureScreenRecordingPermissionForTesting()) { error in
+            guard case CaptureControllerError.screenRecordingPermissionRequired = error else {
+                return XCTFail("Expected first request to report required permission, got \(error)")
+            }
+        }
         XCTAssertThrowsError(try controller.ensureScreenRecordingPermissionForTesting()) { error in
             guard case CaptureControllerError.screenRecordingPermissionUnavailableAfterRequest = error else {
                 return XCTFail("Expected same-session repeated request to be suppressed, got \(error)")


### PR DESCRIPTION
## Summary

- Tightens the same-session screen recording permission denial test to assert the exact first error case.
- Keeps the change scoped to test coverage only, with no production code changes.

## Validation

- `swift test --filter ScreenRecordingPermissionTests` in `apps/macos` (5 tests passed).