### PR TITLE
Type release version regex fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ReleaseVersionTests.swift
@@ -26,7 +26,9 @@ final class ReleaseVersionTests: XCTestCase {
         let cargoTomlURL = packageRoot()
             .appendingPathComponent("../rust-service/Cargo.toml")
         let cargoToml = try String(contentsOf: cargoTomlURL, encoding: .utf8)
-        let regex = try NSRegularExpression(pattern: #"(?m)^version\s*=\s*"(\d+\.\d+\.\d+)"\s*$"#)
+        let regex: NSRegularExpression = try NSRegularExpression(
+            pattern: #"(?m)^version\s*=\s*"(\d+\.\d+\.\d+)"\s*$"#
+        )
         let range: NSRange = NSRange(cargoToml.startIndex..<cargoToml.endIndex, in: cargoToml)
 
         let match = try XCTUnwrap(


### PR DESCRIPTION
## Summary
- add an explicit NSRegularExpression type to the release version test helper

## Tests
- swift test --filter ReleaseVersionTests