### PR TITLE
Tighten update checker plist test fixture

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class UpdateCheckerTests: XCTestCase {
-    private typealias InfoPlistFixture = [String: Any]
+    private typealias InfoPlistFixture = [String: String]
 
     func testUpdateCheckerIsEnabledForProductionBundleWithHTTPSFeed() throws {
         let bundle = try makeBundle(
@@ -93,8 +93,12 @@ final class UpdateCheckerTests: XCTestCase {
         var plist: InfoPlistFixture = [
             "CFBundlePackageType": "BNDL",
         ]
-        plist["CFBundleIdentifier"] = identifier
-        plist["SUFeedURL"] = feedURLString
+        if let identifier {
+            plist["CFBundleIdentifier"] = identifier
+        }
+        if let feedURLString {
+            plist["SUFeedURL"] = feedURLString
+        }
         let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
         try data.write(to: infoPlistURL)
 


### PR DESCRIPTION
## Summary\n- narrow the update checker plist fixture to string-only values\n- avoid inserting optional values into the test bundle plist\n\n## Verification\n- swift test (apps/macos)