### PR TITLE
[codex] Stabilize capture cancellation tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -169,9 +169,7 @@ final class CaptureDriverStateMachineTests: XCTestCase {
         XCTAssertEqual(started, 1)
 
         _ = driver.send(.recordingStopRequested)
-        for _ in 0..<20 where !canceled {
-            await Task.yield()
-        }
+        await waitForCancellation { canceled }
 
         XCTAssertTrue(cancelEffectRan)
         XCTAssertTrue(canceled)
@@ -210,12 +208,16 @@ final class CaptureDriverStateMachineTests: XCTestCase {
         XCTAssertEqual(started, 1)
 
         _ = driver.send(.cancelCapture)
-        for _ in 0..<20 where !canceled {
-            await Task.yield()
-        }
+        await waitForCancellation { canceled }
 
         XCTAssertTrue(cancelEffectRan)
         XCTAssertTrue(canceled)
+    }
+
+    private func waitForCancellation(_ condition: () -> Bool) async {
+        for _ in 0..<100 where !condition() {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace fixed `Task.yield()` polling in capture cancellation tests with a bounded async wait helper
- keep the change scoped to `CaptureDriverStateMachineTests`

## Why
The cancellation assertions were scheduler-sensitive because they only yielded a fixed number of times. A short bounded wait preserves the same behavior under test while reducing timing flakiness.

## Validation
- `swift test --filter CaptureDriverStateMachineTests` from `apps/macos`