### PR TITLE
Use window info alias for legacy bounds

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -674,7 +674,7 @@ final class CaptureController: ObservableObject {
     }
 
     private func legacyWindowFrame(from window: CGWindowInfoDictionary) -> CGRect {
-        guard let bounds = window[kCGWindowBounds as String] as? [String: Any] else {
+        guard let bounds = window[kCGWindowBounds as String] as? CGWindowInfoDictionary else {
             return .zero
         }
 


### PR DESCRIPTION
## Summary\n- Use the existing CGWindowInfoDictionary alias when reading legacy window bounds.\n\n## Tests\n- swift test