### PR TITLE
Stabilize timestamped filename formatting

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -817,6 +817,8 @@ struct HealthPayload: Codable {
 
 func timestampedFileName(prefix: String, extension fileExtension: String, date: Date = Date()) -> String {
     let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.calendar = Calendar(identifier: .gregorian)
     formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
     return "\(prefix)-\(formatter.string(from: date)).\(fileExtension)"
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -6,6 +6,8 @@ final class AppModelStateTests: XCTestCase {
     func testTimestampedFileNameUsesProvidedDate() {
         let date = Date(timeIntervalSince1970: 1_767_267_303)
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
 
         XCTAssertEqual(


### PR DESCRIPTION
## Summary
- Use a POSIX locale and Gregorian calendar for timestamped filename formatting.
- Update the existing timestamped filename test to verify the fixed formatter assumptions.

## Verification
- swift test --package-path apps/macos --filter AppModelStateTests/testTimestampedFileNameUsesProvidedDate