### PR TITLE
Cover mixed-case zoom preset parsing

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
@@ -110,6 +110,7 @@ final class AutoZoomGeneratorTests: XCTestCase {
     func testStoredZoomAnimationPresetTrimsWhitespace() {
         XCTAssertEqual(TimelineZoomAnimationPreset.storedValue(" snappy\n"), .snappy)
         XCTAssertEqual(TimelineZoomAnimationPreset.storedValue("CINEMATIC"), .cinematic)
+        XCTAssertEqual(TimelineZoomAnimationPreset.storedValue("\tGuIdEd "), .guided)
     }
 
     func testStoredZoomAnimationPresetDefaultsInvalidValuesToBalanced() {


### PR DESCRIPTION
## Summary
- add coverage for mixed-case, whitespace-padded stored zoom preset values

## Tests
- swift test --filter AutoZoomGeneratorTests/testStoredZoomAnimationPresetTrimsWhitespace