### PR TITLE
Add explicit native window command ID type

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -804,7 +804,7 @@ enum NativeWindowCommandAction: Equatable {
 }
 
 struct NativeWindowCommand: Identifiable {
-    var id = UUID()
+    var id: UUID = UUID()
     var action: NativeWindowCommandAction
     var editorSession: EditorSession?
 }


### PR DESCRIPTION
## Summary
- Add an explicit UUID type annotation to NativeWindowCommand.id

## Verification
- swift test