### PR TITLE
Add explicit ReactNode type import

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en">


### PR DESCRIPTION
## Summary
- import ReactNode explicitly in the landing app root layout
- keep the layout props type independent from the React namespace

## Verification
- pnpm --dir apps/landing lint
- pnpm --dir apps/landing build