### PR TITLE
Clarify landing ESLint comments

### DIFF
--- a/apps/landing/eslint.config.mjs
+++ b/apps/landing/eslint.config.mjs
@@ -5,9 +5,9 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  // Keep Next's defaults and add this package's extra build ignores.
+  // Keep Next's defaults and ignore generated or local build artifacts for this app.
   globalIgnores([
-    // Extra ignores for this package:
+    // App-specific ignores:
     ".next/**",
     "**/._*",
     "out/**",


### PR DESCRIPTION
## What changed

- Updated the landing ESLint config comments so they accurately describe the ignore list.

## Why

- The previous wording referred only to build ignores, but the config also ignores generated artifacts like `next-env.d.ts`.

## Verification

- `pnpm --dir apps/landing lint`
