### PR TITLE
[codex] remove redundant landing url types

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import type { ReactElement } from "react";
 
-const docsUrl: string = "https://docs.openrecorder.xyz/";
-const sourceUrl: string = "https://github.com/imbhargav5/open-recorder";
+const docsUrl = "https://docs.openrecorder.xyz/";
+const sourceUrl = "https://github.com/imbhargav5/open-recorder";
 
 type ProofPoint = readonly [value: string, label: string];
 


### PR DESCRIPTION
### What changed
- Removed two redundant `: string` annotations from the landing page URL constants.
- No runtime behavior changed.

### Verification
- `pnpm --dir apps/landing lint`
- `pnpm --dir apps/landing build`
