### PR TITLE
Harden Rust service test lock cleanup

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -61,8 +61,8 @@ private final class LockedBox<Value>: @unchecked Sendable {
 
     func set(_ value: Value) {
         lock.lock()
+        defer { lock.unlock() }
         storage = value
-        lock.unlock()
     }
 
     func get() -> Value? {


### PR DESCRIPTION
## Summary\n- release the Rust service test helper lock with defer in the setter\n\n## Tests\n- swift test --filter RustServiceClientTests