### PR TITLE
Tighten async test polling intervals

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1399,7 +1399,7 @@ private func waitForCondition(
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: timeout)
     while !condition(), clock.now < deadline {
-        try? await clock.sleep(for: .milliseconds(10))
+        try? await clock.sleep(for: .milliseconds(1))
     }
     XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s", file: file, line: line)
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -246,7 +246,7 @@ private func waitForCondition(
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: timeout)
     while !condition(), clock.now < deadline {
-        try? await clock.sleep(for: .milliseconds(10))
+        try? await clock.sleep(for: .milliseconds(1))
     }
     XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s", file: file, line: line)
 }


### PR DESCRIPTION
## Summary
- reduce two async test polling helper sleeps from 10 ms to 1 ms
- keep the change scoped to test wait latency only

## Tests
- swift test