### PR TITLE
Type recording session JSON test fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -80,7 +80,7 @@ final class ProjectAutosaveCoordinatorTests: XCTestCase {
 
 final class ProjectEditorStateCodableTests: XCTestCase {
     private typealias JSONDictionary = [String: Any]
-    private typealias RecordingSessionJSON = JSONDictionary
+    private typealias RecordingSessionJSON = [String: Any]
 
     func testFormattedProjectDateUsesStableMonthLabelsForEpochStrings() {
         let timestamp = "1767225600"


### PR DESCRIPTION
## Summary
- Give the recording session JSON assertion in ProjectAutosaveTests an explicit dictionary type alias.

## Tests
- swift test --filter ProjectEditorStateCodableTests