### PR TITLE
Clarify recording HUD comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -450,8 +450,7 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
 }
 
 
-// Recording HUD gradient top color. Kept private because only the recording
-// state uses it.
+// Top accent color for the recording HUD variant.
 private let hudRecordingGradientTop = Color(red: 0.16, green: 0.10, blue: 0.11)
 
 struct HUDSurface<Content: View>: View {


### PR DESCRIPTION
Small maintenance update: reword the recording HUD accent comment in SharedStudioViews for clarity.

Verification: `cd apps/macos && swift test`