### PR TITLE
Centralize export-ready status copy

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
@@ -45,6 +45,7 @@ enum VideoExportEffect: Equatable {
 
 enum VideoExportCopy {
     static let saveDialogCanceled = "Save dialog canceled. Click Save Again to save without re-rendering."
+    static let exportReadyToSave = "Export ready to save."
 }
 
 extension VideoExportState {
@@ -114,7 +115,7 @@ extension VideoExportState {
         case .savePanelCanceled:
             phase = .savePending
             errorMessage = VideoExportCopy.saveDialogCanceled
-            return [.setStatusMessage("Export ready to save.")]
+            return [.setStatusMessage(VideoExportCopy.exportReadyToSave)]
 
         case .saveSucceeded(let targetURL):
             pendingTempURL = nil

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -360,7 +360,7 @@ final class VideoExportStateMachineTests: XCTestCase {
         XCTAssertEqual(state.phase, .saving)
         XCTAssertEqual(state.progress, 1)
 
-        XCTAssertEqual(state.applying(.savePanelCanceled), [.setStatusMessage("Export ready to save.")])
+        XCTAssertEqual(state.applying(.savePanelCanceled), [.setStatusMessage(VideoExportCopy.exportReadyToSave)])
         XCTAssertEqual(state.phase, .savePending)
         XCTAssertEqual(state.errorMessage, VideoExportCopy.saveDialogCanceled)
         XCTAssertEqual(state.pendingTempURL, tempURL)


### PR DESCRIPTION
## Summary
- Centralize the export-ready status string in `VideoExportCopy`
- Update the state machine test to assert against the shared constant

## Verification
- `swift test --filter VideoExportStateMachineTests`
