### PR TITLE
Clarify plist format typing in tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -43,7 +43,8 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         let url = packageRoot()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
-        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let format: UnsafeMutablePointer<PropertyListSerialization.PropertyListFormat>? = nil
+        let plist = try PropertyListSerialization.propertyList(from: data, format: format)
 
         return try XCTUnwrap(plist as? PlistDictionary, "Resources/Info.plist should be a dictionary")
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -16,7 +16,8 @@ final class ReleaseVersionTests: XCTestCase {
         let url = packageRoot()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
-        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let format: UnsafeMutablePointer<PropertyListSerialization.PropertyListFormat>? = nil
+        let plist = try PropertyListSerialization.propertyList(from: data, format: format)
 
         return try XCTUnwrap(plist as? PlistDictionary, "Resources/Info.plist should be a dictionary")
     }


### PR DESCRIPTION
## Summary
- add explicit plist format pointer typing in macOS plist test helpers

## Tests
- swift test