### PR TITLE
Clean up async test timeout messages

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1401,7 +1401,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(1))
     }
-    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s", file: file, line: line)
+    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)", file: file, line: line)
 }
 
 @MainActor

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -248,7 +248,7 @@ private func waitForCondition(
     while !condition(), clock.now < deadline {
         try? await clock.sleep(for: .milliseconds(1))
     }
-    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)s", file: file, line: line)
+    XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)", file: file, line: line)
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- remove the extra literal `s` from async test timeout failure messages
- keep the helper diagnostics aligned with Swift `Duration` formatting

## Tests
- `swift test --filter 'AppPresentationStateMachineTests|AppModelStateTests'`
- `swift test --filter StateMachineTests`