### PR TITLE
Add editor shortcut list type

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
@@ -437,7 +437,7 @@ struct StudioTitleBar: View {
 struct EditorShortcutsHelpDialog: View {
     @Binding var isPresented: Bool
 
-    private let shortcuts = [
+    private let shortcuts: [EditorShortcutHelpItem] = [
         EditorShortcutHelpItem(keys: "Space", action: "Play or pause preview"),
         EditorShortcutHelpItem(keys: "Z", action: "Add zoom section at playhead"),
         EditorShortcutHelpItem(keys: "S", action: "Cycle selected clip speed"),


### PR DESCRIPTION
## Summary
- add an explicit EditorShortcutHelpItem array type to the editor shortcuts help dialog

## Tests
- swift test