### PR TITLE
Ignore facecam timing without facecam recording

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/RecordingSessionBuilder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingSessionBuilder.swift
@@ -11,7 +11,7 @@ struct RecordingSessionBuilder {
         facecamStartedAt: Date?
     ) -> RecordingSession {
         let offsetMs: Int?
-        if let screenStartedAt, let facecamStartedAt {
+        if facecamURL != nil, let screenStartedAt, let facecamStartedAt {
             offsetMs = Int(facecamStartedAt.timeIntervalSince(screenStartedAt) * 1000)
         } else {
             offsetMs = nil

--- a/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
@@ -94,6 +94,24 @@ final class RecordingSessionBuilderTests: XCTestCase {
         XCTAssertFalse(session.hasRecordedCamera)
     }
 
+    func testBuildRecordingSessionWithoutFacecamIgnoresFacecamTimingMetadata() {
+        let screenURL = URL(fileURLWithPath: "/tmp/screen.mp4")
+
+        let session = RecordingSessionBuilder.build(
+            screenVideoURL: screenURL,
+            facecamURL: nil,
+            sourceName: nil,
+            showCursor: false,
+            cursorTelemetryURL: nil,
+            screenStartedAt: Date(timeIntervalSince1970: 10),
+            facecamStartedAt: Date(timeIntervalSince1970: 11.25)
+        )
+
+        XCTAssertNil(session.facecamVideoPath)
+        XCTAssertNil(session.facecamOffsetMs)
+        XCTAssertFalse(session.hasRecordedCamera)
+    }
+
     func testRecordingSessionHasRecordedCameraRequiresFacecamPath() {
         var session = RecordingSession(
             screenVideoPath: "/tmp/screen.mp4",


### PR DESCRIPTION
## Summary
- only compute facecam offset metadata when a facecam recording exists
- add a regression test for stray facecam timing metadata without a facecam URL

## Tests
- swift test --filter RecordingSessionBuilderTests
- swift test