### PR TITLE
Cover blank window title fallback

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
@@ -78,6 +78,17 @@ final class WindowSourceFilterTests: XCTestCase {
         XCTAssertEqual(displayInfo?.subtitle, "Preview")
     }
 
+    func testUsesOwnerNameWhenTrimmedWindowTitleIsEmpty() {
+        let displayInfo = displayInfo(
+            title: " \n\t ",
+            ownerName: "Preview",
+            bundleIdentifier: "com.apple.Preview"
+        )
+
+        XCTAssertEqual(displayInfo?.name, "Preview")
+        XCTAssertEqual(displayInfo?.subtitle, "Preview")
+    }
+
     func testTrimsWindowTitleAndOwnerNameForDisplay() {
         let displayInfo = displayInfo(
             title: "  Project Notes  \n",


### PR DESCRIPTION
## Summary
- add a WindowSourceFilter regression test for whitespace-only window titles falling back to the owner name

## Tests
- swift test --package-path apps/macos --filter WindowSourceFilterTests
- swift test --package-path apps/macos