### PR TITLE
Type plist format in macOS tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -49,7 +49,8 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         let url = packageRoot()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
-        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        let plist = try PropertyListSerialization.propertyList(from: data, format: &format)
 
         return try XCTUnwrap(plist as? PlistDictionary, "Resources/Info.plist should be a dictionary")
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -16,7 +16,8 @@ final class ReleaseVersionTests: XCTestCase {
         let url = packageRoot()
             .appendingPathComponent("Resources/Info.plist")
         let data = try Data(contentsOf: url)
-        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        let plist = try PropertyListSerialization.propertyList(from: data, format: &format)
 
         return try XCTUnwrap(plist as? PlistDictionary, "Resources/Info.plist should be a dictionary")
     }


### PR DESCRIPTION
## Summary
- make plist parsing helpers use an explicit PropertyListFormat out parameter
- keep Info.plist test behavior unchanged while avoiding an untyped nil argument

## Tests
- swift test --package-path apps/macos --filter 'PrivacyUsageDescriptionTests|ReleaseVersionTests'