### PR TITLE
Cover project document media kind fallbacks

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
@@ -23,6 +23,18 @@ final class ProjectDocumentMediaKindTests: XCTestCase {
 
         XCTAssertEqual(document.mediaKind, .screenshot)
     }
+
+    func testMediaKindFallsBackToVideoWhenOnlyRecordingPathExists() {
+        let document = makeProjectDocument(recordingPath: "/tmp/recording.mp4", screenshotPath: nil)
+
+        XCTAssertEqual(document.mediaKind, .video)
+    }
+
+    func testMediaKindIsNilWhenNoMediaPathExists() {
+        let document = makeProjectDocument(recordingPath: nil, screenshotPath: nil)
+
+        XCTAssertNil(document.mediaKind)
+    }
 }
 
 private func makeProjectSummary(recordingPath: String?, screenshotPath: String?) -> ProjectSummary {


### PR DESCRIPTION
## Summary
- add coverage for ProjectDocument mediaKind video fallback
- add coverage for nil mediaKind when no media path exists

## Tests
- swift test --package-path apps/macos --filter ProjectDocumentMediaKindTests
- swift test --package-path apps/macos