### PR TITLE
Add crop passthrough test coverage

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -85,6 +85,18 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(decoded, selection)
     }
 
+    func testPassthroughRequiresFullFrameSourceSizing() {
+        XCTAssertTrue(VideoCropSelection.fullFrame.isPassthrough)
+        XCTAssertFalse(VideoCropSelection.fullFrame.withSizing(.preset(.p1080)).isPassthrough)
+
+        let croppedSelection = VideoCropSelection(
+            normalizedRect: CGRect(x: 0.1, y: 0.1, width: 0.8, height: 0.8),
+            sizing: .preset(.source)
+        )
+
+        XCTAssertFalse(croppedSelection.isPassthrough)
+    }
+
     func testCropSizingCustomSizeOnlyReflectsCustomDimensions() {
         XCTAssertNil(VideoCropSizing.preset(.p1080).customSize)
         XCTAssertEqual(VideoCropSizing.custom(width: 1001, height: 777).customSize, CGSize(width: 1001, height: 777))


### PR DESCRIPTION
## Summary\n- add a focused unit test for crop passthrough requirements\n- verify passthrough only applies to full-frame source-sized selections\n\n## Tests\n- swift test --package-path apps/macos --filter VideoCropSelectionTests