### PR TITLE
Stabilize project date formatting calendar

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
@@ -420,6 +420,7 @@ func formattedProjectDate(_ value: String) -> String {
 
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.calendar = Calendar(identifier: .gregorian)
     formatter.dateFormat = "MMM d, h:mm a"
     return formatter.string(from: date)
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -68,6 +68,7 @@ final class ProjectEditorStateCodableTests: XCTestCase {
         let expectedDate = Date(timeIntervalSince1970: 1_767_225_600)
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "MMM d, h:mm a"
 
         XCTAssertEqual(formattedProjectDate(timestamp), formatter.string(from: expectedDate))
@@ -78,6 +79,7 @@ final class ProjectEditorStateCodableTests: XCTestCase {
         let expectedDate = try XCTUnwrap(ISO8601DateFormatter().date(from: timestamp))
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "MMM d, h:mm a"
 
         XCTAssertEqual(formattedProjectDate(timestamp), formatter.string(from: expectedDate))


### PR DESCRIPTION
## Summary
- Pin project date formatting to the Gregorian calendar alongside the existing POSIX locale
- Update project date tests to expect the same calendar configuration

## Verification
- swift test --filter ProjectEditorStateCodableTests
- make test-macos