### PR TITLE
Handle non-finite pixel crop rects

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -103,6 +103,13 @@ struct VideoCropSelection: Equatable, Hashable, Codable {
 
     static func clampedPixelRect(_ rect: CGRect, in sourceSize: CGSize) -> CGRect {
         let safeSize = safeSourceSize(sourceSize)
+        guard rect.origin.x.isFinite,
+              rect.origin.y.isFinite,
+              rect.size.width.isFinite,
+              rect.size.height.isFinite else {
+            return CGRect(origin: .zero, size: safeSize)
+        }
+
         let standardized = rect.standardized
         let minWidth = min(Self.minimumPixelLength, safeSize.width)
         let minHeight = min(Self.minimumPixelLength, safeSize.height)

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -41,6 +41,15 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertTrue(selection.isFullFrame)
     }
 
+    func testNonFinitePixelCropFallsBackToSafeSourceFrame() {
+        let rect = VideoCropSelection.clampedPixelRect(
+            CGRect(x: CGFloat.nan, y: 20, width: 200, height: 100),
+            in: CGSize(width: 640, height: 360)
+        )
+
+        XCTAssertEqual(rect, CGRect(x: 0, y: 0, width: 640, height: 360))
+    }
+
     func testReversedNormalizedCropStandardizesBeforeClamping() {
         let selection = VideoCropSelection(
             normalizedRect: CGRect(x: 0.75, y: 0.8, width: -0.5, height: -0.4)


### PR DESCRIPTION
## Summary
- guard pixel crop clamping against non-finite rectangle values
- add regression coverage for falling back to the safe source frame

## Tests
- swift test --package-path apps/macos --filter VideoCropSelectionTests