### PR TITLE
Harden update checker test fixture cleanup

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -85,10 +85,10 @@ final class UpdateCheckerTests: XCTestCase {
         let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
         let infoPlistURL = contentsURL.appendingPathComponent("Info.plist")
 
-        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
         addTeardownBlock {
             try? FileManager.default.removeItem(at: bundleURL)
         }
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
 
         var plist: InfoPlistFixture = [
             "CFBundlePackageType": "BNDL",


### PR DESCRIPTION
## Summary
- register UpdateCheckerTests temporary bundle teardown before fixture setup can throw
- keeps failed fixture setup from leaving temporary bundle directories behind

## Tests
- swift test --filter UpdateCheckerTests