### PR TITLE
Add explicit HUD size state type

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/ContentView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ContentView.swift
@@ -15,7 +15,7 @@ enum AppWindowRole {
 
 struct ContentView: View {
     @EnvironmentObject private var model: AppModel
-    @State private var measuredHUDSize = HUDWindowMetrics.defaultSize
+    @State private var measuredHUDSize: CGSize = HUDWindowMetrics.defaultSize
     var role: AppWindowRole = .studio
     var editorSession: EditorSession?
 


### PR DESCRIPTION
## Summary
- add an explicit CGSize annotation for the HUD measured size state

## Tests
- cd apps/macos && swift test