### PR TITLE
Cover even crop geometry sizing

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -90,6 +90,12 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(roundTrip.height, pixelRect.height, accuracy: 0.001)
     }
 
+    func testEvenSizeRoundsDownToPositiveEvenDimensions() {
+        XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 1001, height: 777)), CGSize(width: 1000, height: 776))
+        XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 17.8, height: 12.2)), CGSize(width: 16, height: 12))
+        XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 1, height: -4)), CGSize(width: 2, height: 2))
+    }
+
     func testSourceExportOutputSizeUsesCropSourceDimensions() {
         let cropSize = CGSize(width: 1725, height: 965)
         let options = VideoExportOptions(


### PR DESCRIPTION
## Summary\n- add direct coverage for VideoCropGeometry.evenSize rounding odd, fractional, and tiny dimensions to positive even sizes\n\n## Tests\n- swift test --package-path apps/macos --filter VideoCropSelectionTests