### PR TITLE
[codex] clarify release help text

### DIFF
--- a/scripts/dispatch-production-release-build.mjs
+++ b/scripts/dispatch-production-release-build.mjs
@@ -17,7 +17,7 @@ next semantic version, updates the native Swift/Rust release metadata, and opens
 or updates the release PR. Merging that PR triggers the macOS release build.
 
 Options:
-  --release-type VALUE     Release type: patch, minor, or major. Uses a selector if omitted.
+  --release-type VALUE     Release type: patch, minor, or major. Uses an interactive picker if omitted.
   --name VALUE             Optional release title override.
   --notes VALUE            Optional release notes body. Defaults to commits since the previous release.
   --latest true|false      Whether the eventual release should be marked latest. Defaults to true.


### PR DESCRIPTION
## Summary
- Update the release dispatcher help text so it says "interactive picker" instead of the stale "selector" wording.

## Validation
- `node --check scripts/dispatch-production-release-build.mjs`
- `node scripts/dispatch-production-release-build.mjs --help`
