### PR TITLE
[codex] scope signing temp plist

### DIFF
--- a/scripts/sign-macos-app-shared.zsh
+++ b/scripts/sign-macos-app-shared.zsh
@@ -163,6 +163,7 @@ sign_sparkle_framework() {
 }
 
 ad_hoc_app_entitlements() {
+	local temporary_entitlements_plist
 	temporary_entitlements_plist="$(mktemp "${TMPDIR:-/tmp}/open-recorder-entitlements.XXXXXX")"
 
 	if [[ -f "$entitlements_plist" ]]; then


### PR DESCRIPTION
## Summary
- Scope the temporary entitlements plist inside `ad_hoc_app_entitlements()` so the signing helper does not leak a global shell variable.

## Validation
- `zsh -n scripts/sign-macos-app-shared.zsh`
