### PR TITLE
Cover tiny timeline tick count

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -190,6 +190,13 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertEqual(ticks.map(\.label), ["0:00", "0:10", "0:20", "0:30", "0:40", "0:50", "1:00"])
     }
 
+    func testTimelineTicksClampTooSmallMaxTickCount() {
+        let ticks = TimelineRulerTickBuilder.ticks(duration: 12, maxTickCount: 1)
+
+        XCTAssertEqual(ticks.map(\.time), [0, 10, 12])
+        XCTAssertEqual(ticks.map(\.label), ["0:00", "0:10", "0:12"])
+    }
+
     func testVisibleTicksSanitizeInvalidWindowInputs() {
         let ticks = TimelineRulerTickBuilder.ticks(
             visibleStart: .nan,


### PR DESCRIPTION
## Summary
- Add a unit test covering TimelineRulerTickBuilder when maxTickCount is smaller than the supported floor.

## Tests
- swift test --filter TimelineAudioWaveformTests
- swift test