### PR TITLE
Cover zero waveform target count

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -36,6 +36,16 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertTrue(samples.allSatisfy { abs($0 - TimelineWaveformDownsampler.quietLevel) < 0.0001 })
     }
 
+    func testNonPositiveTargetCountReturnsNoSamples() {
+        XCTAssertTrue(
+            TimelineWaveformDownsampler.downsample(
+                interleavedSamples: [0.7, 0.2, 0.4],
+                channelCount: 1,
+                targetCount: 0
+            ).isEmpty
+        )
+    }
+
     func testInvalidChannelCountReturnsQuietSamples() {
         let samples = TimelineWaveformDownsampler.downsample(
             interleavedSamples: [0.7, 0.2, 0.4],


### PR DESCRIPTION
## Summary
- add focused Swift test coverage for zero waveform downsample target counts

## Verification
- `swift test --package-path apps/macos --filter TimelineAudioWaveformTests`

Note: `make test-macos` could not run in this environment because `cargo` is not installed.