### PR TITLE
[codex] clarify source picker fallback comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -243,6 +243,7 @@ final class CaptureController: ObservableObject {
 
     func reloadSources(requestScreenRecordingPermission: Bool = false) async {
         guard canLoadPreviewSources(requestScreenRecordingPermission: requestScreenRecordingPermission) else {
+            // Keep the source picker populated when preview access is unavailable.
             var nextSources = legacyDisplaySources()
             nextSources.append(contentsOf: legacyWindowSources())
             sources = nextSources


### PR DESCRIPTION
## What
- Document the legacy source fallback in `CaptureController.reloadSources`.

## Why
- When preview access is unavailable, the source picker still needs to show display and window entries.

## Validation
- `make test-macos`
