### PR TITLE
Add screen-only recording session test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
@@ -48,6 +48,27 @@ final class RecordingSessionBuilderTests: XCTestCase {
         XCTAssertEqual(session.facecamVideoPath, facecamURL.path)
     }
 
+    func testBuildRecordingSessionWithoutFacecamDisablesFacecamDefaults() {
+        let screenURL = URL(fileURLWithPath: "/tmp/screen.mp4")
+
+        let session = RecordingSessionBuilder.build(
+            screenVideoURL: screenURL,
+            facecamURL: nil,
+            sourceName: nil,
+            showCursor: false,
+            cursorTelemetryURL: nil,
+            screenStartedAt: Date(timeIntervalSince1970: 10),
+            facecamStartedAt: nil
+        )
+
+        XCTAssertEqual(session.screenVideoPath, screenURL.path)
+        XCTAssertNil(session.facecamVideoPath)
+        XCTAssertNil(session.facecamOffsetMs)
+        XCTAssertEqual(session.facecamSettings?.enabled, false)
+        XCTAssertFalse(session.showCursorOverlay)
+        XCTAssertFalse(session.hasRecordedCamera)
+    }
+
     func testRecordingSessionHasRecordedCameraRequiresFacecamPath() {
         var session = RecordingSession(
             screenVideoPath: "/tmp/screen.mp4",


### PR DESCRIPTION
## Summary
- Add coverage for building a screen-only recording session without facecam media
- Assert disabled facecam defaults and absent camera metadata stay consistent

## Verification
- `swift test --filter RecordingSessionBuilderTests`
- `make test-macos`