### PR TITLE
Add native recorder configuration defaults coverage

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
@@ -30,6 +30,8 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.channelCount, 2)
         XCTAssertFalse(configuration.excludesCurrentProcessAudio)
         XCTAssertFalse(configuration.showsCursor)
+        XCTAssertFalse(configuration.showMouseClicks)
+        XCTAssertEqual(configuration.sourceRect, .zero)
     }
 
     func testStreamConfigurationCapturesSelectedMicrophoneWhenEnabled() {


### PR DESCRIPTION
## Summary
- add assertions for default mouse click and source rect configuration values in native recorder tests

## Tests
- swift test --filter NativeScreenRecorderConfigurationTests
- make test-macos