### PR TITLE
[codex] Fix landing turbopack root warning

### DIFF
--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -1,5 +1,9 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  turbopack: {
+    root: process.cwd(),
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## What changed
- Set `turbopack.root` in `apps/landing/next.config.ts` to `process.cwd()`.

## Why
- `next build` was warning that it inferred the workspace root from the top-level lockfile while a nested `pnpm-workspace.yaml` also existed in the landing app.
- Pinning the root removes that warning without changing runtime behavior.

## Verification
- `pnpm --dir apps/landing lint`
- `pnpm --dir apps/landing build`
