### PR TITLE
Fix release dispatcher arg parsing

### DIFF
--- a/scripts/dispatch-production-release-build.mjs
+++ b/scripts/dispatch-production-release-build.mjs
@@ -43,7 +43,7 @@ function parseArgs(argv) {
 		const arg = argv[index];
 		switch (arg) {
 			case "--":
-				break;
+				return args;
 			case "--release-type":
 				args.releaseType = argv[++index] ?? die("--release-type requires a value");
 				break;


### PR DESCRIPTION
Treat `--` as an end-of-options sentinel in the release dispatcher so trailing tokens are ignored instead of causing parse failures.

Verified by running the dispatcher against a fake `gh` shim with a trailing `--bogus` argument.
