### PR TITLE
[codex] Clarify ignored microphone fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
@@ -62,7 +62,8 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
             sourceRect: CGRect(x: 20, y: 30, width: 640, height: 360),
             options: RecordingCaptureOptions(
                 includeMicrophone: false,
-                microphoneDeviceID: "stale-device",
+                // This identifier is ignored when microphone capture is disabled.
+                microphoneDeviceID: "ignored-device",
                 includeSystemAudio: false,
                 includeCamera: false,
                 cameraDeviceID: nil,


### PR DESCRIPTION
## What changed\n- Renamed the test fixture microphone device ID to make it clear it is ignored when microphone capture is disabled.\n- Added a short comment explaining why the value does not affect the configuration.\n\n## Why\n- This keeps the configuration test easier to read without changing behavior.\n\n## Verification\n- 