### PR TITLE
Tighten compositor cache option test

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -17,10 +17,11 @@ final class VideoPreviewLayoutTests: XCTestCase {
         XCTAssertEqual(formatPlaybackTime(125.8), "2:05")
     }
 
-    func testVideoCompositorDoesNotCacheStreamingIntermediates() {
+    func testVideoCompositorDoesNotCacheStreamingIntermediates() throws {
         let options = VideoBackgroundCompositor.ciContextOptions()
+        let cacheIntermediates = try XCTUnwrap(options[.cacheIntermediates] as? Bool)
 
-        XCTAssertEqual(options[.cacheIntermediates] as? Bool, false)
+        XCTAssertEqual(cacheIntermediates, false)
     }
 
     func testAutoPreviewAspectUsesCropSelectionAspect() {


### PR DESCRIPTION
## Summary
- unwrap the compositor cache option as a Bool before asserting it is disabled
- make the test fail clearly if the CI context option is missing or changes type

## Tests
- swift test --package-path apps/macos --filter VideoPreviewLayoutTests