### PR TITLE
Tighten update checker feed validation

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/UpdateChecker.swift
+++ b/apps/macos/Sources/OpenRecorderMac/UpdateChecker.swift
@@ -38,7 +38,8 @@ final class UpdateChecker: NSObject {
         guard bundle.bundleIdentifier == productionBundleIdentifier,
               let feedURLString = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String,
               let feedURL = URL(string: feedURLString),
-              feedURL.scheme?.lowercased() == "https" else {
+              feedURL.scheme?.lowercased() == "https",
+              feedURL.host?.isEmpty == false else {
             return false
         }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -51,6 +51,15 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
     }
 
+    func testUpdateCheckerIsDisabledForHTTPSFeedWithoutHost() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app",
+            feedURLString: "https://"
+        )
+
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
     func testUpdateCheckerIsDisabledForMalformedFeedURL() throws {
         let bundle = try makeBundle(
             identifier: "dev.openrecorder.app",


### PR DESCRIPTION
## Summary\n- reject hostless HTTPS feed URLs in UpdateChecker\n- add a regression test for `https://`\n\n## Verification\n- swift test --filter UpdateCheckerTests