### PR TITLE
merge queue: queuing main (51ec474), #358 and #359 together

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -539,6 +539,9 @@ final class AppModelStateTests: XCTestCase {
     func testStoppingRecordingWithoutWrittenFileReleasesCaptureState() async throws {
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("missing-recording-\(UUID().uuidString).mp4")
+        defer {
+            try? FileManager.default.removeItem(at: outputURL)
+        }
         let model = AppModel(
             stopRecording: {
                 outputURL

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -169,9 +169,7 @@ final class CaptureDriverStateMachineTests: XCTestCase {
         XCTAssertEqual(started, 1)
 
         _ = driver.send(.recordingStopRequested)
-        for _ in 0..<20 where !canceled {
-            await Task.yield()
-        }
+        await waitForCondition { canceled }
 
         XCTAssertTrue(cancelEffectRan)
         XCTAssertTrue(canceled)
@@ -210,12 +208,21 @@ final class CaptureDriverStateMachineTests: XCTestCase {
         XCTAssertEqual(started, 1)
 
         _ = driver.send(.cancelCapture)
-        for _ in 0..<20 where !canceled {
-            await Task.yield()
-        }
+        await waitForCondition { canceled }
 
         XCTAssertTrue(cancelEffectRan)
         XCTAssertTrue(canceled)
+    }
+}
+
+@MainActor
+private func waitForCondition(
+    timeout: TimeInterval = 1,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition(), Date() < deadline {
+        try? await Task.sleep(nanoseconds: 10_000_000)
     }
 }
 


### PR DESCRIPTION
<!---
DO NOT EDIT
-*- Mergify Payload -*-
{"merge-queue-pr": true}
-*- Mergify Payload End -*-
-->

**✨ Pull request #358 which was ahead in the queue has been dequeued (for the following reason: `pull request manually updated`). The pull request [#359](/imbhargav5/open-recorder/pull/359) has been requeued. ✨**

Branch **main** (51ec474), [#358](/imbhargav5/open-recorder/pull/358) and [#359](/imbhargav5/open-recorder/pull/359) are queued together for merge.

This pull request has been created by Mergify to speculatively check the mergeability of [#359](/imbhargav5/open-recorder/pull/359).
You don't need to do anything. Mergify will close this pull request automatically when it is complete.

**Required conditions of queue rule** `Default merge queue` **for merge:**

- [ ] `check-success=GitGuardian Security Checks`
- [ ] `check-success=changes`
- [ ] any of:
  - [ ] `check-skipped=Native macOS tests`
  - [ ] `check-success=Native macOS tests`

**Required conditions to stay in the queue:** None

```yaml
---
checking_base_sha: b1c89150650a0a2e1c7f3621509ff76e80dc83ae
previous_check_retries: []
previous_failed_batches: []
pull_requests:
  - number: 359
    scopes: []
scopes: []
...

```