### PR TITLE
Cover command option crop shortcut

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -313,5 +313,6 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 0, modifierFlags: []))
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.option]))
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.control]))
+        XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.command, .option]))
     }
 }


### PR DESCRIPTION
## Summary\n- add coverage that command+option crop arrow shortcuts are ignored\n\n## Tests\n- cd apps/macos && swift test --filter VideoCropSelectionTests