### PR TITLE
Cover trimmed recorder metadata exclusion

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/OpenRecorderCaptureExclusionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/OpenRecorderCaptureExclusionTests.swift
@@ -39,6 +39,16 @@ final class OpenRecorderCaptureExclusionTests: XCTestCase {
         ))
     }
 
+    func testExcludesOpenRecorderApplicationsAfterTrimmingMetadata() {
+        XCTAssertTrue(OpenRecorderCaptureExclusion.shouldExcludeApplication(
+            bundleIdentifier: "  dev.openrecorder.app.dev\n",
+            applicationName: "  Open Recorder Dev  ",
+            processID: 100,
+            currentProcessID: 200,
+            currentBundleIdentifier: "dev.openrecorder.app.dev"
+        ))
+    }
+
     func testAllowsUnrelatedApplications() {
         XCTAssertFalse(OpenRecorderCaptureExclusion.shouldExcludeApplication(
             bundleIdentifier: "com.example.editor",


### PR DESCRIPTION
## Summary\n- add coverage that Open Recorder capture exclusion trims bundle and app metadata before matching\n\n## Tests\n- swift test --package-path apps/macos --filter OpenRecorderCaptureExclusionTests