### PR TITLE
Clarify HUD gradient comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -450,7 +450,7 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
 }
 
 
-// Top gradient stop for the recording HUD variant.
+// Top gradient stop for the recording-state HUD gradient.
 private let hudRecordingGradientTop = Color(red: 0.16, green: 0.10, blue: 0.11)
 
 struct HUDSurface<Content: View>: View {


### PR DESCRIPTION
## Summary
- Clarify the comment for the recording-state HUD gradient color.

## Verification
- `cd apps/macos && swift test`
