### PR TITLE
Cover default microphone stream configuration

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
@@ -98,4 +98,24 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
         XCTAssertTrue(configuration.captureMicrophone)
         XCTAssertEqual(configuration.microphoneCaptureDeviceID, "built-in-microphone")
     }
+
+    func testStreamConfigurationAllowsDefaultMicrophoneSelection() {
+        let configuration = NativeScreenRecorder.makeStreamConfiguration(
+            width: 1280,
+            height: 720,
+            sourceRect: nil,
+            options: RecordingCaptureOptions(
+                includeMicrophone: true,
+                microphoneDeviceID: nil,
+                includeSystemAudio: false,
+                includeCamera: false,
+                cameraDeviceID: nil,
+                showCursor: false,
+                showClicks: false
+            )
+        )
+
+        XCTAssertTrue(configuration.captureMicrophone)
+        XCTAssertNil(configuration.microphoneCaptureDeviceID)
+    }
 }


### PR DESCRIPTION
## Summary\n- add coverage for native stream configuration when microphone capture is enabled without a selected device ID\n\n## Tests\n- swift test --filter NativeScreenRecorderConfigurationTests\n- swift test