### PR TITLE
Clarify plist type tag assertion

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/PrivacyUsageDescriptionTests.swift
@@ -39,11 +39,11 @@ final class PrivacyUsageDescriptionTests: XCTestCase {
         XCTAssertEqual(exportedType["UTTypeIdentifier"] as? String, "dev.openrecorder.project")
         XCTAssertEqual(exportedType["UTTypeDescription"] as? String, "Open Recorder Project")
         XCTAssertEqual(exportedType["UTTypeConformsTo"] as? [String], ["public.json"])
-        let expectedTypeTagSpecification: TypeTagSpecification = ["public.filename-extension": ["openrecorder"]]
-        XCTAssertEqual(
-            exportedType["UTTypeTagSpecification"] as? TypeTagSpecification,
-            expectedTypeTagSpecification
-        )
+        let actualTypeTagSpecification = exportedType["UTTypeTagSpecification"] as? TypeTagSpecification
+        let expectedTypeTagSpecification: TypeTagSpecification = [
+            "public.filename-extension": ["openrecorder"]
+        ]
+        XCTAssertEqual(actualTypeTagSpecification, expectedTypeTagSpecification)
     }
 
     private func loadInfoPlist() throws -> PlistDictionary {


### PR DESCRIPTION
## Summary
- split the exported UTType tag specification cast into an explicitly typed local before assertion
- keep the expected Info.plist document type fixture typed as TypeTagSpecification

## Tests
- swift test --package-path apps/macos --filter PrivacyUsageDescriptionTests
