### PR TITLE
[codex] clarify README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Run verification:
 make test-macos
 ```
 
-The root `pnpm dev`, `pnpm build`, and `pnpm test` aliases now call those same macOS Swift/Rust targets.
+The root `pnpm dev`, `pnpm build`, and `pnpm test` aliases call those same macOS Swift/Rust targets.
 
 Run the landing page locally:
 


### PR DESCRIPTION
### What changed

- Removed a time-relative word from the root README so the note about `pnpm dev`, `pnpm build`, and `pnpm test` stays accurate.

### Why

- This keeps the maintenance note from reading like a stale, dated comment.

### Validation

- `git diff --check`
- `pnpm --dir apps/landing lint`
