### PR TITLE
Improve Rust service timeout diagnostics

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -38,7 +38,7 @@ final class RustServiceClientTests: XCTestCase {
         let waitResult = XCTWaiter.wait(for: [completed], timeout: 10)
         guard waitResult == .completed else {
             terminateServiceScript(at: serviceURL)
-            XCTFail("RustServiceClient deadlocked on a response larger than the stdout pipe buffer.")
+            XCTFail("RustServiceClient did not complete a response larger than the stdout pipe buffer: \(waitResult).")
             return
         }
 


### PR DESCRIPTION
## Summary\n- include the actual XCTWaiter result when the Rust service large-response test times out\n\n## Tests\n- timeout 60 swift test --filter RustServiceClientTests