### PR TITLE
Normalize stored zoom preset casing

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineZoomAnimationPreset.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineZoomAnimationPreset.swift
@@ -116,7 +116,7 @@ enum TimelineZoomAnimationPreset: String, CaseIterable, Codable, Hashable, Ident
 
     static func storedValue(_ rawValue: String?) -> TimelineZoomAnimationPreset {
         guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
-              let preset = TimelineZoomAnimationPreset(rawValue: rawValue) else {
+              let preset = TimelineZoomAnimationPreset(rawValue: rawValue.lowercased()) else {
             return .balanced
         }
         return preset

--- a/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
@@ -109,6 +109,7 @@ final class AutoZoomGeneratorTests: XCTestCase {
 
     func testStoredZoomAnimationPresetTrimsWhitespace() {
         XCTAssertEqual(TimelineZoomAnimationPreset.storedValue(" snappy\n"), .snappy)
+        XCTAssertEqual(TimelineZoomAnimationPreset.storedValue("CINEMATIC"), .cinematic)
     }
 
     func testStoredZoomAnimationPresetDefaultsInvalidValuesToBalanced() {


### PR DESCRIPTION
## Summary
- normalize persisted zoom animation preset values case-insensitively after trimming whitespace
- cover uppercase preset strings in the existing AutoZoomGenerator tests

## Tests
- swift test --package-path apps/macos --filter AutoZoomGeneratorTests
- make test-macos