### PR TITLE
Clarify HUD gradient comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -450,8 +450,8 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
 }
 
 
-// Recording HUD gradient top color. Kept private because only the destructive
-// recording state uses it.
+// Recording HUD gradient top color. Kept private because only the recording
+// HUD uses it.
 private let hudRecordingGradientTop = Color(red: 0.16, green: 0.10, blue: 0.11)
 
 struct HUDSurface<Content: View>: View {


### PR DESCRIPTION
## Summary\n- Clarify the HUD gradient comment in the shared SwiftUI layer\n\n## Verification\n- Test Suite 'Selected tests' started at 2026-06-29 03:21:58.127.
Test Suite 'OpenRecorderMacPackageTests.xctest' started at 2026-06-29 03:21:58.134.
Test Suite 'HUDWindowMetricsTests' started at 2026-06-29 03:21:58.134.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testDefaultWidthMatchesCondensedHUDLayout]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testDefaultWidthMatchesCondensedHUDLayout]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testHUDWindowBehaviorFollowsActiveMacOSSpace]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testHUDWindowBehaviorFollowsActiveMacOSSpace]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testInvalidMeasurementFallsBackToDefaultWidth]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testInvalidMeasurementFallsBackToDefaultWidth]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testMeasuredWidthClampsToVisibleFrameMargin]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testMeasuredWidthClampsToVisibleFrameMargin]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testMeasuredWidthIsPreservedWhenItFitsVisibleFrame]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testMeasuredWidthIsPreservedWhenItFitsVisibleFrame]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testScreenSelectionOverlayChromeCanCoverFullscreenSpaces]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testScreenSelectionOverlayChromeCanCoverFullscreenSpaces]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testWidthNeverDropsBelowMinimum]' started.
Test Case '-[OpenRecorderMacTests.HUDWindowMetricsTests testWidthNeverDropsBelowMinimum]' passed (0.000 seconds).
Test Suite 'HUDWindowMetricsTests' passed at 2026-06-29 03:21:58.136.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
Test Suite 'OpenRecorderMacPackageTests.xctest' passed at 2026-06-29 03:21:58.136.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
Test Suite 'Selected tests' passed at 2026-06-29 03:21:58.136.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.009) seconds
◇ Test run started.
↳ Testing Library Version: 1501
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.