### PR TITLE
Make screenshot cancel test wait for state

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -539,7 +539,9 @@ final class AppModelStateTests: XCTestCase {
         await waitForCondition {
             didCapture
         }
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await waitForCondition {
+            model.canStartNewCapture
+        }
 
         XCTAssertEqual(model.hudState, .choosingMode)
         XCTAssertEqual(model.statusMessage, "Ready")


### PR DESCRIPTION
## Summary
- replace a fixed sleep in the screenshot cancellation test with the existing state polling helper
- wait for the capture slot to be released before asserting post-cancel state

## Tests
- swift test --filter AppModelStateTests/testCancelingScreenshotDuringCaptureDoesNotOpenEditor
- swift test --filter AppModelStateTests