### PR TITLE
Clamp timeline ruler visible start

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
@@ -29,9 +29,10 @@ enum TimelineRulerTickBuilder {
     }
 
     static func ticks(visibleStart: Double, visibleDuration: Double, totalDuration: Double, maxTickCount: Int = 8) -> [TimelineRulerTick] {
-        let safeVisibleStart = visibleStart.isFinite && visibleStart > 0 ? visibleStart : 0
         let safeVisibleDuration = visibleDuration.isFinite && visibleDuration > 0 ? visibleDuration : 6
         let safeTotalDuration = totalDuration.isFinite && totalDuration > 0 ? totalDuration : safeVisibleDuration
+        let unclampedVisibleStart = visibleStart.isFinite && visibleStart > 0 ? visibleStart : 0
+        let safeVisibleStart = min(unclampedVisibleStart, safeTotalDuration)
         let safeTickCount = max(maxTickCount, 2)
         let step = tickStep(for: safeVisibleDuration, maxTickCount: safeTickCount)
         let visibleEnd = min(safeTotalDuration, safeVisibleStart + safeVisibleDuration)
@@ -75,9 +76,10 @@ enum TimelineRulerTickBuilder {
     }
 
     static func halfSecondTicks(visibleStart: Double, visibleDuration: Double, totalDuration: Double) -> [TimelineRulerTick] {
-        let safeVisibleStart = visibleStart.isFinite && visibleStart > 0 ? visibleStart : 0
         let safeVisibleDuration = visibleDuration.isFinite && visibleDuration > 0 ? visibleDuration : 6
         let safeTotalDuration = totalDuration.isFinite && totalDuration > 0 ? totalDuration : safeVisibleDuration
+        let unclampedVisibleStart = visibleStart.isFinite && visibleStart > 0 ? visibleStart : 0
+        let safeVisibleStart = min(unclampedVisibleStart, safeTotalDuration)
         let visibleEnd = min(safeTotalDuration, safeVisibleStart + safeVisibleDuration)
         var ticks: [TimelineRulerTick] = []
         var time = (safeVisibleStart - 0.5).rounded(.up) + 0.5

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -189,6 +189,28 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertEqual(ticks.map(\.time), [0, 2, 4])
         XCTAssertEqual(ticks.map(\.label), ["", "2s", "4s"])
     }
+
+    func testVisibleTicksClampStartBeyondTotalDuration() {
+        let ticks = TimelineRulerTickBuilder.ticks(
+            visibleStart: 12,
+            visibleDuration: 4,
+            totalDuration: 10,
+            maxTickCount: 4
+        )
+
+        XCTAssertEqual(ticks.map(\.time), [10])
+        XCTAssertEqual(ticks.map(\.label), ["10s"])
+    }
+
+    func testVisibleHalfSecondTicksClampStartBeyondTotalDuration() {
+        let ticks = TimelineRulerTickBuilder.halfSecondTicks(
+            visibleStart: 12,
+            visibleDuration: 4,
+            totalDuration: 10
+        )
+
+        XCTAssertTrue(ticks.isEmpty)
+    }
 }
 
 final class TimelineSeekMapperTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Clamp visible timeline ruler windows that start beyond the total duration
- Add regression coverage for major and half-second visible tick generation

## Tests
- swift test --filter TimelineAudioWaveformTests
- swift test