### PR TITLE
Type waveform renderer test samples

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineAudioWaveformTests.swift
@@ -16,7 +16,7 @@ final class TimelineAudioWaveformTests: XCTestCase {
     }
 
     func testWaveformBarRendererPreservesPeakWhenResampling() {
-        var samples = Array(repeating: 0.1, count: 60)
+        var samples = Array(repeating: Double(0.1), count: 60)
         samples[28] = 0.95
 
         let bars = TimelineWaveformBarRenderer.resampledLevels(from: samples, width: 60)


### PR DESCRIPTION
## Summary
- Type the waveform renderer resampling fixture as Double to match the renderer API directly.

## Tests
- swift test --package-path apps/macos