### PR TITLE
Name update checker plist fixture type

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 @MainActor
 final class UpdateCheckerTests: XCTestCase {
+    private typealias InfoPlistFixture = [String: String]
+
     func testUpdateCheckerIsEnabledForProductionBundleWithHTTPSFeed() throws {
         let bundle = try makeBundle(
             identifier: "dev.openrecorder.app",
@@ -79,7 +81,7 @@ final class UpdateCheckerTests: XCTestCase {
             try? FileManager.default.removeItem(at: bundleURL)
         }
 
-        var plist: [String: String] = [
+        var plist: InfoPlistFixture = [
             "CFBundlePackageType": "BNDL",
         ]
         plist["CFBundleIdentifier"] = identifier


### PR DESCRIPTION
## Summary
- add a local InfoPlistFixture alias for the update checker test bundle fixture

## Tests
- cd apps/macos && swift test