### PR TITLE
Type invalid UTF8 test fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -21,7 +21,7 @@ final class RustServiceClientTests: XCTestCase {
 
     func testMissingExecutableFailsBeforeDecodingRawParameters() {
         let client = RustServiceClient(executableURL: nil)
-        let invalidUTF8 = Data([0xFF])
+        let invalidUTF8: Data = Data([0xFF])
 
         XCTAssertThrowsError(
             try client.call("listProjects", paramsData: invalidUTF8, as: String.self)


### PR DESCRIPTION
## Summary\n- add an explicit Data type annotation for the invalid UTF-8 Rust service client test fixture\n\n## Tests\n- swift test --package-path apps/macos --filter RustServiceClientTests