### PR TITLE
Approve landing build scripts

### DIFF
--- a/apps/landing/pnpm-workspace.yaml
+++ b/apps/landing/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-ignoredBuiltDependencies:
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
Summary:
- Replace the landing app's placeholder pnpm build-policy entries with explicit approvals for sharp and unrs-resolver.

Verification:
- pnpm --dir apps/landing lint
- pnpm --dir apps/landing build