### PR TITLE
Type HUD idle state fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
@@ -4,7 +4,9 @@ import XCTest
 @MainActor
 final class HUDStateMachineTests: XCTestCase {
     func testIdleAndChoosingModeDoNotOccupyCaptureSlot() {
-        for state in [HUDState.idle, .choosingMode] {
+        let states: [HUDState] = [.idle, .choosingMode]
+
+        for state in states {
             XCTAssertNil(state.mode)
             XCTAssertNil(state.source)
             XCTAssertFalse(state.isCaptureOccupied)


### PR DESCRIPTION
## Summary
- Add an explicit HUDState fixture type in the idle/choosing-mode state-machine test.

## Tests
- swift test --filter HUDStateMachineTests
- make test-macos