### PR TITLE
docs: remove stale README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/open%20source-Apache%202.0-2563eb?style=for-the-badge" alt="Apache 2.0 license" />
 </p>
 
-Open Recorder is now a macOS-only screen recorder, screenshot tool, and lightweight editor built as a native Swift app backed by a Rust service.
+Open Recorder is a macOS-only screen recorder, screenshot tool, and lightweight editor built as a native Swift app backed by a Rust service.
 
 The product uses a small native stack: Swift owns the macOS experience, capture UI, recording controls, screenshot flow, playback, and Finder/privacy integrations. Rust owns durable local service work such as app paths, project metadata, recording registration, screenshot indexing, and export bookkeeping.
 


### PR DESCRIPTION
## Summary\n- Remove the stale "now" wording from the top-level README project description.\n\n## Verification\n- 