### PR TITLE
Update facecam contribution area

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Areas where help is especially valuable:
 
 - Native Swift editor controls
 - Rust service persistence and export workflows
-- Webcam overlay bubble
+- Facecam overlay controls
 - Localisation support, especially Chinese
 - UI/UX design improvements
 - Export speed improvements


### PR DESCRIPTION
## Summary
- update the contributor guide's stale webcam overlay wording to match the current facecam terminology

## Tests
- make test-macos