### PR TITLE
[codex] Clarify thumbnail cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -706,7 +706,7 @@ final class CaptureController: ObservableObject {
         configuration.height = max(Int(size.height), 1)
         configuration.scalesToFit = true
         configuration.preservesAspectRatio = true
-        // ScreenCaptureKit thumbnails intentionally omit the cursor overlay.
+        // ScreenCaptureKit thumbnail captures stay cursor-free.
         configuration.showsCursor = false
         configuration.shouldBeOpaque = true
         configuration.ignoreShadowsSingleWindow = ignoreWindowShadow


### PR DESCRIPTION
## What changed
- Clarified the ScreenCaptureKit thumbnail comment in `CaptureController` to describe the cursor-free capture path directly.

## Why
- The note now matches the current implementation more precisely and avoids implying extra behavior.

## Verification
- `swift test --filter NativeScreenRecorderConfigurationTests`
