### PR TITLE
Test uppercase update feed schemes

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -13,6 +13,15 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertTrue(UpdateChecker.isEnabled(for: bundle))
     }
 
+    func testUpdateCheckerAcceptsUppercaseHTTPSFeedScheme() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app",
+            feedURLString: "HTTPS://openrecorder.dev/appcast.xml"
+        )
+
+        XCTAssertTrue(UpdateChecker.isEnabled(for: bundle))
+    }
+
     func testUpdateCheckerIsDisabledForNonProductionBundleIdentifier() throws {
         let bundle = try makeBundle(
             identifier: "dev.openrecorder.debug",


### PR DESCRIPTION
## Summary
- add UpdateChecker coverage for uppercase HTTPS feed URL schemes

## Tests
- swift test --filter UpdateCheckerTests
- make test-macos