### PR TITLE
Tighten plist test helpers

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -40,11 +40,6 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
 
-        guard let dictionary = plist as? [String: Any] else {
-            XCTFail("Resources/Info.plist should be a dictionary")
-            return [:]
-        }
-
-        return dictionary
+        return try XCTUnwrap(plist as? [String: Any], "Resources/Info.plist should be a dictionary")
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -16,12 +16,7 @@ final class ReleaseVersionTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
 
-        guard let dictionary = plist as? [String: Any] else {
-            XCTFail("Resources/Info.plist should be a dictionary")
-            return [:]
-        }
-
-        return dictionary
+        return try XCTUnwrap(plist as? [String: Any], "Resources/Info.plist should be a dictionary")
     }
 
     private func loadRustServiceVersion() throws -> String {


### PR DESCRIPTION
## Summary
- replace fallback empty dictionaries in plist test helpers with direct XCTUnwrap failures
- keeps malformed plist fixtures from cascading into unrelated assertions

## Tests
- swift test