### PR TITLE
Clarify design token comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -904,6 +904,7 @@ struct HUDToggle: View {
 //   Actions         actionPrimary(+Fg) / accent(+Fg) / destructive(+Fg)
 //   Overlays        overlay / overlayStrong / scrim
 //   Status          statusError / statusWarning / statusSuccess / statusInfo
+//   Timeline        timelineClip / timelineClipForeground / timelineClipBorder / timelineHandle / timelineCamera
 //
 // Prefer these over raw Color.white.opacity(N) or Color(red:...) literals.
 


### PR DESCRIPTION
## Summary\n- Clarify the macOS design-token comment to include the timeline palette entries that follow it.\n\n## Verification\n- swift test in apps/macos (449 tests, 0 failures)