### PR TITLE
Cover empty project summary media path

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
@@ -15,6 +15,13 @@ final class ProjectSummaryTests: XCTestCase {
         XCTAssertEqual(summary.mediaKind, .video)
         XCTAssertEqual(summary.mediaPath, "/tmp/recording.mp4")
     }
+
+    func testMediaPathIsNilWhenNoMediaPathExists() {
+        let summary = makeProjectSummary(recordingPath: nil, screenshotPath: nil)
+
+        XCTAssertEqual(summary.mediaKind, .video)
+        XCTAssertNil(summary.mediaPath)
+    }
 }
 
 final class ProjectDocumentMediaKindTests: XCTestCase {


### PR DESCRIPTION
## Summary\n- Add coverage for ProjectSummary when neither recordingPath nor screenshotPath is present\n- Assert the current fallback media kind and nil media path behavior\n\n## Verification\n- swift test --package-path apps/macos --filter ProjectSummaryTests