### PR TITLE
Cover trimmed window source labels

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
@@ -67,6 +67,17 @@ final class WindowSourceFilterTests: XCTestCase {
         XCTAssertEqual(displayInfo?.subtitle, "Example App")
     }
 
+    func testTrimsWindowTitleAndOwnerNameForDisplay() {
+        let displayInfo = displayInfo(
+            title: "  Project Notes  \n",
+            ownerName: "\tNotes App  ",
+            bundleIdentifier: "com.example.notes"
+        )
+
+        XCTAssertEqual(displayInfo?.name, "Project Notes")
+        XCTAssertEqual(displayInfo?.subtitle, "Notes App")
+    }
+
     private func displayInfo(
         title: String?,
         ownerName: String?,


### PR DESCRIPTION
## Summary
- Add focused coverage that window source titles and owner names are trimmed before display.

## Tests
- swift test --package-path apps/macos --filter WindowSourceFilterTests