### PR TITLE
Add landing layout return type

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -12,7 +12,7 @@ export default function RootLayout({
   children,
 }: Readonly<{
   children: ReactNode;
-}>) {
+}>): ReactElement {
   return (
     <html lang="en">
       <body>{children}</body>


### PR DESCRIPTION
## Summary
- Add an explicit ReactElement return type to the landing RootLayout component.

## Verification
- PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --dir apps/landing lint
- ./node_modules/.bin/eslint src/app/layout.tsx