### PR TITLE
Tighten update checker plist fixture type

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class UpdateCheckerTests: XCTestCase {
-    private typealias InfoPlistFixture = [String: String]
+    private typealias InfoPlistFixture = [String: Any]
 
     func testUpdateCheckerIsEnabledForProductionBundleWithHTTPSFeed() throws {
         let bundle = try makeBundle(


### PR DESCRIPTION
## Summary
- widen the update checker Info.plist fixture dictionary to `[String: Any]` so it matches the property-list API

## Verification
- `swift test --filter UpdateCheckerTests`