### PR TITLE
Cover timestamped filename formatting

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -815,8 +815,8 @@ struct HealthPayload: Codable {
     var platform: String
 }
 
-func timestampedFileName(prefix: String, extension fileExtension: String) -> String {
+func timestampedFileName(prefix: String, extension fileExtension: String, date: Date = Date()) -> String {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
-    return "\(prefix)-\(formatter.string(from: Date())).\(fileExtension)"
+    return "\(prefix)-\(formatter.string(from: date)).\(fileExtension)"
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -3,6 +3,17 @@ import XCTest
 
 @MainActor
 final class AppModelStateTests: XCTestCase {
+    func testTimestampedFileNameUsesProvidedDate() {
+        let date = Date(timeIntervalSince1970: 1_767_267_303)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
+
+        XCTAssertEqual(
+            timestampedFileName(prefix: "recording", extension: "mp4", date: date),
+            "recording-\(formatter.string(from: date)).mp4"
+        )
+    }
+
     func testBeginRecordingMovesToSourceTypeChoiceAndRequestsHUD() {
         let model = AppModel()
 


### PR DESCRIPTION
## Summary
- make timestamped filename generation accept an injectable date while preserving the existing default
- add deterministic coverage for timestamped recording filenames

## Tests
- swift test --package-path apps/macos --filter AppModelStateTests/testTimestampedFileNameUsesProvidedDate
- swift test --package-path apps/macos --filter AppModelStateTests