### PR TITLE
Test project summary media path selection

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import OpenRecorderMac
+
+final class ProjectSummaryTests: XCTestCase {
+    func testMediaPathUsesScreenshotPathWhenAvailable() {
+        let summary = makeProjectSummary(recordingPath: "/tmp/recording.mp4", screenshotPath: "/tmp/screenshot.png")
+
+        XCTAssertEqual(summary.mediaKind, .screenshot)
+        XCTAssertEqual(summary.mediaPath, "/tmp/screenshot.png")
+    }
+
+    func testMediaPathFallsBackToRecordingPath() {
+        let summary = makeProjectSummary(recordingPath: "/tmp/recording.mp4", screenshotPath: nil)
+
+        XCTAssertEqual(summary.mediaKind, .video)
+        XCTAssertEqual(summary.mediaPath, "/tmp/recording.mp4")
+    }
+}
+
+private func makeProjectSummary(recordingPath: String?, screenshotPath: String?) -> ProjectSummary {
+    ProjectSummary(
+        id: "project-1",
+        title: "Project",
+        path: "/tmp/project.openrecorder",
+        recordingPath: recordingPath,
+        screenshotPath: screenshotPath,
+        sourceName: "Display 1",
+        createdAt: "2026-06-26T00:00:00Z",
+        updatedAt: "2026-06-26T00:00:00Z",
+        lastOpenedAt: "2026-06-26T00:00:00Z",
+        missing: false
+    )
+}


### PR DESCRIPTION
## Summary
- add focused coverage for ProjectSummary media kind/path selection
- verify screenshot summaries prefer screenshotPath and video summaries fall back to recordingPath

## Tests
- swift test