### PR TITLE
Add explicit landing page return type

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -101,7 +101,7 @@ function GitHubIcon(): ReactElement {
   );
 }
 
-export default function Home() {
+export default function Home(): ReactElement {
   return (
     <main>
       <nav className="top-nav" aria-label="Primary navigation">


### PR DESCRIPTION
## Summary
- Add an explicit ReactElement return type to the landing page component for consistency with the local component typing.

## Verification
- pnpm --dir apps/landing lint
- pnpm --dir apps/landing build