### PR TITLE
Cover serializable color alpha coding

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/SerializableColorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/SerializableColorTests.swift
@@ -21,4 +21,14 @@ final class SerializableColorTests: XCTestCase {
 
         XCTAssertEqual(color.hexString, "#0080FF")
     }
+
+    func testCodableRoundTripPreservesAlpha() throws {
+        let color = SerializableColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 0.4)
+
+        let data = try JSONEncoder().encode(color)
+        let decoded = try JSONDecoder().decode(SerializableColor.self, from: data)
+
+        XCTAssertEqual(decoded, color)
+        XCTAssertEqual(decoded.alpha, 0.4)
+    }
 }


### PR DESCRIPTION
## Summary
- add a focused SerializableColor Codable round-trip test for alpha preservation

## Tests
- swift test --filter SerializableColorTests
- swift test