### PR TITLE
Assert async test wait timeout

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -224,6 +224,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }
+    XCTAssertTrue(condition(), "Timed out waiting for condition")
 }
 
 @MainActor


### PR DESCRIPTION
## Summary\n- Add an explicit timeout assertion to the async wait helper used by capture driver cancellation tests.\n\n## Tests\n- swift test --package-path apps/macos