### PR TITLE
Test update checker without bundle identifier

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -31,6 +31,15 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
     }
 
+    func testUpdateCheckerIsDisabledWithoutBundleIdentifier() throws {
+        let bundle = try makeBundle(
+            identifier: nil,
+            feedURLString: "https://openrecorder.dev/appcast.xml"
+        )
+
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
     func testUpdateCheckerIsDisabledForNonHTTPSFeed() throws {
         let bundle = try makeBundle(
             identifier: "dev.openrecorder.app",
@@ -58,7 +67,7 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
     }
 
-    private func makeBundle(identifier: String, feedURLString: String?) throws -> Bundle {
+    private func makeBundle(identifier: String?, feedURLString: String?) throws -> Bundle {
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenRecorderMacTests-\(UUID().uuidString)", isDirectory: true)
             .appendingPathExtension("bundle")
@@ -71,9 +80,9 @@ final class UpdateCheckerTests: XCTestCase {
         }
 
         var plist: [String: String] = [
-            "CFBundleIdentifier": identifier,
             "CFBundlePackageType": "BNDL",
         ]
+        plist["CFBundleIdentifier"] = identifier
         plist["SUFeedURL"] = feedURLString
         let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
         try data.write(to: infoPlistURL)


### PR DESCRIPTION
## Summary
- add UpdateChecker coverage for bundles missing CFBundleIdentifier
- allow the test bundle helper to omit the identifier key

## Tests
- swift test --filter UpdateCheckerTests
- make test-macos