### PR TITLE
Cover invalid clip duration formatting

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -306,6 +306,15 @@ final class TimelineSeekMapperTests: XCTestCase {
     }
 }
 
+final class TimelineClipDurationFormattingTests: XCTestCase {
+    func testClipDurationFormattingSanitizesInvalidDurations() {
+        XCTAssertEqual(formatClipDuration(.nan), "0s")
+        XCTAssertEqual(formatClipDuration(.infinity), "0s")
+        XCTAssertEqual(formatClipDuration(-1), "0s")
+        XCTAssertEqual(formatClipDuration(0.2), "1s")
+    }
+}
+
 final class TimelineViewportTests: XCTestCase {
     func testFullDurationViewportTracksDurationShrink() {
         let viewport = TimelineViewport.reconciled(


### PR DESCRIPTION
## Summary
- add coverage for invalid and sub-second clip duration formatting

## Tests
- swift test --package-path apps/macos --filter TimelineClipDurationFormattingTests
- make test-macos