### PR TITLE
Add explicit landing icon return type

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import type { ReactElement } from "react";
 
 const docsUrl = "https://docs.openrecorder.xyz/";
 const sourceUrl = "https://github.com/imbhargav5/open-recorder";
@@ -85,7 +86,7 @@ const architectureNotes: readonly ArchitectureNote[] = [
   },
 ];
 
-function GitHubIcon() {
+function GitHubIcon(): ReactElement {
   return (
     <svg
       aria-hidden="true"


### PR DESCRIPTION
## Summary\n- add an explicit ReactElement return type to the landing page GitHub icon component\n\n## Verification\n- pnpm --dir apps/landing lint\n- pnpm --dir apps/landing build