### PR TITLE
Clarify native recorder area error

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -25,7 +25,7 @@ enum NativeScreenRecorderError: LocalizedError {
         case .selfCaptureUnsupported:
             return "Open Recorder windows are excluded from recordings."
         case .unsupportedSource:
-            return "Selected-area video recording is not implemented in the native recorder yet."
+            return "Selected-area video recording requires a valid area selection."
         case .recordingOutputUnavailable:
             return "ScreenCaptureKit recording output is not available on this macOS version."
         }

--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderErrorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderErrorTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import OpenRecorderMac
+
+final class NativeScreenRecorderErrorTests: XCTestCase {
+    func testUnsupportedSourceErrorDescriptionExplainsMissingAreaSelection() {
+        XCTAssertEqual(
+            NativeScreenRecorderError.unsupportedSource.errorDescription,
+            "Selected-area video recording requires a valid area selection."
+        )
+    }
+}


### PR DESCRIPTION
## Summary\n- Update the native recorder's unsupported-source message so it matches the actual area-capture fallback condition.\n- Add a focused unit test that pins the new wording.\n\n## Verification\n- swift test --filter NativeScreenRecorderErrorTests