### PR TITLE
chore: add explicit type for blocklist prefixes

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -159,7 +159,7 @@ enum WindowSourceFilter {
         "spotlight"
     ]
 
-    private static let blockedBundlePrefixes = [
+    private static let blockedBundlePrefixes: [String] = [
         "com.apple.controlcenter",
         "com.apple.dock",
         "com.apple.loginwindow",


### PR DESCRIPTION
## Summary\n- Add an explicit  type annotation to the macOS window blocklist prefix list in .\n\n## Verification\n- Test Suite 'Selected tests' started at 2026-06-30 20:23:19.735.
Test Suite 'OpenRecorderMacPackageTests.xctest' started at 2026-06-30 20:23:19.741.
Test Suite 'WindowSourceFilterTests' started at 2026-06-30 20:23:19.741.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testExcludesControlCenterSpotlightAndSystemUIWindows]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testExcludesControlCenterSpotlightAndSystemUIWindows]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testExcludesTinyTransparentNonNormalAndOwnWindows]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testExcludesTinyTransparentNonNormalAndOwnWindows]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testKeepsBrowserWindows]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testKeepsBrowserWindows]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testKeepsNormalAppWindows]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testKeepsNormalAppWindows]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testTrimsWindowTitleAndOwnerNameForDisplay]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testTrimsWindowTitleAndOwnerNameForDisplay]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testUsesOwnerNameWhenTitleLooksLikeBundleIdentifier]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testUsesOwnerNameWhenTitleLooksLikeBundleIdentifier]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testUsesOwnerNameWhenTrimmedWindowTitleIsEmpty]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testUsesOwnerNameWhenTrimmedWindowTitleIsEmpty]' passed (0.000 seconds).
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testUsesOwnerNameWhenWindowTitleIsMissing]' started.
Test Case '-[OpenRecorderMacTests.WindowSourceFilterTests testUsesOwnerNameWhenWindowTitleIsMissing]' passed (0.000 seconds).
Test Suite 'WindowSourceFilterTests' passed at 2026-06-30 20:23:19.743.
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
Test Suite 'OpenRecorderMacPackageTests.xctest' passed at 2026-06-30 20:23:19.743.
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
Test Suite 'Selected tests' passed at 2026-06-30 20:23:19.743.
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.001 (0.008) seconds
◇ Test run started.
↳ Testing Library Version: 1501
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.