### PR TITLE
Document landing app install step

### DIFF
--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -5,6 +5,7 @@ Next.js landing page for Open Recorder.
 Run locally:
 
 ```bash
+pnpm install --dir apps/landing --frozen-lockfile
 pnpm --dir apps/landing dev
 ```
 


### PR DESCRIPTION
## Summary\n- Add the missing landing app install step to the README so fresh worktrees can run lint/build successfully.\n\n## Verification\n- pnpm --dir apps/landing lint\n- pnpm --dir apps/landing build