### PR TITLE
Test project document handler rank

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -31,6 +31,7 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         XCTAssertEqual(documentType["CFBundleTypeExtensions"] as? [String], ["openrecorder"])
         XCTAssertEqual(documentType["CFBundleTypeName"] as? String, "Open Recorder Project")
         XCTAssertEqual(documentType["CFBundleTypeRole"] as? String, "Editor")
+        XCTAssertEqual(documentType["LSHandlerRank"] as? String, "Owner")
         XCTAssertEqual(documentType["LSItemContentTypes"] as? [String], ["dev.openrecorder.project"])
         XCTAssertEqual(exportedType["UTTypeIdentifier"] as? String, "dev.openrecorder.project")
         XCTAssertEqual(


### PR DESCRIPTION
## Summary
- assert the Open Recorder project document type keeps LSHandlerRank set to Owner

## Tests
- swift test --filter PrivacyUsageDescriptionTests