### PR TITLE
Test missing update feed URL

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -49,7 +49,16 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
     }
 
-    private func makeBundle(identifier: String, feedURLString: String) throws -> Bundle {
+    func testUpdateCheckerIsDisabledWithoutFeedURL() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app",
+            feedURLString: nil
+        )
+
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
+    private func makeBundle(identifier: String, feedURLString: String?) throws -> Bundle {
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenRecorderMacTests-\(UUID().uuidString)", isDirectory: true)
             .appendingPathExtension("bundle")
@@ -61,11 +70,11 @@ final class UpdateCheckerTests: XCTestCase {
             try? FileManager.default.removeItem(at: bundleURL)
         }
 
-        let plist: [String: String] = [
+        var plist: [String: String] = [
             "CFBundleIdentifier": identifier,
             "CFBundlePackageType": "BNDL",
-            "SUFeedURL": feedURLString,
         ]
+        plist["SUFeedURL"] = feedURLString
         let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
         try data.write(to: infoPlistURL)
 


### PR DESCRIPTION
## Summary
- add coverage that the update checker stays disabled when the production bundle has no SUFeedURL
- make the test bundle helper support omitting the feed URL key

## Tests
- swift test --filter UpdateCheckerTests