### PR TITLE
Test invalid auto zoom preset fallback

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
@@ -111,6 +111,12 @@ final class AutoZoomGeneratorTests: XCTestCase {
         XCTAssertEqual(TimelineZoomAnimationPreset.storedValue(" snappy\n"), .snappy)
     }
 
+    func testStoredZoomAnimationPresetDefaultsInvalidValuesToBalanced() {
+        XCTAssertEqual(TimelineZoomAnimationPreset.storedValue(nil), .balanced)
+        XCTAssertEqual(TimelineZoomAnimationPreset.storedValue(""), .balanced)
+        XCTAssertEqual(TimelineZoomAnimationPreset.storedValue("unknown"), .balanced)
+    }
+
     func testPresetChangesGeneratedTimingAndDepth() {
         let payload = CursorTelemetryPayload(
             width: 1000,


### PR DESCRIPTION
## Summary
- add coverage that invalid or missing stored auto-zoom animation presets fall back to `.balanced`

## Verification
- swift test --package-path apps/macos --filter AutoZoomGeneratorTests
- make test-macos
