### PR TITLE
Guard cursor overlay scale for empty crops

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CursorOverlayGeometry.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CursorOverlayGeometry.swift
@@ -14,8 +14,13 @@ enum CursorOverlayGeometry {
         }
 
         let standardizedCrop = cropRect.standardized
-        let widthScale = contentRect.width / max(standardizedCrop.width, 1)
-        let heightScale = contentRect.height / max(standardizedCrop.height, 1)
+        guard standardizedCrop.width > 0,
+              standardizedCrop.height > 0 else {
+            return 0
+        }
+
+        let widthScale = contentRect.width / standardizedCrop.width
+        let heightScale = contentRect.height / standardizedCrop.height
         let scale = min(widthScale, heightScale)
         return scale.isFinite ? max(scale, 0) : 0
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/CursorOverlaySettingsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CursorOverlaySettingsTests.swift
@@ -138,6 +138,22 @@ final class CursorOverlaySettingsTests: XCTestCase {
         )
     }
 
+    func testCursorOverlayGeometryTreatsEmptyCropRectAsZeroScale() {
+        let contentRect = CGRect(x: 0, y: 0, width: 960, height: 540)
+        let cropRect = CGRect(x: 0, y: 0, width: 0, height: 540)
+
+        XCTAssertEqual(
+            CursorOverlayGeometry.displayScale(contentRect: contentRect, cropRect: cropRect),
+            0,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            CursorOverlayGeometry.glyphSize(contentRect: contentRect, cropRect: cropRect, settings: .default),
+            1,
+            accuracy: 0.001
+        )
+    }
+
     func testProjectVideoStateDecodesLegacyCursorOverlayDefaults() throws {
         let data = try utf8Data("""
         {


### PR DESCRIPTION
## Summary
- return zero display scale for empty standardized crop rectangles
- cover empty crop behavior for cursor overlay sizing

## Tests
- swift test --filter CursorOverlaySettingsTests