### PR TITLE
Improve AppModel test timeout diagnostics

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1399,7 +1399,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }
-    XCTAssertTrue(condition(), "Timed out waiting for condition")
+    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s")
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- include the timeout duration in the AppModelStateTests wait helper failure message
- keep the diagnostic consistent with the related AppPresentationStateMachineTests helper

## Verification
- swift test --filter AppModelStateTests
- swift test