### PR TITLE
Improve AppModel wait test diagnostics

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1397,6 +1397,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }
+    XCTAssertTrue(condition(), "Timed out waiting for condition")
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- assert when AppModelStateTests waitForCondition times out
- match the diagnostic behavior used by nearby async test helpers

## Tests
- swift test --filter AppModelStateTests