### PR TITLE
[codex] type landing URLs

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import type { ReactElement } from "react";
 
-const docsUrl = "https://docs.openrecorder.xyz/";
-const sourceUrl = "https://github.com/imbhargav5/open-recorder";
+const docsUrl: string = "https://docs.openrecorder.xyz/";
+const sourceUrl: string = "https://github.com/imbhargav5/open-recorder";
 
 type ProofPoint = readonly [value: string, label: string];
 


### PR DESCRIPTION
Annotate the landing page URL constants with explicit `string` types.

Why:
- Keeps the intent of the shared URLs obvious in the landing page entrypoint.
- No runtime behavior changes.

Verification:
- `pnpm --dir apps/landing lint`
- `pnpm --dir apps/landing build`
