### PR TITLE
Add crop shortcut modifier test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -328,6 +328,7 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 0, modifierFlags: []))
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.option]))
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.control]))
+        XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.command, .control]))
         XCTAssertNil(VideoCropKeyboardAdjustment.make(keyCode: 123, modifierFlags: [.command, .option]))
     }
 }


### PR DESCRIPTION
## Summary
- Add a regression assertion that Command+Control arrow shortcuts are ignored by crop keyboard adjustment handling.

## Tests
- swift test --package-path apps/macos --filter VideoCropSelectionTests/testCropKeyboardShortcutsIgnoreUnsupportedKeysAndModifiers
- swift test --package-path apps/macos --filter VideoCropSelectionTests