### PR TITLE
Use millisecond precision for timestamped file names

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -819,6 +819,6 @@ func timestampedFileName(prefix: String, extension fileExtension: String, date: 
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.calendar = Calendar(identifier: .gregorian)
-    formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
+    formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss-SSS"
     return "\(prefix)-\(formatter.string(from: date)).\(fileExtension)"
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -8,7 +8,7 @@ final class AppModelStateTests: XCTestCase {
         let formatter: DateFormatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
+        formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss-SSS"
 
         XCTAssertEqual(
             timestampedFileName(prefix: "recording", extension: "mp4", date: date),


### PR DESCRIPTION
## Summary\n- Expand timestamped file names to millisecond precision so same-second capture starts are less likely to collide.\n- Update the matching unit test.\n\n## Verification\n- swift test --filter AppModelStateTests/testTimestampedFileNameUsesProvidedDate