### PR TITLE
Clarify native cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -90,7 +90,7 @@ final class NativeScreenRecorder: NSObject {
         configuration.height = height
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 60)
         configuration.queueDepth = 8
-        // Hide the native cursor here; cursor overlays are composited later in the editor/export pipeline.
+        // Hide the system cursor here so the editor can composite its own cursor overlay later.
         configuration.showsCursor = false
         configuration.capturesAudio = options.includeSystemAudio
         configuration.sampleRate = 48_000


### PR DESCRIPTION
## Summary\n- Clarify the NativeScreenRecorder cursor comment to match the current capture pipeline wording.\n\n## Verification\n-  (apps/macos)