### PR TITLE
Type screenshot orientation fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class ScreenshotExportRendererTests: XCTestCase {
-    private let orientationProbeRows = ["RGB", "CYM"]
+    private let orientationProbeRows: [String] = ["RGB", "CYM"]
 
     func testSuggestedFileNameUsesScreenshotBaseName() {
         let url = URL(fileURLWithPath: "/tmp/open-recorder/screen-shot.png")


### PR DESCRIPTION
## Summary
- adds an explicit `[String]` type to the screenshot orientation probe fixture

## Tests
- `swift test --package-path apps/macos --filter ScreenshotExportRendererTests`
- `swift test --package-path apps/macos`