### PR TITLE
Cover unchanged settings preferences

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -323,8 +323,10 @@ final class OnboardingAndSettingsStateMachineTests: XCTestCase {
 
         XCTAssertEqual(state.applying(.autoZoomPreferenceChanged(true)), [.persistAutoZoomPreference(true)])
         XCTAssertTrue(state.createZoomsAutomatically)
+        XCTAssertEqual(state.applying(.autoZoomPreferenceChanged(true)), [])
         XCTAssertEqual(state.applying(.autoZoomAnimationPresetChanged(.cinematic)), [.persistAutoZoomAnimationPreset(.cinematic)])
         XCTAssertEqual(state.autoZoomAnimationPreset, .cinematic)
+        XCTAssertEqual(state.applying(.autoZoomAnimationPresetChanged(.cinematic)), [])
         XCTAssertEqual(state.applying(.autoZoomAnimationPresetSynced(.guided)), [])
         XCTAssertEqual(state.autoZoomAnimationPreset, .guided)
         XCTAssertEqual(state.applying(.folderOpenRequested("/tmp")), [.openFolder("/tmp")])


### PR DESCRIPTION
## Summary
- Add assertions that repeated auto-zoom preference and animation preset selections are reducer no-ops.

## Tests
- swift test --filter OnboardingAndSettingsStateMachineTests/testSettingsPreferenceAndFolderEffects
- make test-macos