### PR TITLE
Test exported project type description

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -34,6 +34,7 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         XCTAssertEqual(documentType["LSHandlerRank"] as? String, "Owner")
         XCTAssertEqual(documentType["LSItemContentTypes"] as? [String], ["dev.openrecorder.project"])
         XCTAssertEqual(exportedType["UTTypeIdentifier"] as? String, "dev.openrecorder.project")
+        XCTAssertEqual(exportedType["UTTypeDescription"] as? String, "Open Recorder Project")
         XCTAssertEqual(exportedType["UTTypeConformsTo"] as? [String], ["public.json"])
         XCTAssertEqual(
             exportedType["UTTypeTagSpecification"] as? [String: [String]],


### PR DESCRIPTION
## Summary
- Add coverage that the exported Open Recorder project UTI declares the expected display description.

## Verification
- swift test --filter PrivacyUsageDescriptionTests
- swift test