### PR TITLE
[codex] reuse source URL constant

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -234,7 +234,7 @@ export default function Home(): ReactElement {
             <p className="eyebrow">Open source on GitHub</p>
             <h2>Make your next product demo feel finished.</h2>
           </div>
-          <a className="primary-action" href="https://github.com/imbhargav5/open-recorder">
+          <a className="primary-action" href={sourceUrl}>
             View repository
           </a>
         </div>


### PR DESCRIPTION
## Summary
- Reuse the existing `sourceUrl` constant for the footer repository link.

## Validation
- `pnpm --dir apps/landing lint`
- `pnpm --dir apps/landing build`
