### PR TITLE
Clarify SwiftPM tools version comment

### DIFF
--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -1,5 +1,5 @@
 // swift-tools-version: 6.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// The swift-tools-version declares the SwiftPM tools version used to interpret this manifest.
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary
- Clarify the macOS package manifest comment for `swift-tools-version` so it describes SwiftPM manifest interpretation instead of the app build requirement.

## Tests
- `swift test` from `apps/macos` (445 tests, 0 failures)