### PR TITLE
Harden async test polling against clock changes

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1379,9 +1379,10 @@ private func waitForCondition(
     timeout: TimeInterval = 1,
     condition: @escaping @MainActor () -> Bool
 ) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while !condition(), Date() < deadline {
-        try? await Task.sleep(nanoseconds: 10_000_000)
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .milliseconds(Int(timeout * 1_000)))
+    while !condition(), clock.now < deadline {
+        try? await clock.sleep(for: .milliseconds(10))
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -219,9 +219,10 @@ private func waitForCondition(
     timeout: TimeInterval = 1,
     condition: @escaping @MainActor () -> Bool
 ) async {
-    let deadline = Date().addingTimeInterval(timeout)
-    while !condition(), Date() < deadline {
-        try? await Task.sleep(nanoseconds: 10_000_000)
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .milliseconds(Int(timeout * 1_000)))
+    while !condition(), clock.now < deadline {
+        try? await clock.sleep(for: .milliseconds(10))
     }
 }
 


### PR DESCRIPTION
## Summary
- Use Swift's monotonic ContinuousClock in async test polling helpers
- Avoid Date-based deadlines in AppModel and AppPresentation state tests

## Verification
- cd apps/macos && swift test