### PR TITLE
[codex] Harden Rust service pipe reader cleanup

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
@@ -141,11 +141,11 @@ private final class PipeDataReader: @unchecked Sendable {
     func start() {
         group.enter()
         queue.async { [self] in
+            defer { group.leave() }
             let readData = fileHandle.readDataToEndOfFile()
             lock.lock()
+            defer { lock.unlock() }
             data = readData
-            lock.unlock()
-            group.leave()
         }
     }
 


### PR DESCRIPTION
## Summary

- Scope Rust service pipe-reader cleanup with `defer` for both the dispatch group and lock release.
- Preserve the existing read/store/waiter signaling behavior while making the helper harder to break during future edits.

## Validation

- `swift test --package-path apps/macos --filter RustServiceClientTests`