### PR TITLE
Use HTTPS docs link on landing page

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-const docsUrl = "http://docs.openrecorder.xyz/";
+const docsUrl = "https://docs.openrecorder.xyz/";
 const sourceUrl = "https://github.com/imbhargav5/open-recorder";
 
 const proofPoints = [


### PR DESCRIPTION
## Summary
- update the landing page docs URL to use HTTPS

## Verification
- curl -I https://docs.openrecorder.xyz/
- pnpm --dir apps/landing lint