### PR TITLE
Clarify recording HUD gradient comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -450,7 +450,7 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
 }
 
 
-// Top accent color for the recording HUD variant.
+// Top gradient stop for the recording HUD variant.
 private let hudRecordingGradientTop = Color(red: 0.16, green: 0.10, blue: 0.11)
 
 struct HUDSurface<Content: View>: View {


### PR DESCRIPTION
Small maintenance cleanup: clarify the recording HUD color comment so it describes the gradient stop more precisely.

Verification:
- `cd apps/macos && swift test --filter UpdateCheckerTests`