### PR TITLE
Clarify cursor overlay recorder configuration

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -90,6 +90,7 @@ final class NativeScreenRecorder: NSObject {
         configuration.height = height
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 60)
         configuration.queueDepth = 8
+        // Cursor visibility is handled by the editor/export overlay path so telemetry stays editable.
         configuration.showsCursor = false
         configuration.capturesAudio = options.includeSystemAudio
         configuration.sampleRate = 48_000


### PR DESCRIPTION
## Summary
- Clarify why ScreenCaptureKit cursor capture remains disabled in the native recorder configuration
- Document that cursor visibility is handled by the editor/export overlay path so telemetry stays editable

## Tests
- swift test --filter NativeScreenRecorderConfigurationTests