### PR TITLE
Guard invalid video crop frame sizing

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -146,6 +146,13 @@ struct VideoCropSelection: Equatable, Hashable, Codable {
 
 enum VideoCropGeometry {
     static func fittedVideoFrame(sourceSize: CGSize, in availableSize: CGSize) -> CGRect {
+        guard availableSize.width.isFinite,
+              availableSize.height.isFinite,
+              availableSize.width > 0,
+              availableSize.height > 0 else {
+            return .zero
+        }
+
         let safeSourceSize = VideoCropSelection.safeSourceSize(sourceSize)
         let fittedSize = PreviewStageLayout.fittedSize(
             forAspectRatio: safeSourceSize.width / safeSourceSize.height,

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -90,6 +90,15 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(roundTrip.height, pixelRect.height, accuracy: 0.001)
     }
 
+    func testFittedVideoFrameReturnsZeroForInvalidAvailableSize() {
+        let frame = VideoCropGeometry.fittedVideoFrame(
+            sourceSize: CGSize(width: 1920, height: 1080),
+            in: CGSize(width: CGFloat.nan, height: 720)
+        )
+
+        XCTAssertEqual(frame, CGRect.zero)
+    }
+
     func testEvenSizeRoundsDownToPositiveEvenDimensions() {
         XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 1001, height: 777)), CGSize(width: 1000, height: 776))
         XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 17.8, height: 12.2)), CGSize(width: 16, height: 12))


### PR DESCRIPTION
## Summary
- Return `.zero` from video crop fitted-frame geometry when the available size is non-finite or non-positive.
- Add a focused regression test for invalid available sizing.

## Tests
- `swift test --filter VideoCropSelectionTests/testFittedVideoFrameReturnsZeroForInvalidAvailableSize`
- `swift test`
