### PR TITLE
[codex] Clarify thumbnail cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -706,6 +706,7 @@ final class CaptureController: ObservableObject {
         configuration.height = max(Int(size.height), 1)
         configuration.scalesToFit = true
         configuration.preservesAspectRatio = true
+        // Thumbnails intentionally omit the cursor; source previews render cursor state separately.
         configuration.showsCursor = false
         configuration.shouldBeOpaque = true
         configuration.ignoreShadowsSingleWindow = ignoreWindowShadow


### PR DESCRIPTION
Summary
- Clarify why thumbnail capture intentionally omits the cursor in the macOS capture controller.

Validation
- `swift test` in `apps/macos` (449 tests, 0 failures).
