### PR TITLE
[codex] clarify cursor capture comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -90,7 +90,7 @@ final class NativeScreenRecorder: NSObject {
         configuration.height = height
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 60)
         configuration.queueDepth = 8
-        // Disable system cursor capture so the editor and export pipelines can draw a single cursor consistently.
+        // The editor/export pipeline composites cursor overlays itself, so keep the recorder from capturing the system cursor.
         configuration.showsCursor = false
         configuration.capturesAudio = options.includeSystemAudio
         configuration.sampleRate = 48_000


### PR DESCRIPTION
## What changed
- Clarified the recorder comment that explains why system cursor capture is disabled.

## Why
- The old wording was a bit indirect; this now states the ownership boundary more plainly.

## Validation
- `swift test --filter NativeScreenRecorderConfigurationTests`
