### PR TITLE
Cover format-specific frame rate options

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -258,6 +258,8 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(VideoExportGIFSize.allCases.map(\.title), ["Medium", "Large", "Original"])
         XCTAssertFalse(VideoExportResolution.exportOptions.contains(.source))
         XCTAssertFalse(VideoExportFrameRate.exportOptions.contains(.source))
+        XCTAssertEqual(VideoExportFrameRate.exportOptions(for: .mov), VideoExportFrameRate.exportOptions)
+        XCTAssertEqual(VideoExportFrameRate.exportOptions(for: .gif), VideoExportFrameRate.gifExportOptions)
         XCTAssertEqual(VideoExportFrameRate.defaultExportOption(for: .mov), .fps30)
         XCTAssertEqual(VideoExportFrameRate.defaultExportOption(for: .mp4), .fps30)
         XCTAssertEqual(VideoExportFrameRate.defaultExportOption(for: .gif), .fps15)


### PR DESCRIPTION
## Summary
- add test coverage for format-specific frame-rate option routing
- verify MOV uses movie frame-rate options and GIF uses GIF-specific options

## Tests
- swift test --package-path apps/macos --filter VideoCropSelectionTests