### PR TITLE
[codex] isolate screenshot renderer tests to the main actor

### DIFF
--- a/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import XCTest
 @testable import OpenRecorderMac
 
+@MainActor
 final class ScreenshotExportRendererTests: XCTestCase {
     private typealias BackgroundOrientationFixture = (name: String, style: BackgroundStyle)
 


### PR DESCRIPTION
## What changed
- Marked `ScreenshotExportRendererTests` as `@MainActor` so its AppKit image work runs on the expected actor.

## Why
- The test file uses `NSImage`, `NSColor`, and `NSBitmapImageRep`, so isolating it avoids accidental off-actor AppKit access.

## Validation
- `swift test --filter ScreenshotExportRendererTests`
