### PR TITLE
Type HUD visible frame fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
@@ -39,9 +39,10 @@ final class HUDWindowMetricsTests: XCTestCase {
 
     func testMeasuredWidthClampsToVisibleFrameMargin() {
         let visibleWidth: CGFloat = 800
+        let visibleFrame: CGRect = CGRect(x: 0, y: 0, width: visibleWidth, height: 800)
         let size = HUDWindowMetrics.clampedSize(
             for: CGSize(width: 1200, height: 64),
-            visibleFrame: CGRect(x: 0, y: 0, width: visibleWidth, height: 800)
+            visibleFrame: visibleFrame
         )
 
         XCTAssertEqual(size.width, visibleWidth - HUDWindowMetrics.horizontalScreenMargin * 2)


### PR DESCRIPTION
## Summary
- add an explicit CGRect fixture for the HUD visible frame clamp test

## Tests
- swift test --package-path apps/macos --filter HUDWindowMetricsTests