### PR TITLE
Add Codable coverage for export option enums

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -81,7 +81,7 @@ enum VideoExportResolution: String, CaseIterable, Identifiable, Codable, Hashabl
     }
 }
 
-enum VideoExportFormat: String, CaseIterable, Identifiable {
+enum VideoExportFormat: String, CaseIterable, Identifiable, Codable, Hashable {
     case mov
     case mp4
     case gif
@@ -217,7 +217,7 @@ enum VideoExportGIFSize: String, CaseIterable, Identifiable, Codable, Hashable {
     }
 }
 
-enum VideoExportFrameRate: String, CaseIterable, Identifiable {
+enum VideoExportFrameRate: String, CaseIterable, Identifiable, Codable, Hashable {
     case source
     case fps15
     case fps20

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -282,6 +282,14 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(VideoExportFrameRate.defaultExportOption(for: .gif), .fps15)
     }
 
+    func testExportFormatAndFrameRateRoundTripThroughCodable() throws {
+        let formatData = try JSONEncoder().encode(VideoExportFormat.mp4)
+        let frameRateData = try JSONEncoder().encode(VideoExportFrameRate.fps60)
+
+        XCTAssertEqual(try JSONDecoder().decode(VideoExportFormat.self, from: formatData), .mp4)
+        XCTAssertEqual(try JSONDecoder().decode(VideoExportFrameRate.self, from: frameRateData), .fps60)
+    }
+
     func testGIFSizeControlsRenderedOutputSize() {
         let sourceSize = CGSize(width: 1920, height: 1080)
         var options = VideoExportOptions.default


### PR DESCRIPTION
## Summary\n- Add Codable and Hashable conformance to VideoExportFormat and VideoExportFrameRate\n- Cover direct Codable round trips for both export option enums\n\n## Tests\n- swift test