### PR TITLE
Name default crop source size

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -26,6 +26,7 @@ enum VideoCropSizing: Equatable, Hashable, Codable {
 
 struct VideoCropSelection: Equatable, Hashable, Codable {
     static let minimumPixelLength: CGFloat = 8
+    static let defaultSourceSize = CGSize(width: 1920, height: 1080)
 
     var normalizedRect: CGRect
     var sizing: VideoCropSizing
@@ -130,8 +131,8 @@ struct VideoCropSelection: Equatable, Hashable, Codable {
 
     static func safeSourceSize(_ sourceSize: CGSize) -> CGSize {
         CGSize(
-            width: sourceSize.width.isFinite && sourceSize.width > 0 ? sourceSize.width : 1920,
-            height: sourceSize.height.isFinite && sourceSize.height > 0 ? sourceSize.height : 1080
+            width: sourceSize.width.isFinite && sourceSize.width > 0 ? sourceSize.width : defaultSourceSize.width,
+            height: sourceSize.height.isFinite && sourceSize.height > 0 ? sourceSize.height : defaultSourceSize.height
         )
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -46,8 +46,7 @@ final class VideoCropSelectionTests: XCTestCase {
             CGSize(width: CGFloat.nan, height: -20)
         )
 
-        XCTAssertEqual(safeSize.width, 1920)
-        XCTAssertEqual(safeSize.height, 1080)
+        XCTAssertEqual(safeSize, VideoCropSelection.defaultSourceSize)
     }
 
     func testDisplayAndPixelCropMappingUseFittedVideoFrame() {


### PR DESCRIPTION
## Summary
- Add a named `VideoCropSelection.defaultSourceSize` constant for fallback crop dimensions
- Update the existing invalid-source-size test to assert against the shared fallback constant

## Verification
- `swift test` from `apps/macos`