### PR TITLE
Include half-second tick at visible boundary

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineAudioWaveform.swift
@@ -85,7 +85,7 @@ enum TimelineRulerTickBuilder {
         var time = (safeVisibleStart - 0.5).rounded(.up) + 0.5
 
         while time < visibleEnd - 0.0001 {
-            if time >= safeVisibleStart + 0.0001 {
+            if time >= safeVisibleStart - 0.0001 {
                 ticks.append(TimelineRulerTick(time: time, label: ""))
             }
             time += 1

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -172,6 +172,17 @@ final class TimelineAudioWaveformTests: XCTestCase {
         XCTAssertEqual(ticks.map(\.label), ["", "", ""])
     }
 
+    func testVisibleHalfSecondTicksIncludeLeftBoundary() {
+        let ticks = TimelineRulerTickBuilder.halfSecondTicks(
+            visibleStart: 0.5,
+            visibleDuration: 2,
+            totalDuration: 10
+        )
+
+        XCTAssertEqual(ticks.map(\.time), [0.5, 1.5])
+        XCTAssertEqual(ticks.map(\.label), ["", ""])
+    }
+
     func testVisibleHalfSecondTicksSanitizeInvalidWindowInputs() {
         let ticks = TimelineRulerTickBuilder.halfSecondTicks(
             visibleStart: .nan,


### PR DESCRIPTION
## Summary
- include visible half-second timeline ticks that land exactly on the left boundary
- add a regression test for the boundary case

## Verification
- swift test --filter TimelineAudioWaveformTests