### PR TITLE
[codex] tighten thumbnail cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -706,7 +706,7 @@ final class CaptureController: ObservableObject {
         configuration.height = max(Int(size.height), 1)
         configuration.scalesToFit = true
         configuration.preservesAspectRatio = true
-        // Thumbnails intentionally omit the cursor; source previews render cursor state separately.
+        // Thumbnails intentionally omit the cursor.
         configuration.showsCursor = false
         configuration.shouldBeOpaque = true
         configuration.ignoreShadowsSingleWindow = ignoreWindowShadow


### PR DESCRIPTION
## What changed
- Simplified the thumbnail cursor comment to match the current capture implementation.

## Validation
- `swift test --filter NativeScreenRecorder`