### PR TITLE
Expand project plist metadata test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -20,8 +20,15 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         let documentTypes = plist["CFBundleDocumentTypes"] as? [[String: Any]]
         let exportedTypes = plist["UTExportedTypeDeclarations"] as? [[String: Any]]
 
+        XCTAssertEqual(documentTypes?.first?["CFBundleTypeExtensions"] as? [String], ["openrecorder"])
+        XCTAssertEqual(documentTypes?.first?["CFBundleTypeName"] as? String, "Open Recorder Project")
+        XCTAssertEqual(documentTypes?.first?["CFBundleTypeRole"] as? String, "Editor")
         XCTAssertEqual(documentTypes?.first?["LSItemContentTypes"] as? [String], ["dev.openrecorder.project"])
         XCTAssertEqual(exportedTypes?.first?["UTTypeIdentifier"] as? String, "dev.openrecorder.project")
+        XCTAssertEqual(
+            exportedTypes?.first?["UTTypeTagSpecification"] as? [String: [String]],
+            ["public.filename-extension": ["openrecorder"]]
+        )
     }
 
     private func loadInfoPlist() throws -> [String: Any] {


### PR DESCRIPTION
## Summary
- add assertions for Open Recorder project document extension, type name, and role
- verify exported UTI filename extension metadata stays aligned with the document type

## Tests
- `swift test --filter PrivacyUsageDescriptionTests`
- `swift test`