### PR TITLE
Cover untitled window source display fallback

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
@@ -67,6 +67,17 @@ final class WindowSourceFilterTests: XCTestCase {
         XCTAssertEqual(displayInfo?.subtitle, "Example App")
     }
 
+    func testUsesOwnerNameWhenWindowTitleIsMissing() {
+        let displayInfo = displayInfo(
+            title: nil,
+            ownerName: "Preview",
+            bundleIdentifier: "com.apple.Preview"
+        )
+
+        XCTAssertEqual(displayInfo?.name, "Preview")
+        XCTAssertEqual(displayInfo?.subtitle, "Preview")
+    }
+
     func testTrimsWindowTitleAndOwnerNameForDisplay() {
         let displayInfo = displayInfo(
             title: "  Project Notes  \n",


### PR DESCRIPTION
## Summary
- add coverage for untitled window sources falling back to the owner name in display info

## Tests
- swift test --filter WindowSourceFilterTests