### PR TITLE
Reduce project filename collisions

### DIFF
--- a/apps/rust-service/src/main.rs
+++ b/apps/rust-service/src/main.rs
@@ -400,7 +400,7 @@ fn save_project_document(
     let file_name = format!(
         "{}-{}.openrecorder",
         sanitize_file_name(title),
-        unix_timestamp()
+        unix_timestamp_millis()
     );
     let project_path = paths.projects_dir.join(file_name);
     let document = ProjectDocument {


### PR DESCRIPTION
Use millisecond precision for generated project filenames so rapid consecutive saves do not collide.

Verification:
- cargo test
- cargo clippy --tests -- -D warnings