### PR TITLE
Improve async test timeout diagnostics

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1392,6 +1392,8 @@ private func makeSource(
 @MainActor
 private func waitForCondition(
     timeout: TimeInterval = 2,
+    file: StaticString = #filePath,
+    line: UInt = #line,
     condition: @escaping @MainActor () -> Bool
 ) async {
     let clock = ContinuousClock()
@@ -1399,7 +1401,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }
-    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s")
+    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s", file: file, line: line)
 }
 
 @MainActor

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -231,6 +231,8 @@ private func waitUntilCancelled() async {
 @MainActor
 private func waitForCondition(
     timeout: TimeInterval = 2,
+    file: StaticString = #filePath,
+    line: UInt = #line,
     condition: @escaping @MainActor () -> Bool
 ) async {
     let clock = ContinuousClock()
@@ -238,7 +240,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }
-    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s")
+    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s", file: file, line: line)
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Preserve caller file and line in async waitForCondition test helpers
- Keep timeout failures pointed at the failing test expectation instead of the helper body

## Tests
- swift test --package-path apps/macos --filter 'AppShellStateMachineTests|CaptureDriverStateMachineTests|AppModelStateTests'