### PR TITLE
Centralize export save-cancel wording

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
@@ -166,7 +166,7 @@ struct VideoExportDialog: View {
         VStack(alignment: .leading, spacing: 16) {
             ExportMessageRow(
                 symbolName: "exclamationmark.triangle.fill",
-                message: errorMessage ?? "Save dialog canceled. Click Save Again to save without re-rendering.",
+                message: errorMessage ?? VideoExportCopy.saveDialogCanceled,
                 tint: .orange
             )
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
@@ -43,6 +43,10 @@ enum VideoExportEffect: Equatable {
     case setStatusMessage(String)
 }
 
+enum VideoExportCopy {
+    static let saveDialogCanceled = "Save dialog canceled. Click Save Again to save without re-rendering."
+}
+
 extension VideoExportState {
     mutating func applying(_ event: VideoExportEvent) -> [VideoExportEffect] {
         switch event {
@@ -109,7 +113,7 @@ extension VideoExportState {
 
         case .savePanelCanceled:
             phase = .savePending
-            errorMessage = "Save dialog canceled. Click Save Again to save without re-rendering."
+            errorMessage = VideoExportCopy.saveDialogCanceled
             return [.setStatusMessage("Export ready to save.")]
 
         case .saveSucceeded(let targetURL):

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -362,7 +362,7 @@ final class VideoExportStateMachineTests: XCTestCase {
 
         XCTAssertEqual(state.applying(.savePanelCanceled), [.setStatusMessage("Export ready to save.")])
         XCTAssertEqual(state.phase, .savePending)
-        XCTAssertEqual(state.errorMessage, "Save dialog canceled. Click Save Again to save without re-rendering.")
+        XCTAssertEqual(state.errorMessage, VideoExportCopy.saveDialogCanceled)
         XCTAssertEqual(state.pendingTempURL, tempURL)
 
         XCTAssertEqual(state.applying(.retrySaveRequested), [


### PR DESCRIPTION
## Summary\n- Centralize the export save-cancel message in one internal constant\n- Reuse the same text in the reducer, dialog fallback, and reducer test\n\n## Verification\n- cd apps/macos && swift test --filter VideoExportStateMachineTests