### PR TITLE
Make SerializableColor test imports explicit

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/SerializableColorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/SerializableColorTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Foundation
 import XCTest
 @testable import OpenRecorderMac
 


### PR DESCRIPTION
## Summary
- Add explicit AppKit and Foundation imports to SerializableColorTests for the NSColor and Data types used by the file.

## Tests
- swift test --filter SerializableColorTests