### PR TITLE
Cover combined native recorder audio capture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
@@ -81,7 +81,7 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.sourceRect, CGRect(x: 20, y: 30, width: 640, height: 360))
     }
 
-    func testStreamConfigurationCapturesMicrophoneWhenEnabled() {
+    func testStreamConfigurationCapturesSystemAudioAndMicrophoneTogether() {
         let configuration = NativeScreenRecorder.makeStreamConfiguration(
             width: 1280,
             height: 720,
@@ -89,7 +89,7 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
             options: RecordingCaptureOptions(
                 includeMicrophone: true,
                 microphoneDeviceID: "built-in-microphone",
-                includeSystemAudio: false,
+                includeSystemAudio: true,
                 includeCamera: false,
                 cameraDeviceID: nil,
                 showCursor: false,
@@ -97,6 +97,7 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
             )
         )
 
+        XCTAssertTrue(configuration.capturesAudio)
         XCTAssertTrue(configuration.captureMicrophone)
         XCTAssertEqual(configuration.microphoneCaptureDeviceID, "built-in-microphone")
     }


### PR DESCRIPTION
## Summary
- replace redundant native recorder microphone-only coverage with combined system audio + microphone coverage
- assert both ScreenCaptureKit audio flags stay enabled together

## Verification
- swift test --package-path apps/macos --filter NativeScreenRecorderConfigurationTests