### PR TITLE
Add Rust service invalid parameter test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -3,6 +3,19 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class RustServiceClientTests: XCTestCase {
+    func testInvalidParametersFailBeforeLaunchingService() {
+        let client = RustServiceClient(executableURL: nil)
+
+        XCTAssertThrowsError(
+            try client.call("listProjects", params: ["value": Double.nan], as: String.self)
+        ) { error in
+            guard case RustServiceError.invalidParameters = error else {
+                XCTFail("Expected invalidParameters, got \(error).")
+                return
+            }
+        }
+    }
+
     func testLargeServiceResponseDoesNotDeadlockWhenStdoutExceedsPipeBuffer() throws {
         let serviceURL = try makeServiceScript(
             name: "large-response-service",


### PR DESCRIPTION
## Summary
- Add a focused RustServiceClient unit test for invalid JSON parameters
- Covers the behavior that parameter validation fails before launching the service executable

## Verification
- swift test --filter RustServiceClientTests