### PR TITLE
Simplify landing docs link markup

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -121,8 +121,8 @@ export default function Home(): ReactElement {
             <a href="#features">Features</a>
             <a href="#workflow">Workflow</a>
             <a href="#architecture">Architecture</a>
-            <a href={docsUrl} target="_blank" rel="noopener noreferrer">
-              <span className="primary-action">Docs</span>
+            <a className="primary-action" href={docsUrl} target="_blank" rel="noopener noreferrer">
+              Docs
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary\n- make the landing page Docs control a single styled anchor instead of a nested span inside an anchor\n\n## Verification\n- pnpm --dir apps/landing lint\n- pnpm --dir apps/landing build