### PR TITLE
Cover invalid visible timeline ticks

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -144,6 +144,18 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertEqual(ticks.map(\.time), [0, 10, 20, 30, 40, 50, 60])
         XCTAssertEqual(ticks.map(\.label), ["0:00", "0:10", "0:20", "0:30", "0:40", "0:50", "1:00"])
     }
+
+    func testVisibleTicksSanitizeInvalidWindowInputs() {
+        let ticks = TimelineRulerTickBuilder.ticks(
+            visibleStart: .nan,
+            visibleDuration: .infinity,
+            totalDuration: 4,
+            maxTickCount: 4
+        )
+
+        XCTAssertEqual(ticks.map(\.time), [0, 2, 4])
+        XCTAssertEqual(ticks.map(\.label), ["", "2s", "4s"])
+    }
 }
 
 final class TimelineSeekMapperTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Add a focused test for visible timeline ruler tick sanitization when window inputs are invalid.

## Tests
- `swift test --package-path apps/macos --filter TimelineAudioWaveformTests`
- `swift test --package-path apps/macos`