### PR TITLE
Stabilize project date formatting

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
@@ -419,6 +419,7 @@ func formattedProjectDate(_ value: String) -> String {
     }
 
     let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.dateFormat = "MMM d, h:mm a"
     return formatter.string(from: date)
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -63,6 +63,16 @@ final class ProjectAutosaveCoordinatorTests: XCTestCase {
 }
 
 final class ProjectEditorStateCodableTests: XCTestCase {
+    func testFormattedProjectDateUsesStableMonthLabelsForEpochStrings() {
+        let timestamp = "1767225600"
+        let expectedDate = Date(timeIntervalSince1970: 1_767_225_600)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d, h:mm a"
+
+        XCTAssertEqual(formattedProjectDate(timestamp), formatter.string(from: expectedDate))
+    }
+
     func testOldProjectDocumentsDecodeWithoutVideoState() throws {
         let data = """
         {


### PR DESCRIPTION
## Summary
- Set the fixed project date formatter to use en_US_POSIX locale
- Add a focused regression test for epoch-string project date formatting

## Verification
- swift test --filter ProjectEditorStateCodableTests/testFormattedProjectDateUsesStableMonthLabelsForEpochStrings
- make test-macos