### PR TITLE
Tighten update checker plist fixture type

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class UpdateCheckerTests: XCTestCase {
-    private typealias InfoPlistFixture = [String: Any]
+    private typealias InfoPlistFixture = [String: String]
 
     func testUpdateCheckerIsEnabledForProductionBundleWithHTTPSFeed() throws {
         let bundle = try makeBundle(


### PR DESCRIPTION
## Description
Tighten the UpdateChecker test plist fixture from `[String: Any]` to `[String: String]` because the fixture only stores string values.

## Motivation
Keep the test helper narrowly typed and reduce fixture looseness without changing behavior.

## Type of Change
- [x] Refactor / Code Cleanup

## Testing Guide
- `swift test --filter UpdateCheckerTests` (apps/macos)

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.
