### PR TITLE
Cover control characters in filename sanitization

### DIFF
--- a/apps/rust-service/src/main.rs
+++ b/apps/rust-service/src/main.rs
@@ -696,6 +696,10 @@ mod tests {
             sanitize_file_name("Product Demo: Screen/Window.mov"),
             "Product-Demo-Screen-Window.mov"
         );
+        assert_eq!(
+            sanitize_file_name("Clip\tTitle\nFinal.mov"),
+            "Clip-Title-Final.mov"
+        );
         assert_eq!(sanitize_file_name("..."), "open-recorder-file");
     }
 


### PR DESCRIPTION
## Summary
- Add a Rust service regression assertion for tab/newline normalization in sanitized file names

## Tests
- `cargo test` from `apps/rust-service`