### PR TITLE
Clarify cursor capture comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -90,7 +90,7 @@ final class NativeScreenRecorder: NSObject {
         configuration.height = height
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 60)
         configuration.queueDepth = 8
-        // Capture without the system cursor so the editor and export overlays can draw it consistently later.
+        // Disable system cursor capture so the editor and export pipelines can draw a single cursor consistently.
         configuration.showsCursor = false
         configuration.capturesAudio = options.includeSystemAudio
         configuration.sampleRate = 48_000


### PR DESCRIPTION
## Summary
- Clarify the NativeScreenRecorder cursor-capture comment to match the current playback/export pipeline wording.

## Verification
- swift test --filter NativeScreenRecorderConfigurationTests