### PR TITLE
Reduce async wait flake in macOS tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1391,7 +1391,7 @@ private func makeSource(
 
 @MainActor
 private func waitForCondition(
-    timeout: TimeInterval = 1,
+    timeout: TimeInterval = 2,
     condition: @escaping @MainActor () -> Bool
 ) async {
     let clock = ContinuousClock()

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -230,7 +230,7 @@ private func waitUntilCancelled() async {
 
 @MainActor
 private func waitForCondition(
-    timeout: TimeInterval = 1,
+    timeout: TimeInterval = 2,
     condition: @escaping @MainActor () -> Bool
 ) async {
     let clock = ContinuousClock()


### PR DESCRIPTION
## Summary
- increase duplicated async wait helper defaults from 1s to 2s in macOS state-machine tests
- keep the change test-only to reduce scheduler-related flakes without touching production code

## Verification
- cd apps/macos && swift test