### PR TITLE
Add plist project type metadata test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -15,6 +15,15 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         )
     }
 
+    func testInfoPlistDocumentTypeMatchesExportedProjectType() throws {
+        let plist = try loadInfoPlist()
+        let documentTypes = plist["CFBundleDocumentTypes"] as? [[String: Any]]
+        let exportedTypes = plist["UTExportedTypeDeclarations"] as? [[String: Any]]
+
+        XCTAssertEqual(documentTypes?.first?["LSItemContentTypes"] as? [String], ["dev.openrecorder.project"])
+        XCTAssertEqual(exportedTypes?.first?["UTTypeIdentifier"] as? String, "dev.openrecorder.project")
+    }
+
     private func loadInfoPlist() throws -> [String: Any] {
         let url = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- add a focused Info.plist test that verifies the app document type references the exported Open Recorder project UTI

## Tests
- `swift test --filter PrivacyUsageDescriptionTests`
- `swift test`

## Notes
- `make test-macos` could not complete locally because `cargo` is not installed on PATH; it failed before running the Rust tests.