### PR TITLE
Add updater enablement tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XCTest
+@testable import OpenRecorderMac
+
+@MainActor
+final class UpdateCheckerTests: XCTestCase {
+    func testUpdateCheckerIsEnabledForProductionBundleWithHTTPSFeed() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app",
+            feedURLString: "https://openrecorder.dev/appcast.xml"
+        )
+
+        XCTAssertTrue(UpdateChecker.isEnabled(for: bundle))
+    }
+
+    func testUpdateCheckerIsDisabledForNonProductionBundleIdentifier() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.debug",
+            feedURLString: "https://openrecorder.dev/appcast.xml"
+        )
+
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
+    func testUpdateCheckerIsDisabledForNonHTTPSFeed() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app",
+            feedURLString: "http://openrecorder.dev/appcast.xml"
+        )
+
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
+    private func makeBundle(identifier: String, feedURLString: String) throws -> Bundle {
+        let bundleURL = temporaryDirectory()
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathExtension("bundle")
+        let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let infoPlistURL = contentsURL.appendingPathComponent("Info.plist")
+
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+
+        let plist: [String: String] = [
+            "CFBundleIdentifier": identifier,
+            "CFBundlePackageType": "BNDL",
+            "SUFeedURL": feedURLString,
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: infoPlistURL)
+
+        return try XCTUnwrap(Bundle(url: bundleURL))
+    }
+
+    private func temporaryDirectory() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for the Sparkle updater enablement gate
- cover production bundle + HTTPS feed, non-production bundle IDs, and non-HTTPS feeds

## Tests
- swift test --filter UpdateCheckerTests
- pnpm test