### PR TITLE
Improve async wait test timeout diagnostics

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -238,7 +238,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }
-    XCTAssertTrue(condition(), "Timed out waiting for condition")
+    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s")
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Include the configured timeout value in the AppPresentationStateMachineTests async wait helper failure message.

## Tests
- swift test --package-path apps/macos --filter AppShellStateMachineTests