### PR TITLE
Guard non-finite export dimensions

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropSelection.swift
@@ -197,9 +197,11 @@ enum VideoCropGeometry {
     }
 
     static func evenSize(_ size: CGSize) -> CGSize {
-        CGSize(
-            width: max(2, floor(max(2, size.width) / 2) * 2),
-            height: max(2, floor(max(2, size.height) / 2) * 2)
+        let width = size.width.isFinite ? size.width : 2
+        let height = size.height.isFinite ? size.height : 2
+        return CGSize(
+            width: max(2, floor(max(2, width) / 2) * 2),
+            height: max(2, floor(max(2, height) / 2) * 2)
         )
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoCropSelectionTests.swift
@@ -169,6 +169,13 @@ final class VideoCropSelectionTests: XCTestCase {
         XCTAssertEqual(VideoCropGeometry.evenSize(CGSize(width: 1, height: -4)), CGSize(width: 2, height: 2))
     }
 
+    func testEvenSizeFallsBackForNonFiniteDimensions() {
+        XCTAssertEqual(
+            VideoCropGeometry.evenSize(CGSize(width: CGFloat.nan, height: CGFloat.infinity)),
+            CGSize(width: 2, height: 2)
+        )
+    }
+
     func testSourceExportOutputSizeUsesCropSourceDimensions() {
         let cropSize = CGSize(width: 1725, height: 965)
         let options = VideoExportOptions(


### PR DESCRIPTION
## Summary
- Guard video export even-size calculations against non-finite width/height values.
- Add a regression test for NaN/infinite crop export dimensions.

## Tests
- `cd apps/macos && swift test --filter VideoCropSelectionTests`
- `make test-macos` (first full run showed one intermittent Swift failure in unrelated output; standalone `swift test` passed on rerun, and the second full `make test-macos` passed cleanly)