### PR TITLE
Broaden update checker plist fixture type

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class UpdateCheckerTests: XCTestCase {
-    private typealias InfoPlistFixture = [String: String]
+    private typealias InfoPlistFixture = [String: Any]
 
     func testUpdateCheckerIsEnabledForProductionBundleWithHTTPSFeed() throws {
         let bundle = try makeBundle(


### PR DESCRIPTION
## Summary
- Broaden the UpdateChecker test plist fixture to `[String: Any]` so it matches `PropertyListSerialization` more accurately.

## Verification
- `swift test --filter UpdateCheckerTests`
