### PR TITLE
Cover hidden source selector tab sync

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -279,6 +279,14 @@ final class SourceSelectorStateMachineTests: XCTestCase {
         XCTAssertEqual(state.applying(.shareRequested), [.share])
         XCTAssertEqual(state.applying(.drawAreaRequested), [.drawArea])
     }
+
+    func testPreferredSourceKindDoesNotSelectHiddenTab() {
+        var state = SourceSelectorState(sourceTab: .windows, visibleTabs: [.windows, .area])
+
+        XCTAssertEqual(state.applying(.preferredSourceKindSynced(.display)), [])
+
+        XCTAssertEqual(state.sourceTab, .windows)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- add coverage that preferred display-source sync does not switch the floating source selector onto a hidden Screens tab

## Tests
- swift test --package-path apps/macos