### PR TITLE
Simplify plist test helpers

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -43,8 +43,7 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         let url = packageRoot()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
-        let format: UnsafeMutablePointer<PropertyListSerialization.PropertyListFormat>? = nil
-        let plist = try PropertyListSerialization.propertyList(from: data, format: format)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
 
         return try XCTUnwrap(plist as? PlistDictionary, "Resources/Info.plist should be a dictionary")
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -16,8 +16,7 @@ final class ReleaseVersionTests: XCTestCase {
         let url = packageRoot()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
-        let format: UnsafeMutablePointer<PropertyListSerialization.PropertyListFormat>? = nil
-        let plist = try PropertyListSerialization.propertyList(from: data, format: format)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
 
         return try XCTUnwrap(plist as? PlistDictionary, "Resources/Info.plist should be a dictionary")
     }


### PR DESCRIPTION
## Summary
- simplify Info.plist test helpers by passing a nil format directly
- remove unnecessary typed format pointer boilerplate from metadata tests

## Tests
- swift test --filter 'PrivacyUsageDescriptionTests|ReleaseVersionTests'