### PR TITLE
Cover reversed pixel crop clamping

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -61,6 +61,18 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(selection.normalizedRect.height, 0.4, accuracy: 0.001)
     }
 
+    func testReversedPixelCropStandardizesBeforeClamping() {
+        let rect = VideoCropSelection.clampedPixelRect(
+            CGRect(x: 90, y: 70, width: -30, height: -20),
+            in: CGSize(width: 100, height: 80)
+        )
+
+        XCTAssertEqual(rect.minX, 60, accuracy: 0.001)
+        XCTAssertEqual(rect.minY, 50, accuracy: 0.001)
+        XCTAssertEqual(rect.width, 30, accuracy: 0.001)
+        XCTAssertEqual(rect.height, 20, accuracy: 0.001)
+    }
+
     func testInvalidSourceSizeFallsBackToDefaultCaptureDimensions() {
         let safeSize = VideoCropSelection.safeSourceSize(
             CGSize(width: CGFloat.nan, height: -20)


### PR DESCRIPTION
## Summary
- add a focused VideoCropSelection test for reversed pixel crop rectangles
- verify clamped pixel crop rectangles standardize before bounds clamping

## Tests
- swift test --filter VideoCropSelectionTests
- swift test