### PR TITLE
Cover editor history transaction cancellation

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/EditorHistoryTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorHistoryTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import OpenRecorderMac
+
+final class EditorHistoryTests: XCTestCase {
+    func testCancelTransactionLeavesRedoStackAvailable() {
+        var history = EditorHistory<Int>()
+
+        history.recordChange(from: 0, to: 1)
+        XCTAssertEqual(history.undo(current: 1), 0)
+        XCTAssertTrue(history.canRedo)
+
+        history.beginTransaction(current: 0)
+        history.cancelTransaction()
+
+        XCTAssertFalse(history.isInTransaction)
+        XCTAssertEqual(history.redo(current: 0), 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add focused EditorHistory coverage for canceling a transaction after undo
- assert redo remains available while transaction state clears

## Tests
- swift test --filter EditorHistoryTests