### PR TITLE
[codex] Guard non-finite crop video frames

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -179,7 +179,10 @@ enum VideoCropGeometry {
 
     static func pixelRect(for displayRect: CGRect, sourceSize: CGSize, videoFrame: CGRect) -> CGRect {
         let safeSourceSize = VideoCropSelection.safeSourceSize(sourceSize)
-        guard videoFrame.width > 0, videoFrame.height > 0 else {
+        guard videoFrame.width.isFinite,
+              videoFrame.height.isFinite,
+              videoFrame.width > 0,
+              videoFrame.height > 0 else {
             return CGRect(origin: .zero, size: safeSourceSize)
         }
         return VideoCropSelection.clampedPixelRect(


### PR DESCRIPTION
## Summary

- Guard crop geometry mapping against non-finite video frame dimensions before converting display coordinates back to source pixels.

## Validation
- swift test --package-path apps/macos --filter VideoCropSelectionTests
