### PR TITLE
Document Rust update helper Clippy exception

### DIFF
--- a/apps/rust-service/src/main.rs
+++ b/apps/rust-service/src/main.rs
@@ -441,6 +441,7 @@ fn save_project_document(
     Ok(summary)
 }
 
+#[allow(clippy::too_many_arguments, reason = "mirrors optional update payload fields")]
 fn update_project_document(
     paths: &InternalPaths,
     project_path: &Path,


### PR DESCRIPTION
## Summary
- document the intentional Clippy exception for the Rust project update helper that mirrors optional update payload fields

## Tests
- cargo test
- cargo clippy --all-targets -- -D warnings
- swift test --package-path apps/macos --filter NativeScreenRecorderConfigurationTests