### PR TITLE
Cover empty update feed URL

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -60,6 +60,15 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
     }
 
+    func testUpdateCheckerIsDisabledForEmptyFeedURL() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app",
+            feedURLString: ""
+        )
+
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
     func testUpdateCheckerIsDisabledWithoutFeedURL() throws {
         let bundle = try makeBundle(
             identifier: "dev.openrecorder.app",


### PR DESCRIPTION
## Summary
- add test coverage that disables the production update checker when SUFeedURL is empty

## Tests
- swift test --filter UpdateCheckerTests
- make test-macos