### PR TITLE
[codex] annotate compositor render closure

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -235,7 +235,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     }
 
     func startRequest(_ request: AVAsynchronousVideoCompositionRequest) {
-        let renderRequest = {
+        let renderRequest: () -> Void = {
             autoreleasepool {
                 // Backpressure is intentional: queued requests retain decoded pixel buffers.
                 // Finish each frame before AVFoundation can hand us an unbounded backlog.


### PR DESCRIPTION
## Summary
- Add an explicit `() -> Void` type to the compositor request closure.

## Validation
- `swift test --package-path apps/macos --filter VideoPreviewLayoutTests/testVideoCompositorDoesNotCacheStreamingIntermediates`