### PR TITLE
[codex] annotate timeline clip speeds

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
@@ -218,7 +218,7 @@ struct TimelineClipSegment: Identifiable, Equatable {
 
 enum TimelineClipSpeed {
     static let defaultSpeed = 1.0
-    static let values = [1.0, 1.25, 1.5, 1.75, 2.0]
+    static let values: [Double] = [1.0, 1.25, 1.5, 1.75, 2.0]
 
     static func normalized(_ speed: Double) -> Double {
         guard speed.isFinite else { return defaultSpeed }


### PR DESCRIPTION
### What changed
- Added an explicit `[Double]` type to `TimelineClipSpeed.values`.

### Why
- The speed table is a fixed numeric set, and the explicit type makes the intent clearer without changing behavior.

### Validation
- `swift test --filter TimelineClipSpeedTests`
