### PR TITLE
Cover smoothed waveform level clamping

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -25,6 +25,13 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertTrue(bars.contains { $0 >= 0.95 })
     }
 
+    func testWaveformBarRendererClampsSmoothedLevels() {
+        let levels = TimelineWaveformBarRenderer.smoothedDisplayLevels(from: [-0.5, 1.8, 0.4])
+
+        XCTAssertEqual(levels.count, 3)
+        XCTAssertTrue(levels.allSatisfy { $0 >= 0 && $0 <= 1 })
+    }
+
     func testEmptyWaveformReturnsQuietSamples() {
         let samples = TimelineWaveformDownsampler.downsample(
             interleavedSamples: [],


### PR DESCRIPTION
## Summary
- add a focused TimelineAudioWaveformTests case for smoothed waveform level clamping

## Tests
- swift test --filter TimelineAudioWaveformTests
- swift test