### PR TITLE
Use Duration in async test helpers

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1391,13 +1391,13 @@ private func makeSource(
 
 @MainActor
 private func waitForCondition(
-    timeout: TimeInterval = 2,
+    timeout: Duration = .seconds(2),
     file: StaticString = #filePath,
     line: UInt = #line,
     condition: @escaping @MainActor () -> Bool
 ) async {
     let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: .milliseconds(Int(timeout * 1_000)))
+    let deadline = clock.now.advanced(by: timeout)
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -238,13 +238,13 @@ private func waitUntilCancelled() async {
 
 @MainActor
 private func waitForCondition(
-    timeout: TimeInterval = 2,
+    timeout: Duration = .seconds(2),
     file: StaticString = #filePath,
     line: UInt = #line,
     condition: @escaping @MainActor () -> Bool
 ) async {
     let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: .milliseconds(Int(timeout * 1_000)))
+    let deadline = clock.now.advanced(by: timeout)
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(10))
     }


### PR DESCRIPTION
## Summary
- use Swift Duration directly in async wait helpers in AppModel and presentation tests
- avoid TimeInterval-to-milliseconds conversion when computing test deadlines

## Tests
- swift test