### PR TITLE
Clean up recorder config test comment

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
@@ -62,7 +62,6 @@ final class NativeScreenRecorderConfigurationTests: XCTestCase {
             sourceRect: CGRect(x: 20, y: 30, width: 640, height: 360),
             options: RecordingCaptureOptions(
                 includeMicrophone: false,
-                // The configuration should clear the identifier when microphone capture is disabled.
                 microphoneDeviceID: "ignored-device",
                 includeSystemAudio: false,
                 includeCamera: false,


### PR DESCRIPTION
## Summary\n- Remove a redundant comment from the native screen recorder configuration test\n\n## Verification\n- `cd apps/macos && swift test --filter NativeScreenRecorderConfigurationTests`