### PR TITLE
chore: clarify thumbnail cursor comment

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -706,7 +706,8 @@ final class CaptureController: ObservableObject {
         configuration.height = max(Int(size.height), 1)
         configuration.scalesToFit = true
         configuration.preservesAspectRatio = true
-        // ScreenCaptureKit thumbnail captures stay cursor-free.
+        // Keep thumbnail captures cursor-free so the snapshot matches the raw frame;
+        // cursor overlays are applied later in playback and export.
         configuration.showsCursor = false
         configuration.shouldBeOpaque = true
         configuration.ignoreShadowsSingleWindow = ignoreWindowShadow


### PR DESCRIPTION
Clarify the thumbnail capture comment in the macOS capture controller so it explicitly states that cursor overlays are applied later in playback and export.\n\nVerification: cd apps/macos && swift test --filter NativeScreenRecorderConfigurationTests