### PR TITLE
Add crop geometry non-finite frame test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -111,6 +111,17 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(frame, CGRect.zero)
     }
 
+    func testPixelRectFallsBackToFullSourceForNonFiniteVideoFrame() {
+        let sourceSize = CGSize(width: 640, height: 360)
+        let rect = VideoCropGeometry.pixelRect(
+            for: CGRect(x: 10, y: 20, width: 100, height: 80),
+            sourceSize: sourceSize,
+            videoFrame: CGRect(x: 0, y: 0, width: CGFloat.nan, height: 240)
+        )
+
+        XCTAssertEqual(rect, CGRect(origin: .zero, size: sourceSize))
+    }
+
     func testEvenSizeRoundsDownToPositiveEvenDimensions() {
         XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 1001, height: 777)), CGSize(width: 1000, height: 776))
         XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 17.8, height: 12.2)), CGSize(width: 16, height: 12))


### PR DESCRIPTION
## Summary
- add focused coverage for crop geometry fallback when the video frame has a non-finite dimension

## Tests
- swift test --filter VideoCropSelectionTests
- swift test