### PR TITLE
Remove stale source picker comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -243,7 +243,6 @@ final class CaptureController: ObservableObject {
 
     func reloadSources(requestScreenRecordingPermission: Bool = false) async {
         guard canLoadPreviewSources(requestScreenRecordingPermission: requestScreenRecordingPermission) else {
-            // Keep the source picker populated when preview access is unavailable.
             var nextSources = legacyDisplaySources()
             nextSources.append(contentsOf: legacyWindowSources())
             sources = nextSources


### PR DESCRIPTION
## Summary\n- Remove a stale comment from CaptureController.reloadSources\n\n## Verification\n- swift test (apps/macos)\n