### PR TITLE
Add Rust service missing executable test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -16,6 +16,20 @@ final class RustServiceClientTests: XCTestCase {
         }
     }
 
+    func testMissingExecutableFailsBeforeDecodingRawParameters() {
+        let client = RustServiceClient(executableURL: nil)
+        let invalidUTF8 = Data([0xFF])
+
+        XCTAssertThrowsError(
+            try client.call("listProjects", paramsData: invalidUTF8, as: String.self)
+        ) { error in
+            guard case RustServiceError.missingExecutable = error else {
+                XCTFail("Expected missingExecutable, got \(error).")
+                return
+            }
+        }
+    }
+
     func testLargeServiceResponseDoesNotDeadlockWhenStdoutExceedsPipeBuffer() throws {
         let serviceURL = try makeServiceScript(
             name: "large-response-service",


### PR DESCRIPTION
## Summary
- add coverage for RustServiceClient's raw-parameter call path when the service executable is unavailable

## Tests
- swift test --filter RustServiceClientTests
- make test-macos