### PR TITLE
[codex] Clarify thumbnail cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -706,7 +706,7 @@ final class CaptureController: ObservableObject {
         configuration.height = max(Int(size.height), 1)
         configuration.scalesToFit = true
         configuration.preservesAspectRatio = true
-        // Thumbnails intentionally omit the cursor.
+        // ScreenCaptureKit thumbnails intentionally omit the cursor overlay.
         configuration.showsCursor = false
         configuration.shouldBeOpaque = true
         configuration.ignoreShadowsSingleWindow = ignoreWindowShadow


### PR DESCRIPTION
## Summary
- Clarify the ScreenCaptureKit thumbnail comment in `CaptureController`.

## Validation
- `cd apps/macos && swift test`
