### PR TITLE
[codex] Remove placeholder Next config comment

### DIFF
--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Remove the stale template placeholder comment from the landing app's `next.config.ts`.
- Keep the typed Next config as an empty object since there are no active options.

## Validation

- `./node_modules/.bin/eslint` from `apps/landing`
- `./node_modules/.bin/next build` from `apps/landing`

Note: `pnpm --dir apps/landing lint` and `pnpm --dir apps/landing build` could not run through the bundled pnpm wrapper because dependency setup exited on the existing ignored-build-scripts gate for `sharp` and `unrs-resolver`. The installed script binaries passed after dependencies were materialized.