### PR TITLE
Stabilize serializable color alpha tests

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/SerializableColorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/SerializableColorTests.swift
@@ -15,7 +15,7 @@ final class SerializableColorTests: XCTestCase {
     func testHexInitializerPreservesProvidedAlpha() {
         let color = SerializableColor(hex: "#FFFFFF", alpha: 0.42)
 
-        XCTAssertEqual(color.alpha, 0.42)
+        XCTAssertEqual(color.alpha, 0.42, accuracy: 0.0001)
     }
 
     func testHexInitializerAcceptsLowercaseValueWithoutHash() {
@@ -32,7 +32,7 @@ final class SerializableColorTests: XCTestCase {
         XCTAssertEqual(color.red, 0)
         XCTAssertEqual(color.green, 0)
         XCTAssertEqual(color.blue, 0)
-        XCTAssertEqual(color.alpha, 0.75)
+        XCTAssertEqual(color.alpha, 0.75, accuracy: 0.0001)
     }
 
     func testHexStringClampsOutOfRangeComponents() {
@@ -48,7 +48,7 @@ final class SerializableColorTests: XCTestCase {
         let decoded = try JSONDecoder().decode(SerializableColor.self, from: data)
 
         XCTAssertEqual(decoded, color)
-        XCTAssertEqual(decoded.alpha, 0.4)
+        XCTAssertEqual(decoded.alpha, 0.4, accuracy: 0.0001)
     }
 
     func testNSColorInitializerReadsSRGBComponents() {


### PR DESCRIPTION
## Summary\n- Use the existing floating-point tolerance for SerializableColor alpha assertions\n- Keep the change limited to test maintenance\n\n## Tests\n- swift test --filter SerializableColorTests\n- swift test