### PR TITLE
docs: tighten landing page metadata

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -3,9 +3,9 @@ import type { ReactElement, ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Open Recorder - Native macOS capture studio",
+  title: "Open Recorder | Native macOS capture studio",
   description:
-    "Open Recorder is an open-source macOS screen recorder, screenshot tool, and lightweight editor built with Swift and Rust.",
+    "Open Recorder is an open-source macOS screen recorder, screenshot tool, and native editor built with Swift and Rust.",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary\n- tighten the landing page title and description metadata to better match the current hero copy\n\n## Verification\n- pnpm --dir apps/landing lint\n- pnpm --dir apps/landing build