### PR TITLE
Tighten release version test parsing

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -28,11 +28,14 @@ final class ReleaseVersionTests: XCTestCase {
         let regex = try NSRegularExpression(pattern: #"(?m)^version\s*=\s*"(\d+\.\d+\.\d+)"\s*$"#)
         let range = NSRange(cargoToml.startIndex..<cargoToml.endIndex, in: cargoToml)
 
-        guard let match = regex.firstMatch(in: cargoToml, range: range),
-              let versionRange = Range(match.range(at: 1), in: cargoToml) else {
-            XCTFail("apps/rust-service/Cargo.toml should declare a semantic version")
-            return ""
-        }
+        let match = try XCTUnwrap(
+            regex.firstMatch(in: cargoToml, range: range),
+            "apps/rust-service/Cargo.toml should declare a semantic version"
+        )
+        let versionRange = try XCTUnwrap(
+            Range(match.range(at: 1), in: cargoToml),
+            "apps/rust-service/Cargo.toml version capture should map to a String range"
+        )
 
         return String(cargoToml[versionRange])
     }


### PR DESCRIPTION
## Summary
- Replace the release version test's sentinel fallback with XCTUnwrap assertions for the Cargo.toml version match and capture range.
- Keep failure reporting focused on the actual parse step when version metadata is missing or malformed.

## Tests
- swift test --package-path apps/macos --filter ReleaseVersionTests
- swift test --package-path apps/macos