### PR TITLE
Cover partial waveform frames

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -94,6 +94,17 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertEqual(samples[1], 0.5, accuracy: 0.0001)
     }
 
+    func testDownsamplerIgnoresTrailingPartialFrame() {
+        let samples = TimelineWaveformDownsampler.downsample(
+            interleavedSamples: [0.2, 0.4, 1.0],
+            channelCount: 2,
+            targetCount: 1
+        )
+
+        XCTAssertEqual(samples.count, 1)
+        XCTAssertEqual(samples[0], 0.3, accuracy: 0.0001)
+    }
+
     func testWaveformAlwaysUsesTargetSampleCount() {
         let samples = TimelineWaveformDownsampler.downsample(
             interleavedSamples: Array(repeating: Float(0.4), count: 100),


### PR DESCRIPTION
## Summary
- add waveform downsampler coverage for buffers with trailing partial frames

## Tests
- `swift test --package-path apps/macos --filter TimelineAudioWaveformTests/testDownsamplerIgnoresTrailingPartialFrame`
- `swift test --package-path apps/macos --filter TimelineAudioWaveformTests`