### PR TITLE
Name plist tag specification type in tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class PrivacyUsageDescriptionTests: XCTestCase {
     private typealias PlistDictionary = [String: Any]
+    private typealias TypeTagSpecification = [String: [String]]
 
     func testInfoPlistDeclaresCameraAndMicrophoneUsageDescriptions() throws {
         let plist = try loadInfoPlist()
@@ -39,7 +40,7 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         XCTAssertEqual(exportedType["UTTypeDescription"] as? String, "Open Recorder Project")
         XCTAssertEqual(exportedType["UTTypeConformsTo"] as? [String], ["public.json"])
         XCTAssertEqual(
-            exportedType["UTTypeTagSpecification"] as? [String: [String]],
+            exportedType["UTTypeTagSpecification"] as? TypeTagSpecification,
             ["public.filename-extension": ["openrecorder"]]
         )
     }


### PR DESCRIPTION
## Summary
- Name the nested Info.plist UTType tag specification shape in privacy usage tests.
- Keep the assertion behavior unchanged while making the cast easier to read.

## Verification
- swift test --filter PrivacyUsageDescriptionTests
- make test-macos
