### PR TITLE
Add landing content types

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -3,14 +3,33 @@ import Image from "next/image";
 const docsUrl = "https://docs.openrecorder.xyz/";
 const sourceUrl = "https://github.com/imbhargav5/open-recorder";
 
-const proofPoints = [
+type ProofPoint = readonly [value: string, label: string];
+
+type LandingContentBlock = Readonly<{
+  title: string;
+  eyebrow: string;
+  copy: string;
+}>;
+
+type WorkflowStep = Readonly<{
+  step: string;
+  title: string;
+  copy: string;
+}>;
+
+type ArchitectureNote = Readonly<{
+  label: string;
+  value: string;
+}>;
+
+const proofPoints: readonly ProofPoint[] = [
   ["Native macOS", "Swift capture UI with system privacy flows"],
   ["Local-first", "Recordings and projects stay on your Mac"],
   ["Open source", "Apache 2.0 with a small Swift + Rust stack"],
   ["Editor included", "Zooms, camera clips, cursor overlays, and exports"],
 ];
 
-const featureHighlights = [
+const featureHighlights: readonly LandingContentBlock[] = [
   {
     title: "Capture exactly what matters",
     eyebrow: "Display, window, or region",
@@ -28,7 +47,7 @@ const featureHighlights = [
   },
 ];
 
-const workflow = [
+const workflow: readonly WorkflowStep[] = [
   {
     step: "01",
     title: "Choose the source",
@@ -51,7 +70,7 @@ const workflow = [
   },
 ];
 
-const architectureNotes = [
+const architectureNotes: readonly ArchitectureNote[] = [
   {
     label: "Swift app",
     value: "Capture UI, editor timeline, screenshot composition, Finder integration",


### PR DESCRIPTION
## Summary
- Add explicit readonly types for the landing page's static content arrays.
- Keep the change limited to compile-time type clarity with no behavior or visual changes.

## Verification
- pnpm --dir apps/landing lint
- pnpm --dir apps/landing build