### PR TITLE
Trim stored zoom preset values

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineZoomAnimationPreset.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineZoomAnimationPreset.swift
@@ -115,7 +115,7 @@ enum TimelineZoomAnimationPreset: String, CaseIterable, Codable, Hashable, Ident
     }
 
     static func storedValue(_ rawValue: String?) -> TimelineZoomAnimationPreset {
-        guard let rawValue,
+        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
               let preset = TimelineZoomAnimationPreset(rawValue: rawValue) else {
             return .balanced
         }

--- a/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
@@ -107,6 +107,10 @@ final class AutoZoomGeneratorTests: XCTestCase {
         XCTAssertNil(zoom.sourceClickTimestamp)
     }
 
+    func testStoredZoomAnimationPresetTrimsWhitespace() {
+        XCTAssertEqual(TimelineZoomAnimationPreset.storedValue(" snappy\n"), .snappy)
+    }
+
     func testPresetChangesGeneratedTimingAndDepth() {
         let payload = CursorTelemetryPayload(
             width: 1000,


### PR DESCRIPTION
## Summary
- Trim whitespace around persisted auto-zoom animation preset values before decoding them.
- Add focused coverage for whitespace-padded stored preset strings.

## Verification
- `swift test --filter AutoZoomGeneratorTests`
- `swift test`

Note: `make test-macos` could not run in this environment because `cargo` is not installed (`/bin/sh: cargo: command not found`) before the Swift test step.