### PR TITLE
Test exported project type conformance

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -34,6 +34,7 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         XCTAssertEqual(documentType["LSHandlerRank"] as? String, "Owner")
         XCTAssertEqual(documentType["LSItemContentTypes"] as? [String], ["dev.openrecorder.project"])
         XCTAssertEqual(exportedType["UTTypeIdentifier"] as? String, "dev.openrecorder.project")
+        XCTAssertEqual(exportedType["UTTypeConformsTo"] as? [String], ["public.json"])
         XCTAssertEqual(
             exportedType["UTTypeTagSpecification"] as? [String: [String]],
             ["public.filename-extension": ["openrecorder"]]


### PR DESCRIPTION
## Summary\n- Assert that the exported Open Recorder project UTI conforms to public.json.\n\n## Tests\n- swift test --filter PrivacyUsageDescriptionTests