### PR TITLE
[codex] landing anchor scroll offset

### DIFF
--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -26,6 +26,7 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 88px;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Add `scroll-padding-top` to the landing page root so sticky navigation does not obscure in-page anchors.

## Validation
- `pnpm --dir apps/landing lint`
- `pnpm --dir apps/landing build`
