### PR TITLE
Cover playback time formatting

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -5,6 +5,18 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class VideoPreviewLayoutTests: XCTestCase {
+    func testFormatPlaybackTimeHandlesInvalidAndNegativeValues() {
+        XCTAssertEqual(formatPlaybackTime(.nan), "0:00")
+        XCTAssertEqual(formatPlaybackTime(.infinity), "0:00")
+        XCTAssertEqual(formatPlaybackTime(-1), "0:00")
+    }
+
+    func testFormatPlaybackTimeUsesWholeSecondsAndMinutes() {
+        XCTAssertEqual(formatPlaybackTime(9.9), "0:09")
+        XCTAssertEqual(formatPlaybackTime(60), "1:00")
+        XCTAssertEqual(formatPlaybackTime(125.8), "2:05")
+    }
+
     func testVideoCompositorDoesNotCacheStreamingIntermediates() {
         let options = VideoBackgroundCompositor.ciContextOptions()
 


### PR DESCRIPTION
## Summary\n- add focused tests for playback time formatting invalid, negative, and minute rollover inputs\n\n## Tests\n- swift test --filter VideoPreviewLayoutTests\n- swift test