### PR TITLE
Clarify export retry wording

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
@@ -166,7 +166,7 @@ struct VideoExportDialog: View {
         VStack(alignment: .leading, spacing: 16) {
             ExportMessageRow(
                 symbolName: "exclamationmark.triangle.fill",
-                message: errorMessage ?? "Save dialog canceled. Click Save Again to save without re-exporting.",
+                message: errorMessage ?? "Save dialog canceled. Click Save Again to save without re-rendering.",
                 tint: .orange
             )
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
@@ -109,7 +109,7 @@ extension VideoExportState {
 
         case .savePanelCanceled:
             phase = .savePending
-            errorMessage = "Save dialog canceled. Click Save Again to save without re-exporting."
+            errorMessage = "Save dialog canceled. Click Save Again to save without re-rendering."
             return [.setStatusMessage("Export ready to save.")]
 
         case .saveSucceeded(let targetURL):

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -362,7 +362,7 @@ final class VideoExportStateMachineTests: XCTestCase {
 
         XCTAssertEqual(state.applying(.savePanelCanceled), [.setStatusMessage("Export ready to save.")])
         XCTAssertEqual(state.phase, .savePending)
-        XCTAssertEqual(state.errorMessage, "Save dialog canceled. Click Save Again to save without re-exporting.")
+        XCTAssertEqual(state.errorMessage, "Save dialog canceled. Click Save Again to save without re-rendering.")
         XCTAssertEqual(state.pendingTempURL, tempURL)
 
         XCTAssertEqual(state.applying(.retrySaveRequested), [


### PR DESCRIPTION
## Summary\n- change the save-cancel retry copy to say the export can be saved again without re-rendering\n- keep the reducer, dialog, and test assertion in sync\n\n## Verification\n- swift test --filter testExportReducerHandlesSavePendingRetryAndSuccess