### PR TITLE
chore: clarify landing eslint ignore comment

### DIFF
--- a/apps/landing/eslint.config.mjs
+++ b/apps/landing/eslint.config.mjs
@@ -5,7 +5,7 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  // Keep Next's defaults while ignoring generated output, AppleDouble metadata, and generated Next type files.
+  // Keep Next's defaults while ignoring generated output, AppleDouble metadata, and the generated Next type file.
   globalIgnores([
     ".next/**",
     "**/._*",


### PR DESCRIPTION
## Summary\n- Clarify the ESLint ignore comment in the landing app config so it matches the single generated Next type file being ignored.\n\n## Verification\n- pnpm --dir apps/landing lint\n- pnpm --dir apps/landing build\n