### PR TITLE
Increase async test polling timeout

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1391,7 +1391,7 @@ private func makeSource(
 
 @MainActor
 private func waitForCondition(
-    timeout: Duration = .seconds(2),
+    timeout: Duration = .seconds(5),
     file: StaticString = #filePath,
     line: UInt = #line,
     condition: @escaping @MainActor () -> Bool

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -236,7 +236,7 @@ private func waitUntilCancelled() async {
 
 @MainActor
 private func waitForCondition(
-    timeout: Duration = .seconds(2),
+    timeout: Duration = .seconds(5),
     file: StaticString = #filePath,
     line: UInt = #line,
     condition: @escaping @MainActor () -> Bool


### PR DESCRIPTION
## Summary\n- Increase the async polling timeout used by the macOS state machine tests from 2s to 5s in two helper copies.\n\n## Verification\n- cd apps/macos && swift test --filter CaptureDriverStateMachineTests\n- cd apps/macos && swift test --filter AppModelStateTests