### PR TITLE
Fix contributing clone command indentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Areas where help is especially valuable:
 2. **Clone Your Fork**
    - Clone your forked repository to your local machine:
      ```bash
-   git clone https://github.com/your-username/open-recorder.git
+     git clone https://github.com/your-username/open-recorder.git
      ```
 
 3. **Create a New Branch**


### PR DESCRIPTION
## Summary
- Fix indentation for the clone command in the contributing guide so the fenced bash example renders consistently inside the numbered list.

## Verification
- git diff --check