### PR TITLE
Improve legacy project fixture failure handling

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -74,7 +74,7 @@ final class ProjectEditorStateCodableTests: XCTestCase {
     }
 
     func testOldProjectDocumentsDecodeWithoutVideoState() throws {
-        let data = """
+        let data = try XCTUnwrap("""
         {
           "schemaVersion": 2,
           "title": "Legacy",
@@ -92,7 +92,7 @@ final class ProjectEditorStateCodableTests: XCTestCase {
             }
           }
         }
-        """.data(using: .utf8)!
+        """.data(using: .utf8))
 
         let document = try JSONDecoder().decode(ProjectDocument.self, from: data)
 


### PR DESCRIPTION
## Summary
- replace a force unwrap in a legacy project JSON fixture with XCTUnwrap for clearer test failures

## Tests
- swift test --filter ProjectEditorStateCodableTests
- make test-macos