### PR TITLE
[codex] Clarify native recorder cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -90,7 +90,7 @@ final class NativeScreenRecorder: NSObject {
         configuration.height = height
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 60)
         configuration.queueDepth = 8
-        // Keep the raw capture cursor-free; the editor/export overlay renders it separately.
+        // Keep raw capture cursor-free so the editor and export overlays can render it consistently.
         configuration.showsCursor = false
         configuration.capturesAudio = options.includeSystemAudio
         configuration.sampleRate = 48_000


### PR DESCRIPTION
This is a narrow maintenance-only change that clarifies the native recorder cursor comment.

- Keeps the raw capture cursor-free so the editor and export overlays can render it consistently.
- No runtime logic changed.

Validation:
- `swift test --package-path apps/macos --filter NativeScreenRecorderConfigurationTests`
