### PR TITLE
[codex] stabilize test polling

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1399,7 +1399,7 @@ private func waitForCondition(
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: timeout)
     while !condition(), clock.now < deadline {
-        try? await clock.sleep(for: .milliseconds(1))
+        try? await clock.sleep(for: .milliseconds(10))
     }
     XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)", file: file, line: line)
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -244,7 +244,7 @@ private func waitForCondition(
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: timeout)
     while !condition(), clock.now < deadline {
-        try? await clock.sleep(for: .milliseconds(1))
+        try? await clock.sleep(for: .milliseconds(10))
     }
     XCTAssertTrue(condition(), "Timed out waiting for condition after \(timeout)", file: file, line: line)
 }


### PR DESCRIPTION
Stabilize the two async polling helpers used by the macOS state machine tests.

Both helpers were sleeping for 1 ms between condition checks, which is unnecessarily tight and can be sensitive to scheduler granularity. Increasing the backoff to 10 ms keeps the tests responsive while reducing the chance of spurious timing failures.

Validation:
- `swift test --filter AppModelStateTests`
- `swift test --filter CaptureDriverStateMachineTests`
