### PR TITLE
Cover quiet waveform sample count bounds

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -56,6 +56,11 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertEqual(samples, TimelineWaveformDownsampler.quietSamples(targetCount: 3))
     }
 
+    func testQuietSamplesRejectsNonPositiveTargetCounts() {
+        XCTAssertTrue(TimelineWaveformDownsampler.quietSamples(targetCount: 0).isEmpty)
+        XCTAssertTrue(TimelineWaveformDownsampler.quietSamples(targetCount: -3).isEmpty)
+    }
+
     func testConstantWaveformKeepsLevel() {
         let samples = TimelineWaveformDownsampler.downsample(
             interleavedSamples: Array(repeating: Float(0.25), count: 20),


### PR DESCRIPTION
## Summary
- add coverage that quiet waveform sample generation returns no samples for zero and negative target counts

## Tests
- cd apps/macos && swift test --filter TimelineAudioWaveformTests