### PR TITLE
Consolidate macOS state ownership

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -8,59 +8,92 @@ import UniformTypeIdentifiers
 final class AppModel: ObservableObject {
     var selectedSection: AppSection {
         get { appShell.state.selectedSection }
-        set { mutateAppShellState { $0.selectedSection = newValue } }
+        set { sendAppShell(.sectionSelected(newValue)) }
     }
     @Published private(set) var captureState: CaptureState = .choosingMode
     var paths: AppPaths? {
         get { appShell.state.paths }
-        set { mutateAppShellState { $0.paths = newValue } }
+        set { sendAppShell(.pathsChanged(newValue)) }
     }
     var projects: [ProjectSummary] {
         get { appShell.state.projects }
-        set { mutateAppShellState { $0.projects = newValue } }
+        set { sendAppShell(.projectsReplaced(newValue)) }
     }
     var currentVideoURL: URL? {
         get { appShell.state.currentVideoURL }
-        set { mutateAppShellState { $0.currentVideoURL = newValue } }
+        set { sendAppShell(.currentVideoURLChanged(newValue)) }
     }
     var currentScreenshotURL: URL? {
         get { appShell.state.currentScreenshotURL }
-        set { mutateAppShellState { $0.currentScreenshotURL = newValue } }
+        set { sendAppShell(.currentScreenshotURLChanged(newValue)) }
     }
     var lastEditorSession: EditorSession? {
-        get { appShell.state.lastEditorSession }
-        set { mutateAppShellState { $0.lastEditorSession = newValue } }
+        appShell.state.lastEditorSession
     }
     var statusMessage: String {
         get { appShell.state.statusMessage }
-        set { mutateAppShellState { $0.statusMessage = newValue } }
+        set { sendAppShell(.statusChanged(newValue)) }
     }
     var serviceHealth: HealthPayload? {
-        get { appShell.state.serviceHealth }
-        set { mutateAppShellState { $0.serviceHealth = newValue } }
+        appShell.state.serviceHealth
     }
-    @Published var includeMicrophone = false
-    @Published var includeSystemAudio = false
-    @Published var includeCamera = false
-    @Published var showCursor = true
-    @Published var showClicks = false
-    @Published var createZoomsAutomatically: Bool {
-        didSet {
-            UserDefaults.standard.set(createZoomsAutomatically, forKey: Self.createZoomsAutomaticallyDefaultsKey)
+    var includeMicrophone: Bool {
+        get { captureOptions.state.includeMicrophone }
+        set { captureOptions.send(.microphoneEnabledChanged(newValue)) }
+    }
+    var includeSystemAudio: Bool {
+        get { captureOptions.state.includeSystemAudio }
+        set { captureOptions.send(.systemAudioChanged(newValue)) }
+    }
+    var includeCamera: Bool {
+        get { captureOptions.state.includeCamera }
+        set { captureOptions.send(.cameraEnabledChanged(newValue)) }
+    }
+    var showCursor: Bool {
+        get { captureOptions.state.showCursor }
+        set { captureOptions.send(.cursorVisibilityChanged(newValue)) }
+    }
+    var showClicks: Bool {
+        get { captureOptions.state.showClicks }
+        set { captureOptions.send(.clickVisibilityChanged(newValue)) }
+    }
+    var createZoomsAutomatically: Bool {
+        get { appShell.settings.state.createZoomsAutomatically }
+        set { appShell.settings.send(.autoZoomPreferenceChanged(newValue)) }
+    }
+    var autoZoomAnimationPreset: TimelineZoomAnimationPreset {
+        get { appShell.settings.state.autoZoomAnimationPreset }
+        set { appShell.settings.send(.autoZoomAnimationPresetChanged(newValue)) }
+    }
+    var microphoneDevices: [CaptureDeviceInfo] {
+        get { captureOptions.state.microphoneDevices }
+        set {
+            captureOptions.send(.devicesRefreshed(
+                microphones: newValue,
+                cameras: captureOptions.state.cameraDevices
+            ))
         }
     }
-    @Published var autoZoomAnimationPreset: TimelineZoomAnimationPreset {
-        didSet {
-            UserDefaults.standard.set(autoZoomAnimationPreset.rawValue, forKey: Self.autoZoomAnimationPresetDefaultsKey)
+    var cameraDevices: [CaptureDeviceInfo] {
+        get { captureOptions.state.cameraDevices }
+        set {
+            captureOptions.send(.devicesRefreshed(
+                microphones: captureOptions.state.microphoneDevices,
+                cameras: newValue
+            ))
         }
     }
-    @Published var microphoneDevices: [CaptureDeviceInfo] = []
-    @Published var cameraDevices: [CaptureDeviceInfo] = []
-    @Published var selectedMicrophoneDeviceID: String?
-    @Published var selectedCameraDeviceID: String?
-    @Published var screenRecordingPermissionState: ScreenRecordingPermissionState
-    @Published var accessibilityPermissionState: AccessibilityPermissionState
-    @Published var onboardingStatusMessage = ""
+    var selectedMicrophoneDeviceID: String? { captureOptions.state.selectedMicrophoneDeviceID }
+    var selectedCameraDeviceID: String? { captureOptions.state.selectedCameraDeviceID }
+    var screenRecordingPermissionState: ScreenRecordingPermissionState {
+        appShell.onboarding.state.screenRecordingPermissionState
+    }
+    var accessibilityPermissionState: AccessibilityPermissionState {
+        appShell.onboarding.state.accessibilityPermissionState
+    }
+    var onboardingStatusMessage: String {
+        appShell.onboarding.state.statusMessage
+    }
 
     private var activeScreenStartedAt: Date?
     private var activeFacecamStartedAt: Date?
@@ -75,10 +108,11 @@ final class AppModel: ObservableObject {
     let appShell = AppShellDriver()
     var captureMachine: CaptureDriver { appShell.capture }
     var captureOptions: CaptureOptionsDriver { appShell.captureOptions }
-    var videoExport: VideoExportDriver { appShell.videoExport }
+    var videoExport: VideoExportDriver { appShell.workspace(for: nil).videoExport }
     private let screenRecordingPermission: ScreenRecordingPermission
     private let accessibilityPermission: AccessibilityPermission
     private let onboardingStore: OnboardingStateStore
+    private let recordingPreferences: RecordingPreferencesStore
     private let screenSelectionPresenter: ScreenSelectionPresenting
     private let screenshotCapture: @MainActor (CaptureSource, URL) throws -> Void
     private let startRecordingCapture: @MainActor (CaptureSource, URL, RecordingCaptureOptions) async throws -> Date
@@ -96,13 +130,11 @@ final class AppModel: ObservableObject {
     private let captureDeviceProvider = CaptureDeviceProvider()
     private var nativeWindowCommandHandler: (NativeWindowCommand) -> Void = { _ in }
     private var runRecordingCountdown: @MainActor (CaptureSource) async throws -> Void = { _ in }
-    private static let createZoomsAutomaticallyDefaultsKey = "recording.createZoomsAutomatically"
-    private static let autoZoomAnimationPresetDefaultsKey = "recording.autoZoomAnimationPreset"
-
     init(
         screenRecordingPermission: ScreenRecordingPermission = ScreenRecordingPermission(),
         accessibilityPermission: AccessibilityPermission = AccessibilityPermission(),
         onboardingStore: OnboardingStateStore = .live,
+        recordingPreferences: RecordingPreferencesStore = RecordingPreferencesStore(),
         screenSelectionPresenter: ScreenSelectionPresenting = ScreenSelectionOverlayController(),
         captureUIHideDelayNanoseconds: UInt64 = 180_000_000,
         screenshotCapture: (@MainActor (CaptureSource, URL) throws -> Void)? = nil,
@@ -120,14 +152,12 @@ final class AppModel: ObservableObject {
     ) {
         let service = RustServiceClient()
         let capture = CaptureController(screenRecordingPermission: screenRecordingPermission)
-        self.createZoomsAutomatically = UserDefaults.standard.object(forKey: Self.createZoomsAutomaticallyDefaultsKey) as? Bool ?? true
-        self.autoZoomAnimationPreset = TimelineZoomAnimationPreset.storedValue(
-            UserDefaults.standard.string(forKey: Self.autoZoomAnimationPresetDefaultsKey)
-        )
+        let preferences = recordingPreferences.load()
         self.service = service
         self.screenRecordingPermission = screenRecordingPermission
         self.accessibilityPermission = accessibilityPermission
         self.onboardingStore = onboardingStore
+        self.recordingPreferences = recordingPreferences
         self.screenSelectionPresenter = screenSelectionPresenter
         self.captureUIHideDelayNanoseconds = captureUIHideDelayNanoseconds
         self.capture = capture
@@ -166,15 +196,13 @@ final class AppModel: ObservableObject {
         self.runRecordingCountdown = runRecordingCountdown ?? { [countdownOverlayController] source in
             try await countdownOverlayController.run(for: source)
         }
-        self.screenRecordingPermissionState = screenRecordingPermission.currentState()
-        self.accessibilityPermissionState = accessibilityPermission.currentState()
         appShell.configure(
             refreshBackend: { [weak self] in
                 self?.refreshBackendState()
             },
             emitWindowCommand: { _ in },
-            setStatusMessage: { [weak self] message in
-                self?.statusMessage = message
+            configureWorkspace: { [weak self] workspace in
+                self?.configureEditorWorkspace(workspace)
             }
         )
         captureMachine.configure(
@@ -182,7 +210,6 @@ final class AppModel: ObservableObject {
                 guard let self else { return }
                 self.captureState = transition.state
                 self.captureOptions.send(.availabilityChanged(self.canChangeRecordingOptions))
-                self.syncCaptureOptionsMirror()
                 if let message = transition.statusMessage {
                     self.statusMessage = message
                 }
@@ -251,19 +278,24 @@ final class AppModel: ObservableObject {
             },
             setStatusMessage: { [weak self] message in
                 self?.statusMessage = message
+            },
+            stateWillChange: { [weak self] in
+                self?.objectWillChange.send()
             }
         )
         appShell.onboarding.configure(
             currentPermissions: { [weak self] in
                 guard let self else { return (.requestAvailable, .requestAvailable) }
-                self.refreshOnboardingPermissionStates()
-                return (self.screenRecordingPermissionState, self.accessibilityPermissionState)
+                return (
+                    self.screenRecordingPermission.currentState(),
+                    self.accessibilityPermission.currentState()
+                )
             },
             requestScreenPermission: { [weak self] in
-                self?.requestOnboardingScreenRecordingPermission() ?? .promptAlreadyShown
+                self?.requestScreenRecordingPermission() ?? .promptAlreadyShown
             },
             requestAccessibilityPermission: { [weak self] in
-                self?.requestOnboardingAccessibilityPermission() ?? .promptAlreadyShown
+                self?.requestAccessibilityPermission() ?? .promptAlreadyShown
             },
             openScreenRecordingSettings: { [weak self] in
                 self?.openPrivacySettings()
@@ -272,23 +304,26 @@ final class AppModel: ObservableObject {
                 self?.openAccessibilitySettings()
             },
             completeOnboarding: { [weak self] in
-                self?.completeOnboarding() ?? false
+                self?.persistCompletedOnboarding() ?? false
+            },
+            stateWillChange: { [weak self] in
+                self?.objectWillChange.send()
             }
         )
         appShell.settings.configure(
             refreshService: { [weak self] in
                 guard let self else { return }
                 if self.refreshBackendState() {
-                    self.appShell.settings.send(.serviceRefreshSucceeded(serviceHealth: self.serviceHealth, paths: self.paths))
+                    self.appShell.settings.send(.serviceRefreshSucceeded)
                 } else {
                     self.appShell.settings.send(.serviceRefreshFailed(self.statusMessage))
                 }
             },
             persistAutoZoomPreference: { [weak self] value in
-                self?.createZoomsAutomatically = value
+                self?.recordingPreferences.setCreatesZoomsAutomatically(value)
             },
             persistAutoZoomAnimationPreset: { [weak self] preset in
-                self?.autoZoomAnimationPreset = preset
+                self?.recordingPreferences.setAutoZoomAnimationPreset(preset)
             },
             openFolder: { [weak self] path in
                 self?.openPath(path)
@@ -301,9 +336,27 @@ final class AppModel: ObservableObject {
             },
             showOnboarding: { [weak self] in
                 self?.showOnboarding()
+            },
+            stateWillChange: { [weak self] in
+                self?.objectWillChange.send()
             }
         )
-        videoExport.configure(
+        appShell.settings.send(.autoZoomPreferenceSynced(preferences.createsZoomsAutomatically))
+        appShell.settings.send(.autoZoomAnimationPresetSynced(preferences.autoZoomAnimationPreset))
+        refreshOnboardingPermissionStates()
+        syncAppShellMirror()
+    }
+
+    private func configureEditorWorkspace(_ workspace: EditorWorkspaceDriver) {
+        workspace.configure(
+            setAppSection: { [weak self] section in
+                self?.selectedSection = section
+            },
+            setStatusMessage: { [weak self] message in
+                self?.statusMessage = message
+            }
+        )
+        workspace.videoExport.configure(
             renderVideo: { sourceURL, targetURL, options, cancellationToken, edits, progressHandler in
                 try await VideoExportRenderer.export(
                     sourceURL: sourceURL,
@@ -335,14 +388,14 @@ final class AppModel: ObservableObject {
             revealFile: { url in
                 NSWorkspace.shared.activateFileViewerSelecting([url])
             },
-            setStatusMessage: { [weak self] message in
-                self?.statusMessage = message
+            setStatusMessage: { [weak workspace] message in
+                guard let workspace else { return }
+                workspace.send(.statusUpdated(EditorWorkspaceStatus(
+                    message: message,
+                    severity: workspace.videoExport.state.phase.editorWorkspaceStatusSeverity
+                )))
             }
         )
-        appShell.settings.send(.autoZoomPreferenceSynced(createZoomsAutomatically))
-        appShell.settings.send(.autoZoomAnimationPresetSynced(autoZoomAnimationPreset))
-        syncAppShellMirror()
-        syncCaptureOptionsMirror()
     }
 
     var captureMode: CaptureMode {
@@ -377,7 +430,6 @@ final class AppModel: ObservableObject {
         captureMachine.setStateForTesting(state)
         captureState = state
         captureOptions.send(.availabilityChanged(canChangeRecordingOptions))
-        syncCaptureOptionsMirror()
     }
 
     private func sendAppShell(_ event: AppShellEvent) {
@@ -391,17 +443,7 @@ final class AppModel: ObservableObject {
     }
 
     private func syncAppShellMirror() {
-        syncSettingsDriverFromShell()
         objectWillChange.send()
-    }
-
-    private func mutateAppShellState(_ update: (inout AppShellState) -> Void) {
-        update(&appShell.state)
-        syncAppShellMirror()
-    }
-
-    private func syncSettingsDriverFromShell() {
-        appShell.settings.send(.appeared(serviceHealth: serviceHealth, paths: paths))
     }
 
     var captureFlow: CaptureFlow {
@@ -430,24 +472,14 @@ final class AppModel: ObservableObject {
     }
 
     var canContinueOnboarding: Bool {
-        screenRecordingPermissionState == .granted
+        appShell.onboarding.state.canContinue
     }
 
     func refreshOnboardingPermissionStates() {
-        let nextScreenRecordingPermissionState = screenRecordingPermission.currentState()
-        let nextAccessibilityPermissionState = accessibilityPermission.currentState()
-
-        if screenRecordingPermissionState != nextScreenRecordingPermissionState {
-            screenRecordingPermissionState = nextScreenRecordingPermissionState
-        }
-
-        if accessibilityPermissionState != nextAccessibilityPermissionState {
-            accessibilityPermissionState = nextAccessibilityPermissionState
-        }
-
-        if canContinueOnboarding && onboardingStatusMessage.localizedCaseInsensitiveContains("required") {
-            onboardingStatusMessage = ""
-        }
+        appShell.onboarding.send(.permissionsRefreshed(
+            screen: screenRecordingPermission.currentState(),
+            accessibility: accessibilityPermission.currentState()
+        ))
     }
 
     func presentOnboardingIfNeeded() {
@@ -465,48 +497,36 @@ final class AppModel: ObservableObject {
 
     @discardableResult
     func requestOnboardingScreenRecordingPermission() -> ScreenRecordingPermissionRequestOutcome {
+        let outcome = requestScreenRecordingPermission()
+        appShell.onboarding.send(.screenPermissionRequested(outcome))
+        return outcome
+    }
+
+    private func requestScreenRecordingPermission() -> ScreenRecordingPermissionRequestOutcome {
         switch screenRecordingPermission.currentState() {
         case .granted:
-            onboardingStatusMessage = "Screen Recording is enabled."
             return .granted
         case .requestAvailable:
-            let outcome = screenRecordingPermission.requestGrant()
-            switch outcome {
-            case .granted:
-                onboardingStatusMessage = "Screen Recording is enabled."
-            case .promptShownWithoutGrant, .promptAlreadyShown:
-                onboardingStatusMessage = "Enable Screen Recording in System Settings, then quit and reopen Open Recorder if macOS asks."
-            }
-            refreshOnboardingPermissionStates()
-            return outcome
+            return screenRecordingPermission.requestGrant()
         case .requestAlreadyShown:
-            onboardingStatusMessage = "Enable Screen Recording in System Settings, then quit and reopen Open Recorder if macOS asks."
-            openPrivacySettings()
-            refreshOnboardingPermissionStates()
             return .promptAlreadyShown
         }
     }
 
     @discardableResult
     func requestOnboardingAccessibilityPermission() -> AccessibilityPermissionRequestOutcome {
+        let outcome = requestAccessibilityPermission()
+        appShell.onboarding.send(.accessibilityPermissionRequested(outcome))
+        return outcome
+    }
+
+    private func requestAccessibilityPermission() -> AccessibilityPermissionRequestOutcome {
         switch accessibilityPermission.currentState() {
         case .granted:
-            onboardingStatusMessage = "Accessibility access is enabled."
             return .granted
         case .requestAvailable:
-            let outcome = accessibilityPermission.requestGrant()
-            switch outcome {
-            case .granted:
-                onboardingStatusMessage = "Accessibility access is enabled."
-            case .promptShownWithoutGrant, .promptAlreadyShown:
-                onboardingStatusMessage = "Enable Accessibility access in System Settings to capture shortcuts and cursor details."
-            }
-            refreshOnboardingPermissionStates()
-            return outcome
+            return accessibilityPermission.requestGrant()
         case .requestAlreadyShown:
-            onboardingStatusMessage = "Enable Accessibility access in System Settings to capture shortcuts and cursor details."
-            openAccessibilitySettings()
-            refreshOnboardingPermissionStates()
             return .promptAlreadyShown
         }
     }
@@ -514,13 +534,13 @@ final class AppModel: ObservableObject {
     @discardableResult
     func completeOnboarding() -> Bool {
         refreshOnboardingPermissionStates()
-        guard canContinueOnboarding else {
-            onboardingStatusMessage = "Screen Recording permission is required before continuing."
-            return false
-        }
+        let canComplete = canContinueOnboarding
+        appShell.onboarding.send(.continueRequested)
+        return canComplete
+    }
 
+    private func persistCompletedOnboarding() -> Bool {
         onboardingStore.setCompleted(true)
-        onboardingStatusMessage = ""
         statusMessage = "Ready"
         setCaptureStateMirror(captureState.withPresentation(.visible))
         requestWindow(.finishOnboarding)
@@ -846,7 +866,6 @@ final class AppModel: ObservableObject {
                     try await prepareFacecam(cameraDeviceID: options.cameraDeviceID)
                 } catch {
                     captureOptions.send(.cameraDisabled)
-                    syncCaptureOptionsMirror()
                     options = currentCaptureOptions
                     statusMessage = "Recording without facecam: \(error.localizedDescription)"
                 }
@@ -870,7 +889,6 @@ final class AppModel: ObservableObject {
                     activeFacecamURL = url
                 } catch {
                     captureOptions.send(.cameraDisabled)
-                    syncCaptureOptionsMirror()
                     options = currentCaptureOptions
                     try? FileManager.default.removeItem(at: url)
                     activeFacecamURL = nil
@@ -1248,14 +1266,8 @@ final class AppModel: ObservableObject {
     }
 
     func handleProjectAutosaveStatus(_ status: ProjectAutosaveStatus) {
-        switch status {
-        case .saving:
-            statusMessage = "Saving..."
-        case .saved(let summary):
+        if case .saved(let summary) = status {
             upsertProjectSummary(summary)
-            statusMessage = "Saved"
-        case .failed(let message):
-            statusMessage = "Autosave failed: \(message)"
         }
     }
 
@@ -1394,7 +1406,6 @@ final class AppModel: ObservableObject {
         let microphones = captureDeviceProvider.devices(for: .audio)
         let cameras = captureDeviceProvider.devices(for: .video)
         captureOptions.send(.devicesRefreshed(microphones: microphones, cameras: cameras))
-        syncCaptureOptionsMirror()
     }
 
     func requestMicrophoneSelection(refreshDevices: Bool = true) {
@@ -1402,7 +1413,6 @@ final class AppModel: ObservableObject {
             refreshCaptureDevices()
         }
         captureOptions.send(.microphoneSelectionRequested)
-        syncCaptureOptionsMirror()
     }
 
     func requestCameraSelection(refreshDevices: Bool = true) {
@@ -1410,7 +1420,6 @@ final class AppModel: ObservableObject {
             refreshCaptureDevices()
         }
         captureOptions.send(.cameraSelectionRequested)
-        syncCaptureOptionsMirror()
     }
 
     func cancelMicrophoneSelection() {
@@ -1422,15 +1431,11 @@ final class AppModel: ObservableObject {
     }
 
     func selectMicrophoneDevice(_ deviceID: String?) {
-        syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.microphoneSelected(deviceID))
-        syncCaptureOptionsMirror()
     }
 
     func selectCameraDevice(_ deviceID: String?) {
-        syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.cameraSelected(deviceID))
-        syncCaptureOptionsMirror()
         prewarmSelectedFacecamIfNeeded()
     }
 
@@ -1445,22 +1450,16 @@ final class AppModel: ObservableObject {
     }
 
     func disableMicrophone() {
-        syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.microphoneDisabled)
-        syncCaptureOptionsMirror()
     }
 
     func toggleSystemAudio() {
-        syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.availabilityChanged(canChangeRecordingOptions))
         captureOptions.send(.systemAudioToggled)
-        syncCaptureOptionsMirror()
     }
 
     func disableCamera() {
-        syncCaptureOptionsDriverFromMirror()
         captureOptions.send(.cameraDisabled)
-        syncCaptureOptionsMirror()
         cancelFacecamPrewarm()
     }
 
@@ -1470,32 +1469,6 @@ final class AppModel: ObservableObject {
 
     var selectedCameraDeviceName: String {
         captureOptions.state.selectedCameraDeviceName
-    }
-
-    private func syncCaptureOptionsMirror() {
-        let options = captureOptions.state
-        includeMicrophone = options.includeMicrophone
-        includeSystemAudio = options.includeSystemAudio
-        includeCamera = options.includeCamera
-        showCursor = options.showCursor
-        showClicks = options.showClicks
-        microphoneDevices = options.microphoneDevices
-        cameraDevices = options.cameraDevices
-        selectedMicrophoneDeviceID = options.selectedMicrophoneDeviceID
-        selectedCameraDeviceID = options.selectedCameraDeviceID
-    }
-
-    private func syncCaptureOptionsDriverFromMirror() {
-        captureOptions.state.includeMicrophone = includeMicrophone
-        captureOptions.state.includeSystemAudio = includeSystemAudio
-        captureOptions.state.includeCamera = includeCamera
-        captureOptions.state.showCursor = showCursor
-        captureOptions.state.showClicks = showClicks
-        captureOptions.state.microphoneDevices = microphoneDevices
-        captureOptions.state.cameraDevices = cameraDevices
-        captureOptions.state.selectedMicrophoneDeviceID = selectedMicrophoneDeviceID
-        captureOptions.state.selectedCameraDeviceID = selectedCameraDeviceID
-        captureOptions.state.canChangeOptions = canChangeRecordingOptions
     }
 
     private var currentCaptureOptions: RecordingCaptureOptions {

--- a/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
@@ -48,6 +48,9 @@ struct CaptureOptionsState: Equatable {
 
 enum CaptureOptionsEvent: Equatable {
     case availabilityChanged(Bool)
+    case microphoneEnabledChanged(Bool)
+    case systemAudioChanged(Bool)
+    case cameraEnabledChanged(Bool)
     case devicesRefreshed(microphones: [CaptureDeviceInfo], cameras: [CaptureDeviceInfo])
     case systemAudioToggled
     case microphoneSelectionRequested
@@ -75,6 +78,18 @@ extension CaptureOptionsState {
         switch event {
         case .availabilityChanged(let canChange):
             canChangeOptions = canChange
+            return []
+
+        case .microphoneEnabledChanged(let isEnabled):
+            includeMicrophone = isEnabled
+            return []
+
+        case .systemAudioChanged(let isEnabled):
+            includeSystemAudio = isEnabled
+            return []
+
+        case .cameraEnabledChanged(let isEnabled):
+            includeCamera = isEnabled
             return []
 
         case .devicesRefreshed(let microphones, let cameras):
@@ -151,24 +166,33 @@ extension CaptureOptionsState {
 @Observable
 @MainActor
 final class CaptureOptionsDriver {
-    var state = CaptureOptionsState()
+    private(set) var state = CaptureOptionsState()
 
     @ObservationIgnored private var refreshDevices: () -> (microphones: [CaptureDeviceInfo], cameras: [CaptureDeviceInfo]) = { ([], []) }
     @ObservationIgnored private var requestWindow: (NativeWindowCommandAction) -> Void = { _ in }
     @ObservationIgnored private var setStatusMessage: (String) -> Void = { _ in }
+    @ObservationIgnored private var stateWillChange: () -> Void = {}
 
     func configure(
         refreshDevices: @escaping () -> (microphones: [CaptureDeviceInfo], cameras: [CaptureDeviceInfo]) = { ([], []) },
         requestWindow: @escaping (NativeWindowCommandAction) -> Void = { _ in },
-        setStatusMessage: @escaping (String) -> Void = { _ in }
+        setStatusMessage: @escaping (String) -> Void = { _ in },
+        stateWillChange: @escaping () -> Void = {}
     ) {
         self.refreshDevices = refreshDevices
         self.requestWindow = requestWindow
         self.setStatusMessage = setStatusMessage
+        self.stateWillChange = stateWillChange
     }
 
     func send(_ event: CaptureOptionsEvent) {
-        perform(state.applying(event))
+        var nextState = state
+        let effects = nextState.applying(event)
+        if nextState != state {
+            stateWillChange()
+            state = nextState
+        }
+        perform(effects)
     }
 
     func binding(_ keyPath: WritableKeyPath<CaptureOptionsState, Bool>) -> Binding<Bool> {
@@ -176,12 +200,20 @@ final class CaptureOptionsDriver {
             get: { self.state[keyPath: keyPath] },
             set: { value in
                 switch keyPath {
+                case \.includeMicrophone:
+                    self.send(.microphoneEnabledChanged(value))
+                case \.includeSystemAudio:
+                    self.send(.systemAudioChanged(value))
+                case \.includeCamera:
+                    self.send(.cameraEnabledChanged(value))
                 case \.showCursor:
                     self.send(.cursorVisibilityChanged(value))
                 case \.showClicks:
                     self.send(.clickVisibilityChanged(value))
+                case \.canChangeOptions:
+                    self.send(.availabilityChanged(value))
                 default:
-                    self.state[keyPath: keyPath] = value
+                    assertionFailure("Unsupported capture-options binding")
                 }
             }
         )
@@ -231,6 +263,7 @@ struct SourceSelectorState: Equatable {
 }
 
 enum SourceSelectorEvent: Equatable {
+    case visibleTabsChanged([SourceSelectorTab])
     case tabSelected(SourceSelectorTab)
     case preferredSourceKindSynced(CaptureSourceKind?)
     case heightMeasured(CGFloat)
@@ -250,6 +283,13 @@ enum SourceSelectorEffect: Equatable {
 extension SourceSelectorState {
     mutating func applying(_ event: SourceSelectorEvent) -> [SourceSelectorEffect] {
         switch event {
+        case .visibleTabsChanged(let tabs):
+            visibleTabs = tabs
+            if !visibleTabs.contains(sourceTab), let firstTab = visibleTabs.first {
+                sourceTab = firstTab
+            }
+            return []
+
         case .tabSelected(let tab):
             guard visibleTabs.contains(tab) else { return [] }
             sourceTab = tab
@@ -282,7 +322,7 @@ extension SourceSelectorState {
 @Observable
 @MainActor
 final class SourceSelectorDriver {
-    var state: SourceSelectorState
+    private(set) var state: SourceSelectorState
 
     @ObservationIgnored private var refreshSources: () -> Void = {}
     @ObservationIgnored private var cancel: () -> Void = {}
@@ -434,7 +474,7 @@ extension OnboardingMachineState {
 @Observable
 @MainActor
 final class OnboardingDriver {
-    var state: OnboardingMachineState
+    private(set) var state: OnboardingMachineState
 
     @ObservationIgnored private var currentPermissions: () -> (screen: ScreenRecordingPermissionState, accessibility: AccessibilityPermissionState)
     @ObservationIgnored private var requestScreenPermission: () -> ScreenRecordingPermissionRequestOutcome
@@ -442,6 +482,7 @@ final class OnboardingDriver {
     @ObservationIgnored private var openScreenRecordingSettings: () -> Void
     @ObservationIgnored private var openAccessibilitySettings: () -> Void
     @ObservationIgnored private var completeOnboarding: () -> Bool
+    @ObservationIgnored private var stateWillChange: () -> Void = {}
 
     init(
         screenRecordingPermissionState: ScreenRecordingPermissionState,
@@ -465,7 +506,8 @@ final class OnboardingDriver {
         requestAccessibilityPermission: @escaping () -> AccessibilityPermissionRequestOutcome,
         openScreenRecordingSettings: @escaping () -> Void,
         openAccessibilitySettings: @escaping () -> Void,
-        completeOnboarding: @escaping () -> Bool
+        completeOnboarding: @escaping () -> Bool,
+        stateWillChange: @escaping () -> Void = {}
     ) {
         self.currentPermissions = currentPermissions
         self.requestScreenPermission = requestScreenPermission
@@ -473,10 +515,17 @@ final class OnboardingDriver {
         self.openScreenRecordingSettings = openScreenRecordingSettings
         self.openAccessibilitySettings = openAccessibilitySettings
         self.completeOnboarding = completeOnboarding
+        self.stateWillChange = stateWillChange
     }
 
     func send(_ event: OnboardingEvent) {
-        perform(state.applying(event))
+        var nextState = state
+        let effects = nextState.applying(event)
+        if nextState != state {
+            stateWillChange()
+            state = nextState
+        }
+        perform(effects)
     }
 
     private func perform(_ effects: [OnboardingEffect]) {
@@ -503,8 +552,6 @@ final class OnboardingDriver {
 }
 
 struct SettingsMachineState: Equatable {
-    var serviceHealth: HealthPayload?
-    var paths: AppPaths?
     var createZoomsAutomatically: Bool
     var autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced
     var statusMessage = ""
@@ -512,9 +559,8 @@ struct SettingsMachineState: Equatable {
 }
 
 enum SettingsEvent: Equatable {
-    case appeared(serviceHealth: HealthPayload?, paths: AppPaths?)
     case serviceRefreshRequested
-    case serviceRefreshSucceeded(serviceHealth: HealthPayload?, paths: AppPaths?)
+    case serviceRefreshSucceeded
     case serviceRefreshFailed(String)
     case autoZoomPreferenceSynced(Bool)
     case autoZoomPreferenceChanged(Bool)
@@ -539,20 +585,13 @@ enum SettingsEffect: Equatable {
 extension SettingsMachineState {
     mutating func applying(_ event: SettingsEvent) -> [SettingsEffect] {
         switch event {
-        case .appeared(let serviceHealth, let paths):
-            self.serviceHealth = serviceHealth
-            self.paths = paths
-            return []
-
         case .serviceRefreshRequested:
             isRefreshingService = true
             statusMessage = "Checking service..."
             return [.refreshService]
 
-        case .serviceRefreshSucceeded(let serviceHealth, let paths):
+        case .serviceRefreshSucceeded:
             isRefreshingService = false
-            self.serviceHealth = serviceHealth
-            self.paths = paths
             statusMessage = "Rust service ready"
             return []
 
@@ -598,7 +637,7 @@ extension SettingsMachineState {
 @Observable
 @MainActor
 final class SettingsDriver {
-    var state: SettingsMachineState
+    private(set) var state: SettingsMachineState
 
     @ObservationIgnored private var refreshService: () -> Void = {}
     @ObservationIgnored private var persistAutoZoomPreference: (Bool) -> Void = { _ in }
@@ -607,6 +646,7 @@ final class SettingsDriver {
     @ObservationIgnored private var openScreenRecordingSettings: () -> Void = {}
     @ObservationIgnored private var openAccessibilitySettings: () -> Void = {}
     @ObservationIgnored private var showOnboarding: () -> Void = {}
+    @ObservationIgnored private var stateWillChange: () -> Void = {}
 
     init(createZoomsAutomatically: Bool, autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced) {
         state = SettingsMachineState(
@@ -622,7 +662,8 @@ final class SettingsDriver {
         openFolder: @escaping (String) -> Void = { _ in },
         openScreenRecordingSettings: @escaping () -> Void = {},
         openAccessibilitySettings: @escaping () -> Void = {},
-        showOnboarding: @escaping () -> Void = {}
+        showOnboarding: @escaping () -> Void = {},
+        stateWillChange: @escaping () -> Void = {}
     ) {
         self.refreshService = refreshService
         self.persistAutoZoomPreference = persistAutoZoomPreference
@@ -631,10 +672,17 @@ final class SettingsDriver {
         self.openScreenRecordingSettings = openScreenRecordingSettings
         self.openAccessibilitySettings = openAccessibilitySettings
         self.showOnboarding = showOnboarding
+        self.stateWillChange = stateWillChange
     }
 
     func send(_ event: SettingsEvent) {
-        perform(state.applying(event))
+        var nextState = state
+        let effects = nextState.applying(event)
+        if nextState != state {
+            stateWillChange()
+            state = nextState
+        }
+        perform(effects)
     }
 
     var autoZoomBinding: Binding<Bool> {

--- a/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
@@ -44,6 +44,9 @@ enum AppShellEvent: Equatable {
     case bootstrapRequested
     case sectionSelected(AppSection)
     case statusChanged(String)
+    case pathsChanged(AppPaths?)
+    case currentVideoURLChanged(URL?)
+    case currentScreenshotURLChanged(URL?)
     case windowCommandRequested(NativeWindowCommandAction, editorSession: EditorSession? = nil)
     case windowCommandConsumed(UUID?)
     case backendRefreshed(paths: AppPaths?, projects: [ProjectSummary], health: HealthPayload?)
@@ -77,6 +80,21 @@ extension AppShellState {
             guard statusMessage != message else { return [] }
             statusMessage = message
             return [.setStatusMessage(message)]
+
+        case .pathsChanged(let paths):
+            guard self.paths != paths else { return [] }
+            self.paths = paths
+            return []
+
+        case .currentVideoURLChanged(let url):
+            guard currentVideoURL != url else { return [] }
+            currentVideoURL = url
+            return []
+
+        case .currentScreenshotURLChanged(let url):
+            guard currentScreenshotURL != url else { return [] }
+            currentScreenshotURL = url
+            return []
 
         case .windowCommandRequested(let action, let editorSession):
             let command = NativeWindowCommand(action: action, editorSession: editorSession)
@@ -146,8 +164,8 @@ extension AppShellState {
 @Observable
 @MainActor
 final class AppShellDriver {
-    var state = AppShellState()
-    let workspace = EditorWorkspaceDriver()
+    private(set) var state = AppShellState()
+    @ObservationIgnored private let workspaces = EditorWorkspaceRegistry()
     let capture = CaptureDriver()
     let captureOptions = CaptureOptionsDriver()
     let inlineSourceSelector = SourceSelectorDriver(sourceTab: .screens)
@@ -157,9 +175,6 @@ final class AppShellDriver {
         accessibilityPermissionState: .requestAvailable
     )
     let settings = SettingsDriver(createZoomsAutomatically: false)
-    let videoExport = VideoExportDriver()
-
-    @ObservationIgnored private var editorWorkspacesBySessionID: [UUID: EditorWorkspaceDriver] = [:]
     @ObservationIgnored private var refreshBackend: () -> Void = {}
     @ObservationIgnored private var emitWindowCommand: (NativeWindowCommand) -> Void = { _ in }
     @ObservationIgnored private var openEditorSession: (EditorSession) -> Void = { _ in }
@@ -169,27 +184,48 @@ final class AppShellDriver {
         refreshBackend: @escaping () -> Void = {},
         emitWindowCommand: @escaping (NativeWindowCommand) -> Void = { _ in },
         openEditorSession: @escaping (EditorSession) -> Void = { _ in },
-        setStatusMessage: @escaping (String) -> Void = { _ in }
+        setStatusMessage: @escaping (String) -> Void = { _ in },
+        configureWorkspace: @escaping (EditorWorkspaceDriver) -> Void = { _ in }
     ) {
         self.refreshBackend = refreshBackend
         self.emitWindowCommand = emitWindowCommand
         self.openEditorSession = openEditorSession
         self.setStatusMessage = setStatusMessage
+        workspaces.configure(configureWorkspace)
     }
 
     func workspace(for editorSession: EditorSession?) -> EditorWorkspaceDriver {
-        guard let editorSession else {
-            return workspace
-        }
-
-        if let workspace = editorWorkspacesBySessionID[editorSession.id] {
-            return workspace
-        }
-
-        let workspace = EditorWorkspaceDriver()
-        editorWorkspacesBySessionID[editorSession.id] = workspace
-        return workspace
+        workspaces.workspace(for: editorSession)
     }
+
+    func activateWorkspace(for editorSession: EditorSession?) {
+        workspaces.activate(sessionID: editorSession?.id)
+    }
+
+    @discardableResult
+    func closeWorkspace(for editorSession: EditorSession?) async -> EditorWorkspaceCloseOutcome {
+        return await workspaces.close(session: editorSession)
+    }
+
+    func beginClosingWorkspace(for editorSession: EditorSession?) -> EditorWorkspaceCloseRequest? {
+        return workspaces.beginClose(session: editorSession)
+    }
+
+    @discardableResult
+    func finishClosingWorkspace(_ request: EditorWorkspaceCloseRequest) async -> EditorWorkspaceCloseOutcome {
+        await workspaces.finishClose(request)
+    }
+
+    @discardableResult
+    func discardWorkspace(for editorSession: EditorSession?) -> Bool {
+        workspaces.discard(session: editorSession)
+    }
+
+    #if DEBUG
+    var sessionWorkspaceCountForTesting: Int {
+        workspaces.sessionCountForTesting
+    }
+    #endif
 
     func send(_ event: AppShellEvent) {
         perform(state.applying(event))

--- a/apps/macos/Sources/OpenRecorderMac/CaptureViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureViews.swift
@@ -60,7 +60,7 @@ struct CaptureStudioView: View {
                     sourceSelector.configure(refreshSources: {
                         model.reloadSourcesForPreview()
                     })
-                    sourceSelector.state.visibleTabs = visibleTabs
+                    sourceSelector.send(.visibleTabsChanged(visibleTabs))
                     model.reloadSourcesForPreview()
                 }
                 .onChange(of: model.preferredSourceSelectorKind) { _, kind in

--- a/apps/macos/Sources/OpenRecorderMac/ContentView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ContentView.swift
@@ -97,6 +97,10 @@ struct SettingsView: View {
     @EnvironmentObject private var model: AppModel
 
     var body: some View {
-        SettingsStudioView(driver: model.appShell.settings)
+        SettingsStudioView(
+            driver: model.appShell.settings,
+            serviceHealth: model.serviceHealth,
+            paths: model.paths
+        )
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
@@ -356,6 +356,7 @@ final class VideoEditorDriver {
     @ObservationIgnored private var pausePlayback: () -> Void = {}
     @ObservationIgnored private var exportVideo: (URL?, VideoExportOptions, TimelineEditSnapshot) -> Void = { _, _, _ in }
     @ObservationIgnored private var clearVideoExportDialogState: () -> Void = {}
+    @ObservationIgnored private var exportLaunchTask: Task<Void, Never>?
 
     func configure(
         applyTimelineSnapshot: @escaping (TimelineEditSnapshot) -> Void,
@@ -475,6 +476,27 @@ final class VideoEditorDriver {
         )
     }
 
+    func flushPendingAutosave() async -> Bool {
+        await autosave.flush()
+    }
+
+    var hasPendingAutosave: Bool {
+        autosave.hasPendingChanges
+    }
+
+    func abandonPendingAutosave() -> Bool {
+        autosave.abandonPendingChanges()
+    }
+
+    var canAbandonPendingAutosave: Bool {
+        autosave.canAbandonPendingChanges
+    }
+
+    func cancelPendingExportLaunch() {
+        exportLaunchTask?.cancel()
+        exportLaunchTask = nil
+    }
+
     private func updateVideoValue<Value: Equatable>(
         _ keyPath: WritableKeyPath<ProjectVideoEditorState, Value>,
         to value: Value
@@ -507,34 +529,29 @@ final class VideoEditorDriver {
             case .scheduleAutosave(let snapshot):
                 autosave.schedule(snapshot)
             case .flushAutosave(let snapshot):
-                Task { [weak self] in
-                    await self?.flushAutosave(snapshot)
+                let autosave = autosave
+                autosave.schedule(snapshot)
+                Task {
+                    await autosave.flush()
                 }
             case .pausePlayback:
                 pausePlayback()
             case .startVideoExport(let recordingURL, let options, let edits, let snapshot):
-                Task { [weak self] in
-                    await self?.flushAndExport(recordingURL: recordingURL, options: options, edits: edits, snapshot: snapshot)
+                cancelPendingExportLaunch()
+                let autosave = autosave
+                let exportVideo = exportVideo
+                exportLaunchTask = Task {
+                    await autosave.flush(snapshot)
+                    guard !Task.isCancelled else { return }
+                    exportVideo(recordingURL, options, edits)
                 }
             case .clearVideoExportDialogState:
+                cancelPendingExportLaunch()
                 clearVideoExportDialogState()
             }
         }
     }
 
-    private func flushAutosave(_ snapshot: ProjectAutosaveSnapshot?) async {
-        await autosave.flush(snapshot)
-    }
-
-    private func flushAndExport(
-        recordingURL: URL?,
-        options: VideoExportOptions,
-        edits: TimelineEditSnapshot,
-        snapshot: ProjectAutosaveSnapshot?
-    ) async {
-        await autosave.flush(snapshot)
-        exportVideo(recordingURL, options, edits)
-    }
 }
 
 struct ScreenshotEditorSessionContext: Equatable {
@@ -555,8 +572,68 @@ struct EditorExportRequest: Identifiable, Equatable {
     var editorSessionID: UUID?
 }
 
+enum EditorWorkspaceStatusSeverity: Equatable {
+    case none
+    case informational
+    case progress
+    case success
+    case failure
+}
+
+enum EditorWorkspaceStatusDomain: Equatable {
+    case general
+    case autosave
+}
+
+extension VideoExportPhase {
+    var editorWorkspaceStatusSeverity: EditorWorkspaceStatusSeverity {
+        switch self {
+        case .idle:
+            .none
+        case .exporting, .saving:
+            .progress
+        case .savePending:
+            .informational
+        case .success:
+            .success
+        case .failed:
+            .failure
+        }
+    }
+}
+
+struct EditorWorkspaceStatus: Equatable {
+    var message: String
+    var severity: EditorWorkspaceStatusSeverity
+    var domain: EditorWorkspaceStatusDomain
+    var failureDetail: String?
+
+    init(
+        message: String,
+        severity: EditorWorkspaceStatusSeverity,
+        domain: EditorWorkspaceStatusDomain = .general,
+        failureDetail: String? = nil
+    ) {
+        self.message = message
+        self.severity = severity
+        self.domain = domain
+        self.failureDetail = failureDetail
+    }
+}
+
+enum EditorWorkspaceAutosaveSource: Hashable {
+    case video
+    case screenshot
+    case unspecified
+}
+
 struct EditorWorkspaceState: Equatable {
     var selectedSection: AppSection = .editor
+    var statusMessage = ""
+    var statusSeverity: EditorWorkspaceStatusSeverity = .none
+    var autosaveFailureMessage: String?
+    var isAutosaveRetryInProgress = false
+    var isAutosaveRecoveryPresented = false
     var isShortcutsHelpPresented = false
     var videoExportRequest: EditorExportRequest?
     var screenshotExportRequest: EditorExportRequest?
@@ -565,6 +642,13 @@ struct EditorWorkspaceState: Equatable {
 enum EditorWorkspaceEvent: Equatable {
     case appSectionSynced(AppSection)
     case sectionSelected(AppSection)
+    case statusUpdated(EditorWorkspaceStatus)
+    case statusCleared
+    case autosaveRetryStarted
+    case autosaveRetryFinished
+    case autosaveRecoveryRequired
+    case autosaveRecoveryPresented(Bool)
+    case autosaveRecoveryResolved(String)
     case shortcutsHelpToggled
     case shortcutsHelpPresented(Bool)
     case videoExportRequested(URL?, editorSessionID: UUID?)
@@ -596,6 +680,50 @@ extension EditorWorkspaceState {
             selectedSection = section
             return [.setAppSection(section)]
 
+        case .statusUpdated(let status):
+            return applyStatus(status)
+
+        case .statusCleared:
+            guard autosaveFailureMessage == nil else { return [] }
+            guard !statusMessage.isEmpty || statusSeverity != .none else { return [] }
+            statusMessage = ""
+            statusSeverity = .none
+            return [.setStatusMessage("")]
+
+        case .autosaveRetryStarted:
+            guard !isAutosaveRetryInProgress else { return [] }
+            isAutosaveRetryInProgress = true
+            statusMessage = "Retrying save…"
+            statusSeverity = .progress
+            return [.setStatusMessage("Retrying save…")]
+
+        case .autosaveRetryFinished:
+            guard isAutosaveRetryInProgress else { return [] }
+            isAutosaveRetryInProgress = false
+            return []
+
+        case .autosaveRecoveryRequired:
+            isAutosaveRecoveryPresented = true
+            let didChangeStatus = statusMessage != "Save failed" || statusSeverity != .failure
+            statusMessage = "Save failed"
+            statusSeverity = .failure
+            if autosaveFailureMessage == nil {
+                autosaveFailureMessage = "Open Recorder couldn’t save the latest changes."
+            }
+            return didChangeStatus ? [.setStatusMessage("Save failed")] : []
+
+        case .autosaveRecoveryPresented(let isPresented):
+            isAutosaveRecoveryPresented = isPresented
+            return []
+
+        case .autosaveRecoveryResolved(let message):
+            isAutosaveRecoveryPresented = false
+            isAutosaveRetryInProgress = false
+            statusMessage = message
+            statusSeverity = .success
+            autosaveFailureMessage = nil
+            return [.setStatusMessage(message)]
+
         case .shortcutsHelpToggled:
             isShortcutsHelpPresented.toggle()
             return []
@@ -606,14 +734,20 @@ extension EditorWorkspaceState {
 
         case .videoExportRequested(let url, let editorSessionID):
             guard let url else {
-                return [.setStatusMessage("Open a recording first.")]
+                return applyStatus(EditorWorkspaceStatus(
+                    message: "Open a recording first.",
+                    severity: .failure
+                ))
             }
             videoExportRequest = EditorExportRequest(url: url, editorSessionID: editorSessionID)
             return []
 
         case .screenshotExportRequested(let url, let editorSessionID):
             guard let url else {
-                return [.setStatusMessage("Open a screenshot first.")]
+                return applyStatus(EditorWorkspaceStatus(
+                    message: "Open a screenshot first.",
+                    severity: .failure
+                ))
             }
             screenshotExportRequest = EditorExportRequest(url: url, editorSessionID: editorSessionID)
             return []
@@ -644,18 +778,57 @@ extension EditorWorkspaceState {
             return [.clearTimelineSelection]
         }
     }
+
+    private mutating func applyStatus(_ status: EditorWorkspaceStatus) -> [EditorWorkspaceEffect] {
+        if autosaveFailureMessage != nil, status.domain == .general {
+            return []
+        }
+
+        let failureDetailChanged = status.domain == .autosave
+            && status.severity == .failure
+            && autosaveFailureMessage != (status.failureDetail ?? status.message)
+        guard statusMessage != status.message
+                || statusSeverity != status.severity
+                || failureDetailChanged else {
+            return []
+        }
+        statusMessage = status.message
+        statusSeverity = status.severity
+        if status.domain == .autosave, status.severity == .failure {
+            autosaveFailureMessage = status.failureDetail ?? status.message
+        } else if status.domain == .autosave, status.severity == .success {
+            autosaveFailureMessage = nil
+        }
+        return [.setStatusMessage(status.message)]
+    }
 }
 
 @Observable
 @MainActor
 final class EditorWorkspaceDriver {
-    var state = EditorWorkspaceState()
+    private(set) var state = EditorWorkspaceState()
     let video = VideoEditorDriver()
     let timeline = TimelineEditDriver()
     let screenshot = ScreenshotEditorDriver()
+    let videoExport = VideoExportDriver()
 
+    @ObservationIgnored private let synchronizesAppShell: Bool
     @ObservationIgnored private var setAppSection: (AppSection) -> Void = { _ in }
     @ObservationIgnored private var setStatusMessage: (String) -> Void = { _ in }
+    @ObservationIgnored private var statusClearTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingAutosaveFlushID: UUID?
+    @ObservationIgnored private var pendingAutosaveFlushTask: Task<Bool, Never>?
+    @ObservationIgnored private var isAggregatingAutosaveFlush = false
+    @ObservationIgnored private var autosaveFailureDuringFlush: String?
+    @ObservationIgnored private var autosaveFailuresBySource: [EditorWorkspaceAutosaveSource: String] = [:]
+
+    init(synchronizesAppShell: Bool = false) {
+        self.synchronizesAppShell = synchronizesAppShell
+    }
+
+    deinit {
+        statusClearTask?.cancel()
+    }
 
     func configure(
         setAppSection: @escaping (AppSection) -> Void,
@@ -673,6 +846,13 @@ final class EditorWorkspaceDriver {
         Binding(
             get: { self.state.isShortcutsHelpPresented },
             set: { self.send(.shortcutsHelpPresented($0)) }
+        )
+    }
+
+    var autosaveRecoveryBinding: Binding<Bool> {
+        Binding(
+            get: { self.state.isAutosaveRecoveryPresented },
+            set: { self.send(.autosaveRecoveryPresented($0)) }
         )
     }
 
@@ -714,13 +894,168 @@ final class EditorWorkspaceDriver {
         return true
     }
 
+    func flushPendingAutosaves() async -> Bool {
+        if let pendingAutosaveFlushTask {
+            return await pendingAutosaveFlushTask.value
+        }
+
+        let flushID = UUID()
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return false }
+            let didFlush = await performAutosaveFlush()
+            if pendingAutosaveFlushID == flushID {
+                pendingAutosaveFlushID = nil
+                pendingAutosaveFlushTask = nil
+            }
+            return didFlush
+        }
+        pendingAutosaveFlushID = flushID
+        pendingAutosaveFlushTask = task
+        return await task.value
+    }
+
+    var hasPendingAutosaves: Bool {
+        video.hasPendingAutosave || screenshot.hasPendingAutosave
+    }
+
+    func discardTransientState() {
+        video.cancelPendingExportLaunch()
+        videoExport.clear()
+    }
+
+    func abandonPendingAutosaves() -> Bool {
+        guard canAbandonPendingAutosaves else {
+            return false
+        }
+        let didAbandonVideo = video.abandonPendingAutosave()
+        let didAbandonScreenshot = screenshot.abandonPendingAutosave()
+        return didAbandonVideo && didAbandonScreenshot
+    }
+
+    var canAbandonPendingAutosaves: Bool {
+        video.canAbandonPendingAutosave && screenshot.canAbandonPendingAutosave
+    }
+
+    @discardableResult
+    func retryPendingAutosaves() async -> Bool {
+        let didSave = await retryPendingAutosavesKeepingWindowOpen()
+        if !didSave {
+            send(.autosaveRecoveryRequired)
+        }
+        return didSave
+    }
+
+    @discardableResult
+    func retryPendingAutosavesKeepingWindowOpen() async -> Bool {
+        guard !state.isAutosaveRetryInProgress else { return false }
+        send(.autosaveRetryStarted)
+        let didSave = await flushPendingAutosaves()
+        send(.autosaveRetryFinished)
+        if didSave {
+            autosaveFailuresBySource.removeAll()
+            send(.autosaveRecoveryResolved("Saved"))
+            scheduleStatusClear()
+        }
+        return didSave
+    }
+
+    func handleProjectAutosaveStatus(
+        _ status: ProjectAutosaveStatus,
+        source: EditorWorkspaceAutosaveSource = .unspecified
+    ) {
+        statusClearTask?.cancel()
+        switch status {
+        case .saving:
+            guard currentAutosaveFailureMessage == nil else { return }
+            send(.statusUpdated(EditorWorkspaceStatus(
+                message: "Saving…",
+                severity: .progress,
+                domain: .autosave
+            )))
+        case .saved:
+            autosaveFailuresBySource.removeValue(forKey: source)
+            if let failureMessage = currentAutosaveFailureMessage {
+                sendAutosaveFailure(failureMessage)
+                return
+            }
+            send(.statusUpdated(EditorWorkspaceStatus(
+                message: "Saved",
+                severity: .success,
+                domain: .autosave
+            )))
+            scheduleStatusClear()
+        case .failed(let message):
+            autosaveFailuresBySource[source] = message
+            if isAggregatingAutosaveFlush, autosaveFailureDuringFlush == nil {
+                autosaveFailureDuringFlush = message
+            }
+            sendAutosaveFailure(currentAutosaveFailureMessage ?? message)
+        }
+    }
+
+    private func performAutosaveFlush() async -> Bool {
+        autosaveFailureDuringFlush = nil
+        isAggregatingAutosaveFlush = true
+        defer {
+            isAggregatingAutosaveFlush = false
+            autosaveFailureDuringFlush = nil
+        }
+
+        let didFlushVideo = await video.flushPendingAutosave()
+        let didFlushScreenshot = await screenshot.flushPendingAutosave()
+        guard didFlushVideo && didFlushScreenshot else {
+            let message = currentAutosaveFailureMessage
+                ?? state.autosaveFailureMessage
+                ?? "Open Recorder couldn’t save the latest changes."
+            sendAutosaveFailure(message)
+            return false
+        }
+        return true
+    }
+
+    private var currentAutosaveFailureMessage: String? {
+        autosaveFailuresBySource[.video]
+            ?? autosaveFailuresBySource[.screenshot]
+            ?? autosaveFailuresBySource[.unspecified]
+            ?? autosaveFailureDuringFlush
+    }
+
+    private func sendAutosaveFailure(_ message: String) {
+        send(.statusUpdated(EditorWorkspaceStatus(
+            message: "Save failed",
+            severity: .failure,
+            domain: .autosave,
+            failureDetail: message
+        )))
+    }
+
+    private func scheduleStatusClear() {
+        statusClearTask?.cancel()
+        statusClearTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: 2_000_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled,
+                  self?.state.statusSeverity == .success else {
+                return
+            }
+            self?.send(.statusCleared)
+        }
+    }
+
     private func perform(_ effects: [EditorWorkspaceEffect]) {
         for effect in effects {
             switch effect {
             case .setAppSection(let section):
-                setAppSection(section)
+                if synchronizesAppShell {
+                    setAppSection(section)
+                }
             case .setStatusMessage(let message):
-                setStatusMessage(message)
+                if synchronizesAppShell {
+                    setStatusMessage(message)
+                }
             case .undoTimeline:
                 timeline.undo()
             case .redoTimeline:

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -4,6 +4,23 @@ import CoreGraphics
 import SwiftUI
 import UniformTypeIdentifiers
 
+struct EditorSessionMetadata: Equatable {
+    var recordingSession: RecordingSession?
+    var projectPath: String?
+    var title: String?
+    var videoEditorState: ProjectVideoEditorState?
+    var screenshotEditorState: ScreenshotEditorState?
+
+    init(explicitSession: EditorSession?, fallbackSession: EditorSession?) {
+        let source = explicitSession ?? fallbackSession
+        recordingSession = source?.recordingSession
+        projectPath = source?.projectPath
+        title = source?.title
+        videoEditorState = source?.videoEditorState
+        screenshotEditorState = source?.screenshotEditorState
+    }
+}
+
 struct EditorStudioView: View {
     @EnvironmentObject private var model: AppModel
     var editorSession: EditorSession?
@@ -17,6 +34,7 @@ struct EditorStudioView: View {
                 editorTitle: editorTitle,
                 initialScreenshotState: initialScreenshotState,
                 editorSessionID: editorSession?.id,
+                workspace: workspace,
                 editor: workspace.screenshot,
                 exportRequest: workspace.state.screenshotExportRequest
             )
@@ -29,9 +47,10 @@ struct EditorStudioView: View {
                 initialTimelineEdits: editorSession?.timelineEditSnapshot,
                 initialVideoState: initialVideoState,
                 editorSessionID: editorSession?.id,
+                workspace: workspace,
                 editor: workspace.video,
                 timelineEdits: workspace.timeline,
-                videoExport: model.appShell.videoExport,
+                videoExport: workspace.videoExport,
                 exportRequest: workspace.state.videoExportRequest
             )
         }
@@ -52,23 +71,30 @@ struct EditorStudioView: View {
     }
 
     private var recordingSession: RecordingSession? {
-        editorSession?.recordingSession ?? model.lastEditorSession?.recordingSession
+        sessionMetadata.recordingSession
     }
 
     private var projectPath: String? {
-        editorSession?.projectPath ?? model.lastEditorSession?.projectPath
+        sessionMetadata.projectPath
     }
 
     private var editorTitle: String? {
-        editorSession?.title ?? model.lastEditorSession?.title
+        sessionMetadata.title
     }
 
     private var initialVideoState: ProjectVideoEditorState? {
-        editorSession?.videoEditorState ?? model.lastEditorSession?.videoEditorState
+        sessionMetadata.videoEditorState
     }
 
     private var initialScreenshotState: ScreenshotEditorState? {
-        editorSession?.screenshotEditorState ?? model.lastEditorSession?.screenshotEditorState
+        sessionMetadata.screenshotEditorState
+    }
+
+    private var sessionMetadata: EditorSessionMetadata {
+        EditorSessionMetadata(
+            explicitSession: editorSession,
+            fallbackSession: model.lastEditorSession
+        )
     }
 }
 
@@ -81,6 +107,7 @@ struct VideoEditorStudioView: View {
     var initialTimelineEdits: TimelineEditSnapshot?
     var initialVideoState: ProjectVideoEditorState?
     var editorSessionID: UUID?
+    var workspace: EditorWorkspaceDriver
     @State private var playback = VideoPlaybackController()
     var editor: VideoEditorDriver
     var timelineEdits: TimelineEditDriver
@@ -129,20 +156,22 @@ struct VideoEditorStudioView: View {
                 applyTimelineSnapshot: { snapshot in
                     timelineEdits.applySnapshot(snapshot)
                 },
-                saveHandler: { snapshot in
-                    try await model.autosaveProject(snapshot)
+                saveHandler: { [weak model] snapshot in
+                    guard let model else { throw CancellationError() }
+                    return try await model.autosaveProject(snapshot)
                 },
-                statusHandler: { status in
-                    model.handleProjectAutosaveStatus(status)
+                statusHandler: { [weak workspace, weak model] status in
+                    workspace?.handleProjectAutosaveStatus(status, source: .video)
+                    model?.handleProjectAutosaveStatus(status)
                 },
-                pausePlayback: {
-                    playback.pause()
+                pausePlayback: { [weak playback] in
+                    playback?.pause()
                 },
-                exportVideo: { recordingURL, options, edits in
-                    videoExport.export(sourceURL: recordingURL ?? model.currentVideoURL, options: options, edits: edits)
+                exportVideo: { [weak model, weak videoExport] recordingURL, options, edits in
+                    videoExport?.export(sourceURL: recordingURL ?? model?.currentVideoURL, options: options, edits: edits)
                 },
-                clearVideoExportDialogState: {
-                    videoExport.clear()
+                clearVideoExportDialogState: { [weak videoExport] in
+                    videoExport?.clear()
                 }
             )
             syncEditorSession()

--- a/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+struct EditorWorkspaceRecoveryKey: Hashable {
+    let kind: EditorMediaKind
+    let path: String
+
+    init(session: EditorSession) {
+        kind = session.kind
+        let durablePath = session.projectPath ?? session.path
+        path = URL(fileURLWithPath: durablePath).standardizedFileURL.path
+    }
+}
+
+struct EditorWorkspaceCloseRequest {
+    let sessionID: UUID?
+    let generation: UUID
+    let workspace: EditorWorkspaceDriver
+    let recoveryKey: EditorWorkspaceRecoveryKey?
+}
+
+enum EditorWorkspaceCloseOutcome: Equatable {
+    case closed
+    case canceled
+    case autosaveFailed
+}
+
+@MainActor
+final class EditorWorkspaceRegistry {
+    private(set) var defaultWorkspace = EditorWorkspaceDriver(synchronizesAppShell: true)
+
+    private var workspacesBySessionID: [UUID: EditorWorkspaceDriver] = [:]
+    private var defaultCloseGeneration: UUID?
+    private var closeGenerationBySessionID: [UUID: UUID] = [:]
+    private var recoverableSessionIDsByKey: [EditorWorkspaceRecoveryKey: [UUID]] = [:]
+    private var recoveryKeyBySessionID: [UUID: EditorWorkspaceRecoveryKey] = [:]
+    private var configureWorkspace: (EditorWorkspaceDriver) -> Void = { _ in }
+
+    func configure(_ configureWorkspace: @escaping (EditorWorkspaceDriver) -> Void) {
+        self.configureWorkspace = configureWorkspace
+        configureWorkspace(defaultWorkspace)
+        workspacesBySessionID.values.forEach(configureWorkspace)
+    }
+
+    func workspace(for session: EditorSession?) -> EditorWorkspaceDriver {
+        guard let session else {
+            return defaultWorkspace
+        }
+        let sessionID = session.id
+
+        if let workspace = workspacesBySessionID[sessionID] {
+            return workspace
+        }
+
+        let recoveryKey = EditorWorkspaceRecoveryKey(session: session)
+        if let workspace = recoverWorkspace(for: recoveryKey, newSessionID: sessionID) {
+            return workspace
+        }
+
+        let workspace = EditorWorkspaceDriver(synchronizesAppShell: false)
+        configureWorkspace(workspace)
+        workspacesBySessionID[sessionID] = workspace
+        return workspace
+    }
+
+    func activate(sessionID: UUID?) {
+        guard let sessionID else {
+            defaultCloseGeneration = nil
+            return
+        }
+        closeGenerationBySessionID.removeValue(forKey: sessionID)
+        removeRecoveryRecord(for: sessionID)
+    }
+
+    func beginClose(session: EditorSession?) -> EditorWorkspaceCloseRequest? {
+        let closeGeneration = UUID()
+        guard let session else {
+            defaultCloseGeneration = closeGeneration
+            return EditorWorkspaceCloseRequest(
+                sessionID: nil,
+                generation: closeGeneration,
+                workspace: defaultWorkspace,
+                recoveryKey: nil
+            )
+        }
+        let sessionID = session.id
+        guard let workspace = workspacesBySessionID[sessionID] else { return nil }
+        closeGenerationBySessionID[sessionID] = closeGeneration
+        return EditorWorkspaceCloseRequest(
+            sessionID: sessionID,
+            generation: closeGeneration,
+            workspace: workspace,
+            recoveryKey: EditorWorkspaceRecoveryKey(session: session)
+        )
+    }
+
+    @discardableResult
+    func finishClose(_ request: EditorWorkspaceCloseRequest) async -> EditorWorkspaceCloseOutcome {
+        var didFlushAutosaves = false
+        repeat {
+            didFlushAutosaves = await request.workspace.flushPendingAutosaves()
+            guard !Task.isCancelled else {
+                cancelClose(request)
+                return .canceled
+            }
+            guard didFlushAutosaves else { break }
+        } while request.workspace.hasPendingAutosaves
+
+        guard let sessionID = request.sessionID else {
+            guard defaultCloseGeneration == request.generation,
+                  request.workspace === defaultWorkspace else {
+                return .canceled
+            }
+            defaultCloseGeneration = nil
+            request.workspace.discardTransientState()
+            guard didFlushAutosaves else {
+                request.workspace.send(.autosaveRecoveryRequired)
+                return .autosaveFailed
+            }
+            if request.workspace.state.isAutosaveRecoveryPresented {
+                request.workspace.send(.autosaveRecoveryResolved("Saved"))
+            }
+            return .closed
+        }
+
+        guard closeGenerationBySessionID[sessionID] == request.generation,
+              workspacesBySessionID[sessionID] === request.workspace else {
+            return .canceled
+        }
+        request.workspace.discardTransientState()
+        guard didFlushAutosaves else {
+            closeGenerationBySessionID.removeValue(forKey: sessionID)
+            markRecoverable(request)
+            request.workspace.send(.autosaveRecoveryRequired)
+            return .autosaveFailed
+        }
+        workspacesBySessionID.removeValue(forKey: sessionID)
+        closeGenerationBySessionID.removeValue(forKey: sessionID)
+        removeRecoveryRecord(for: sessionID)
+        return .closed
+    }
+
+    @discardableResult
+    func close(session: EditorSession?) async -> EditorWorkspaceCloseOutcome {
+        guard let request = beginClose(session: session) else { return .canceled }
+        return await finishClose(request)
+    }
+
+    @discardableResult
+    func discard(session: EditorSession?) -> Bool {
+        guard let session else {
+            let discardedWorkspace = defaultWorkspace
+            guard discardedWorkspace.abandonPendingAutosaves() else { return false }
+            discardedWorkspace.discardTransientState()
+            defaultCloseGeneration = nil
+            let replacement = EditorWorkspaceDriver(synchronizesAppShell: true)
+            configureWorkspace(replacement)
+            defaultWorkspace = replacement
+            return true
+        }
+        guard let workspace = workspacesBySessionID[session.id] else { return false }
+        guard workspace.abandonPendingAutosaves() else { return false }
+        workspacesBySessionID.removeValue(forKey: session.id)
+        workspace.discardTransientState()
+        closeGenerationBySessionID.removeValue(forKey: session.id)
+        removeRecoveryRecord(for: session.id)
+        return true
+    }
+
+    private func markRecoverable(_ request: EditorWorkspaceCloseRequest) {
+        guard let sessionID = request.sessionID,
+              let recoveryKey = request.recoveryKey else {
+            return
+        }
+        recoveryKeyBySessionID[sessionID] = recoveryKey
+        var sessionIDs = recoverableSessionIDsByKey[recoveryKey, default: []]
+        if !sessionIDs.contains(sessionID) {
+            sessionIDs.append(sessionID)
+        }
+        recoverableSessionIDsByKey[recoveryKey] = sessionIDs
+    }
+
+    private func cancelClose(_ request: EditorWorkspaceCloseRequest) {
+        guard let sessionID = request.sessionID else {
+            if defaultCloseGeneration == request.generation {
+                defaultCloseGeneration = nil
+            }
+            return
+        }
+        if closeGenerationBySessionID[sessionID] == request.generation {
+            closeGenerationBySessionID.removeValue(forKey: sessionID)
+        }
+    }
+
+    private func recoverWorkspace(
+        for recoveryKey: EditorWorkspaceRecoveryKey,
+        newSessionID: UUID
+    ) -> EditorWorkspaceDriver? {
+        guard var sessionIDs = recoverableSessionIDsByKey[recoveryKey] else { return nil }
+        while let recoverableSessionID = sessionIDs.popLast() {
+            guard let workspace = workspacesBySessionID.removeValue(forKey: recoverableSessionID) else {
+                recoveryKeyBySessionID.removeValue(forKey: recoverableSessionID)
+                continue
+            }
+            closeGenerationBySessionID.removeValue(forKey: recoverableSessionID)
+            recoveryKeyBySessionID.removeValue(forKey: recoverableSessionID)
+            recoverableSessionIDsByKey[recoveryKey] = sessionIDs.isEmpty ? nil : sessionIDs
+            workspacesBySessionID[newSessionID] = workspace
+            return workspace
+        }
+        recoverableSessionIDsByKey.removeValue(forKey: recoveryKey)
+        return nil
+    }
+
+    private func removeRecoveryRecord(for sessionID: UUID) {
+        guard let recoveryKey = recoveryKeyBySessionID.removeValue(forKey: sessionID),
+              var sessionIDs = recoverableSessionIDsByKey[recoveryKey] else {
+            return
+        }
+        sessionIDs.removeAll { $0 == sessionID }
+        recoverableSessionIDsByKey[recoveryKey] = sessionIDs.isEmpty ? nil : sessionIDs
+    }
+
+    #if DEBUG
+    var sessionCountForTesting: Int {
+        workspacesBySessionID.count
+    }
+    #endif
+}

--- a/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
@@ -111,11 +111,11 @@ final class EditorWorkspaceRegistry {
                 return .canceled
             }
             defaultCloseGeneration = nil
-            request.workspace.discardTransientState()
             guard didFlushAutosaves else {
                 request.workspace.send(.autosaveRecoveryRequired)
                 return .autosaveFailed
             }
+            request.workspace.discardTransientState()
             if request.workspace.state.isAutosaveRecoveryPresented {
                 request.workspace.send(.autosaveRecoveryResolved("Saved"))
             }
@@ -126,13 +126,13 @@ final class EditorWorkspaceRegistry {
               workspacesBySessionID[sessionID] === request.workspace else {
             return .canceled
         }
-        request.workspace.discardTransientState()
         guard didFlushAutosaves else {
             closeGenerationBySessionID.removeValue(forKey: sessionID)
             markRecoverable(request)
             request.workspace.send(.autosaveRecoveryRequired)
             return .autosaveFailed
         }
+        request.workspace.discardTransientState()
         workspacesBySessionID.removeValue(forKey: sessionID)
         closeGenerationBySessionID.removeValue(forKey: sessionID)
         removeRecoveryRecord(for: sessionID)

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -358,8 +358,6 @@ final class AppWindowActions {
 
     private func hideAppWindowsForCapture() {
         dismissCaptureWindows()
-        dismissWindow("studio")
-        dismissWindow("editor")
         hideApp()
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/ProjectAutosave.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectAutosave.swift
@@ -49,6 +49,8 @@ final class ProjectAutosaveCoordinator: ObservableObject {
     private var lastSavedSnapshot: ProjectAutosaveSnapshot?
     private var isSaving = false
     private var needsSaveAfterCurrent = false
+    private var isAbandoned = false
+    private var saveCompletionWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         debounceNanoseconds: UInt64 = 800_000_000,
@@ -69,7 +71,17 @@ final class ProjectAutosaveCoordinator: ObservableObject {
         self.statusHandler = statusHandler
     }
 
+    var canAbandonPendingChanges: Bool {
+        !isSaving
+    }
+
+    var hasPendingChanges: Bool {
+        guard !isAbandoned else { return false }
+        return isSaving || needsSaveAfterCurrent || latestSnapshot != lastSavedSnapshot
+    }
+
     func markSaved(_ snapshot: ProjectAutosaveSnapshot?) {
+        guard !isAbandoned else { return }
         pendingTask?.cancel()
         pendingTask = nil
         latestSnapshot = snapshot
@@ -77,7 +89,20 @@ final class ProjectAutosaveCoordinator: ObservableObject {
         needsSaveAfterCurrent = false
     }
 
+    @discardableResult
+    func abandonPendingChanges() -> Bool {
+        guard !isSaving else { return false }
+        isAbandoned = true
+        pendingTask?.cancel()
+        pendingTask = nil
+        latestSnapshot = nil
+        lastSavedSnapshot = nil
+        needsSaveAfterCurrent = false
+        return true
+    }
+
     func schedule(_ snapshot: ProjectAutosaveSnapshot?) {
+        guard !isAbandoned else { return }
         guard let snapshot else { return }
         latestSnapshot = snapshot
 
@@ -101,45 +126,66 @@ final class ProjectAutosaveCoordinator: ObservableObject {
                 return
             }
             guard !Task.isCancelled else { return }
-            await self?.saveLatestSnapshot()
+            await self?.runPendingSave()
         }
     }
 
-    func flush(_ snapshot: ProjectAutosaveSnapshot? = nil) async {
+    @discardableResult
+    func flush(_ snapshot: ProjectAutosaveSnapshot? = nil) async -> Bool {
+        guard !isAbandoned else { return true }
         if let snapshot {
             latestSnapshot = snapshot
         }
         pendingTask?.cancel()
         pendingTask = nil
+        if isSaving {
+            needsSaveAfterCurrent = true
+            await withCheckedContinuation { continuation in
+                saveCompletionWaiters.append(continuation)
+            }
+            return latestSnapshot == lastSavedSnapshot
+        }
+        await saveLatestSnapshot()
+        return latestSnapshot == lastSavedSnapshot
+    }
+
+    private func runPendingSave() async {
+        pendingTask = nil
         await saveLatestSnapshot()
     }
 
     private func saveLatestSnapshot() async {
-        guard let snapshot = latestSnapshot,
-              snapshot != lastSavedSnapshot,
-              let saveHandler else {
-            return
-        }
-
+        guard !isAbandoned else { return }
         if isSaving {
             needsSaveAfterCurrent = true
             return
         }
 
+        guard saveHandler != nil else { return }
         isSaving = true
-        statusHandler?(.saving)
-        do {
-            let summary = try await saveHandler(snapshot)
-            lastSavedSnapshot = snapshot
-            statusHandler?(.saved(summary))
-        } catch {
-            statusHandler?(.failed(error.localizedDescription))
-        }
+        repeat {
+            needsSaveAfterCurrent = false
+            guard let snapshot = latestSnapshot,
+                  snapshot != lastSavedSnapshot,
+                  let saveHandler else {
+                break
+            }
+
+            statusHandler?(.saving)
+            do {
+                let summary = try await saveHandler(snapshot)
+                lastSavedSnapshot = snapshot
+                statusHandler?(.saved(summary))
+            } catch {
+                statusHandler?(.failed(error.localizedDescription))
+            }
+        } while needsSaveAfterCurrent
         isSaving = false
 
-        if needsSaveAfterCurrent {
-            needsSaveAfterCurrent = false
-            await saveLatestSnapshot()
+        let waiters = saveCompletionWaiters
+        saveCompletionWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/RecordingPreferencesStore.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingPreferencesStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct RecordingPreferences: Equatable {
+    var createsZoomsAutomatically: Bool
+    var autoZoomAnimationPreset: TimelineZoomAnimationPreset
+}
+
+@MainActor
+struct RecordingPreferencesStore {
+    private static let createsZoomsAutomaticallyKey = "recording.createZoomsAutomatically"
+    private static let autoZoomAnimationPresetKey = "recording.autoZoomAnimationPreset"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> RecordingPreferences {
+        RecordingPreferences(
+            createsZoomsAutomatically: defaults.object(forKey: Self.createsZoomsAutomaticallyKey) as? Bool ?? true,
+            autoZoomAnimationPreset: TimelineZoomAnimationPreset.storedValue(
+                defaults.string(forKey: Self.autoZoomAnimationPresetKey)
+            )
+        )
+    }
+
+    func setCreatesZoomsAutomatically(_ value: Bool) {
+        defaults.set(value, forKey: Self.createsZoomsAutomaticallyKey)
+    }
+
+    func setAutoZoomAnimationPreset(_ preset: TimelineZoomAnimationPreset) {
+        defaults.set(preset.rawValue, forKey: Self.autoZoomAnimationPresetKey)
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
@@ -1,9 +1,11 @@
+import Darwin
 import Foundation
 
 enum RustServiceError: LocalizedError {
     case missingExecutable
     case invalidParameters
     case processFailed(String)
+    case timedOut(TimeInterval)
     case badResponse
     case serviceError(String)
 
@@ -15,6 +17,8 @@ enum RustServiceError: LocalizedError {
             "The request could not be encoded for the Rust service."
         case .processFailed(let message):
             message
+        case .timedOut(let timeout):
+            "The Rust service did not respond within \(Int(timeout.rounded())) seconds."
         case .badResponse:
             "The Rust service returned an invalid response."
         case .serviceError(let message):
@@ -31,8 +35,10 @@ struct RustServiceClient: Sendable {
     }
 
     private let executableURL: URL?
+    private let callTimeout: TimeInterval
 
-    init() {
+    init(callTimeout: TimeInterval = 5) {
+        self.callTimeout = callTimeout
         if let override = ProcessInfo.processInfo.environment["OPEN_RECORDER_SERVICE_PATH"],
            !override.isEmpty {
             executableURL = URL(fileURLWithPath: override)
@@ -41,8 +47,9 @@ struct RustServiceClient: Sendable {
         }
     }
 
-    init(executableURL: URL?) {
+    init(executableURL: URL?, callTimeout: TimeInterval = 5) {
         self.executableURL = executableURL
+        self.callTimeout = callTimeout
     }
 
     var isAvailable: Bool {
@@ -85,12 +92,34 @@ struct RustServiceClient: Sendable {
         process.standardOutput = outputPipe
         process.standardError = errorPipe
 
-        try process.run()
+        let processExit = DispatchGroup()
+        processExit.enter()
+        process.terminationHandler = { _ in
+            processExit.leave()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            process.terminationHandler = nil
+            processExit.leave()
+            throw error
+        }
         let outputReader = PipeDataReader(pipe: outputPipe, label: "dev.openrecorder.service.stdout")
         let errorReader = PipeDataReader(pipe: errorPipe, label: "dev.openrecorder.service.stderr")
         outputReader.start()
         errorReader.start()
-        process.waitUntilExit()
+
+        guard processExit.wait(timeout: .now() + callTimeout) == .success else {
+            process.terminate()
+            if processExit.wait(timeout: .now() + 1) == .timedOut {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                _ = processExit.wait(timeout: .now() + 1)
+            }
+            outputReader.stop()
+            errorReader.stop()
+            throw RustServiceError.timedOut(callTimeout)
+        }
 
         let outputData = outputReader.waitForData()
         let errorData = errorReader.waitForData()
@@ -154,5 +183,9 @@ private final class PipeDataReader: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return data
+    }
+
+    func stop() {
+        try? fileHandle.close()
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorState.swift
@@ -90,7 +90,7 @@ enum ScreenshotEditorEffect: Equatable {
     case markAutosaved(ProjectAutosaveSnapshot?)
     case scheduleAutosave(ProjectAutosaveSnapshot?)
     case flushAutosave(ProjectAutosaveSnapshot?)
-    case setStatusMessage(String)
+    case setWorkspaceStatus(EditorWorkspaceStatus)
 }
 
 extension ScreenshotEditorMachineState {
@@ -128,16 +128,22 @@ extension ScreenshotEditorMachineState {
             return [.flushAutosave(snapshot)]
 
         case .saveFailed(let message):
-            return [.setStatusMessage(message)]
+            return [.setWorkspaceStatus(EditorWorkspaceStatus(message: message, severity: .failure))]
 
         case .saveSucceeded(let url):
-            return [.setStatusMessage("Exported \(url.lastPathComponent)")]
+            return [.setWorkspaceStatus(EditorWorkspaceStatus(
+                message: "Exported \(url.lastPathComponent)",
+                severity: .success
+            ))]
 
         case .copyFailed(let message):
-            return [.setStatusMessage(message)]
+            return [.setWorkspaceStatus(EditorWorkspaceStatus(message: message, severity: .failure))]
 
         case .copySucceeded:
-            return [.setStatusMessage("Screenshot PNG copied")]
+            return [.setWorkspaceStatus(EditorWorkspaceStatus(
+                message: "Screenshot PNG copied",
+                severity: .success
+            ))]
         }
     }
 }
@@ -150,7 +156,7 @@ final class ScreenshotEditorDriver {
 
     @ObservationIgnored private var history = EditorHistory<ScreenshotEditorState>()
     @ObservationIgnored private let autosave = ProjectAutosaveCoordinator()
-    @ObservationIgnored private var setStatusMessage: (String) -> Void = { _ in }
+    @ObservationIgnored private var setWorkspaceStatus: (EditorWorkspaceStatus) -> Void = { _ in }
     @ObservationIgnored private var renderPNG: (NSImage, ScreenshotEditorState) -> Data? = { image, state in
         let renderer = ScreenshotExportRenderer(configuration: ScreenshotExportConfiguration(screenshotState: state))
         return renderer.renderPNG(from: image)
@@ -189,13 +195,13 @@ final class ScreenshotEditorDriver {
     func configure(
         saveHandler: @escaping ProjectAutosaveCoordinator.SaveHandler,
         statusHandler: @escaping ProjectAutosaveCoordinator.StatusHandler,
-        setStatusMessage: @escaping (String) -> Void,
+        setWorkspaceStatus: @escaping (EditorWorkspaceStatus) -> Void,
         renderPNG: ((NSImage, ScreenshotEditorState) -> Data?)? = nil,
         presentSaveURL: ((String) -> URL?)? = nil,
         writePNG: ((Data, URL) throws -> Void)? = nil,
         copyPNG: ((Data) -> Bool)? = nil
     ) {
-        self.setStatusMessage = setStatusMessage
+        self.setWorkspaceStatus = setWorkspaceStatus
         if let renderPNG {
             self.renderPNG = renderPNG
         }
@@ -325,6 +331,22 @@ final class ScreenshotEditorDriver {
         }
     }
 
+    func flushPendingAutosave() async -> Bool {
+        await autosave.flush()
+    }
+
+    var hasPendingAutosave: Bool {
+        autosave.hasPendingChanges
+    }
+
+    func abandonPendingAutosave() -> Bool {
+        autosave.abandonPendingChanges()
+    }
+
+    var canAbandonPendingAutosave: Bool {
+        autosave.canAbandonPendingChanges
+    }
+
     private func perform(_ effects: [ScreenshotEditorEffect]) {
         for effect in effects {
             switch effect {
@@ -333,16 +355,15 @@ final class ScreenshotEditorDriver {
             case .scheduleAutosave(let snapshot):
                 autosave.schedule(snapshot)
             case .flushAutosave(let snapshot):
-                Task { [weak self] in
-                    await self?.flushAutosave(snapshot)
+                let autosave = autosave
+                autosave.schedule(snapshot)
+                Task {
+                    await autosave.flush()
                 }
-            case .setStatusMessage(let message):
-                setStatusMessage(message)
+            case .setWorkspaceStatus(let status):
+                setWorkspaceStatus(status)
             }
         }
     }
 
-    private func flushAutosave(_ snapshot: ProjectAutosaveSnapshot?) async {
-        await autosave.flush(snapshot)
-    }
 }

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
@@ -10,6 +10,7 @@ struct ScreenshotEditorStudioView: View {
     var editorTitle: String?
     var initialScreenshotState: ScreenshotEditorState?
     var editorSessionID: UUID?
+    var workspace: EditorWorkspaceDriver
     var editor: ScreenshotEditorDriver
     var exportRequest: EditorExportRequest?
     @State private var sidebarWidth: CGFloat = 320
@@ -79,14 +80,16 @@ struct ScreenshotEditorStudioView: View {
         }
         .onAppear {
             editor.configure(
-                saveHandler: { snapshot in
-                    try await model.autosaveProject(snapshot)
+                saveHandler: { [weak model] snapshot in
+                    guard let model else { throw CancellationError() }
+                    return try await model.autosaveProject(snapshot)
                 },
-                statusHandler: { status in
-                    model.handleProjectAutosaveStatus(status)
+                statusHandler: { [weak workspace, weak model] status in
+                    workspace?.handleProjectAutosaveStatus(status, source: .screenshot)
+                    model?.handleProjectAutosaveStatus(status)
                 },
-                setStatusMessage: { message in
-                    model.statusMessage = message
+                setWorkspaceStatus: { [weak workspace] status in
+                    workspace?.send(.statusUpdated(status))
                 }
             )
             syncEditorSession()

--- a/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
@@ -6,6 +6,8 @@ import UniformTypeIdentifiers
 
 struct SettingsStudioView: View {
     var driver: SettingsDriver
+    var serviceHealth: HealthPayload?
+    var paths: AppPaths?
 
     var body: some View {
         ScrollView {
@@ -14,8 +16,8 @@ struct SettingsStudioView: View {
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(Theme.fg)
                 SettingsSection(title: "Service") {
-                    SettingsRow(title: "Status", value: driver.state.serviceHealth.map { "\($0.service) \($0.version)" } ?? "Unavailable")
-                    SettingsRow(title: "Platform", value: driver.state.serviceHealth?.platform ?? "macOS")
+                    SettingsRow(title: "Status", value: serviceHealth.map { "\($0.service) \($0.version)" } ?? "Unavailable")
+                    SettingsRow(title: "Platform", value: serviceHealth?.platform ?? "macOS")
                     StudioButton(hitTarget: .rounded(8)) {
                         driver.send(.serviceRefreshRequested)
                     } label: {
@@ -28,13 +30,13 @@ struct SettingsStudioView: View {
                 }
 
                 SettingsSection(title: "Folders") {
-                    FolderRow(title: "Recordings", path: driver.state.paths?.recordingsDir) {
+                    FolderRow(title: "Recordings", path: paths?.recordingsDir) {
                         driver.send(.folderOpenRequested($0))
                     }
-                    FolderRow(title: "Screenshots", path: driver.state.paths?.screenshotsDir) {
+                    FolderRow(title: "Screenshots", path: paths?.screenshotsDir) {
                         driver.send(.folderOpenRequested($0))
                     }
-                    FolderRow(title: "Projects", path: driver.state.paths?.projectsDir) {
+                    FolderRow(title: "Projects", path: paths?.projectsDir) {
                         driver.send(.folderOpenRequested($0))
                     }
                 }

--- a/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
@@ -6,16 +6,100 @@ import UniformTypeIdentifiers
 
 struct StudioWindowView: View {
     @EnvironmentObject private var model: AppModel
+    @Environment(\.dismissWindow) private var dismissWindow
     var editorSession: EditorSession?
 
     var body: some View {
         let workspace = model.appShell.workspace(for: editorSession)
         StudioShell(editorSession: editorSession, workspace: workspace)
+            .alert("Couldn’t Save Changes", isPresented: workspace.autosaveRecoveryBinding) {
+                Button("Retry and Close") {
+                    Task {
+                        guard await workspace.retryPendingAutosaves() else { return }
+                        let outcome = await model.appShell.closeWorkspace(for: editorSession)
+                        if outcome == .autosaveFailed {
+                            model.appShell.activateWorkspace(for: editorSession)
+                        }
+                        guard outcome == .closed else { return }
+                        dismissEditorWindow()
+                    }
+                }
+                Button("Close Without Saving", role: .destructive) {
+                    guard model.appShell.discardWorkspace(for: editorSession) else { return }
+                    dismissEditorWindow()
+                }
+                .disabled(!workspace.canAbandonPendingAutosaves)
+                Button("Keep Editing", role: .cancel) {}
+            } message: {
+                Text(autosaveRecoveryMessage(for: workspace))
+            }
+            .background {
+                StudioWindowCloseInterceptor {
+                    guard let request = model.appShell.beginClosingWorkspace(for: editorSession) else {
+                        return true
+                    }
+                    let outcome = await model.appShell.finishClosingWorkspace(request)
+                    if outcome == .autosaveFailed {
+                        model.appShell.activateWorkspace(for: editorSession)
+                    }
+                    return outcome == .closed
+                }
+                .frame(width: 0, height: 0)
+            }
             .onAppear {
-                if model.selectedSection == .capture {
+                model.appShell.activateWorkspace(for: editorSession)
+                if editorSession == nil, model.selectedSection == .capture {
                     model.selectedSection = .editor
                 }
             }
+            .task(id: workspace.state.statusSeverity) {
+                guard workspace.state.statusSeverity == .failure else { return }
+                do {
+                    try await Task.sleep(nanoseconds: 150_000_000)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled,
+                      !workspace.state.isAutosaveRecoveryPresented else {
+                    return
+                }
+                announceAutosaveFailure(workspace.state.autosaveFailureMessage)
+            }
+    }
+
+    private func dismissEditorWindow() {
+        if let editorSession {
+            dismissWindow(id: "editor", value: editorSession)
+        } else {
+            dismissWindow(id: "studio")
+        }
+    }
+
+    private func autosaveRecoveryMessage(for workspace: EditorWorkspaceDriver) -> String {
+        let reason = workspace.state.autosaveFailureMessage
+            ?? "Open Recorder couldn’t save the latest changes."
+        if workspace.canAbandonPendingAutosaves {
+            return "Your latest edits haven’t been saved to disk. \(reason) Retry, keep editing, or close and discard them."
+        }
+        return "Your latest edits haven’t been saved to disk. \(reason) Keep editing while the current save finishes, or retry and close afterward."
+    }
+
+    private func announceAutosaveFailure(_ message: String?) {
+        guard let message else { return }
+        let element: Any
+        if let keyWindow = NSApp.keyWindow {
+            element = keyWindow
+        } else {
+            element = NSApplication.shared
+        }
+        NSAccessibility.post(
+            element: element,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: "Save failed. \(message)",
+                .priority: NSAccessibilityPriorityLevel.high.rawValue
+            ]
+        )
     }
 }
 
@@ -31,6 +115,16 @@ struct StudioShell: View {
                 editorSession: editorSession,
                 workspace: workspace
             )
+            if let failureMessage = workspace.state.autosaveFailureMessage {
+                WorkspaceAutosaveFailureBanner(
+                    message: failureMessage,
+                    isRetrying: workspace.state.isAutosaveRetryInProgress
+                ) {
+                    Task {
+                        await workspace.retryPendingAutosavesKeepingWindowOpen()
+                    }
+                }
+            }
             detailView
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -45,22 +139,18 @@ struct StudioShell: View {
             .frame(width: 0, height: 0)
         }
         .onAppear {
-            workspace.configure(
-                setAppSection: { section in
-                    model.selectedSection = section
-                },
-                setStatusMessage: { message in
-                    model.statusMessage = message
+            if editorSession == nil {
+                if model.selectedSection == .capture {
+                    workspace.send(.sectionSelected(.editor))
+                } else {
+                    workspace.send(.appSectionSynced(model.selectedSection))
                 }
-            )
-            if model.selectedSection == .capture {
-                workspace.send(.sectionSelected(.editor))
-            } else {
-                workspace.send(.appSectionSynced(model.selectedSection))
             }
         }
         .onChange(of: model.selectedSection) { _, section in
-            workspace.send(.appSectionSynced(section))
+            if editorSession == nil {
+                workspace.send(.appSectionSynced(section))
+            }
         }
     }
 
@@ -97,7 +187,11 @@ struct StudioShell: View {
         case .editor:
             EditorStudioView(editorSession: editorSession, workspace: workspace)
         case .settings:
-            SettingsStudioView(driver: model.appShell.settings)
+            SettingsStudioView(
+                driver: model.appShell.settings,
+                serviceHealth: model.serviceHealth,
+                paths: model.paths
+            )
         }
     }
 
@@ -117,6 +211,57 @@ struct StudioShell: View {
     private var isTextInputActive: Bool {
         guard let responder = NSApp.keyWindow?.firstResponder else { return false }
         return responder is NSTextView || responder is NSTextField
+    }
+}
+
+private struct WorkspaceAutosaveFailureBanner: View {
+    var message: String
+    var isRetrying: Bool
+    var retry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Color.red)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Changes not saved")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.secondary)
+                    .lineLimit(2)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Changes not saved. \(message)")
+
+            Spacer(minLength: 12)
+
+            StudioButton(hitTarget: .rounded(7), action: retry) {
+                HStack(spacing: 6) {
+                    if isRetrying {
+                        ProgressView()
+                            .controlSize(.mini)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    Text(isRetrying ? "Retrying…" : "Retry Save")
+                }
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 10)
+                    .frame(height: 28)
+                    .background(Theme.overlayStrong, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            }
+            .disabled(isRetrying)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(Color.red.opacity(0.08))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.red.opacity(0.28))
+                .frame(height: 1)
+        }
     }
 }
 
@@ -377,8 +522,44 @@ struct StudioTitleBar: View {
                 .font(.system(size: 14, weight: .semibold))
                 .lineLimit(1)
                 .truncationMode(.middle)
+            workspaceStatusIndicator
         }
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder
+    private var workspaceStatusIndicator: some View {
+        Group {
+            switch workspace.state.statusSeverity {
+            case .none:
+                Color.clear
+                    .accessibilityHidden(true)
+            case .informational:
+                Image(systemName: "info.circle")
+                    .foregroundStyle(Color.secondary)
+                    .accessibilityLabel("Editor status: \(workspace.state.statusMessage)")
+                    .help(workspace.state.statusMessage)
+            case .progress:
+                ProgressView()
+                    .controlSize(.mini)
+                    .accessibilityLabel(workspace.state.statusMessage)
+                    .help(workspace.state.statusMessage)
+            case .success:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.green)
+                    .accessibilityLabel("Editor status: \(workspace.state.statusMessage)")
+                    .help(workspace.state.statusMessage)
+        case .failure:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Color.red)
+                .accessibilityLabel(
+                    "Editor error: \(workspace.state.statusMessage). "
+                        + (workspace.state.autosaveFailureMessage ?? "")
+                )
+                .help(workspace.state.autosaveFailureMessage ?? workspace.state.statusMessage)
+            }
+        }
+        .frame(width: 18, height: 18)
     }
 
     private var title: String {

--- a/apps/macos/Sources/OpenRecorderMac/StudioWindowCloseInterceptor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/StudioWindowCloseInterceptor.swift
@@ -1,0 +1,111 @@
+import AppKit
+import SwiftUI
+
+struct StudioWindowCloseInterceptor: NSViewRepresentable {
+    typealias CloseRequestHandler = @MainActor () async -> Bool
+
+    var onCloseRequest: CloseRequestHandler
+
+    func makeNSView(context: Context) -> StudioWindowCloseInterceptionView {
+        let view = StudioWindowCloseInterceptionView()
+        view.onCloseRequest = onCloseRequest
+        return view
+    }
+
+    func updateNSView(_ nsView: StudioWindowCloseInterceptionView, context: Context) {
+        nsView.onCloseRequest = onCloseRequest
+        nsView.attachToCurrentWindow()
+    }
+
+    static func dismantleNSView(
+        _ nsView: StudioWindowCloseInterceptionView,
+        coordinator: Void
+    ) {
+        nsView.detach()
+    }
+}
+
+@MainActor
+final class StudioWindowCloseInterceptionView: NSView, NSWindowDelegate {
+    var onCloseRequest: StudioWindowCloseInterceptor.CloseRequestHandler = { true }
+
+    private weak var interceptedWindow: NSWindow?
+    nonisolated(unsafe) private weak var forwardedDelegate: (any NSWindowDelegate)?
+    private var closeTask: Task<Void, Never>?
+    private var allowsNextClose = false
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow !== window {
+            detach()
+        }
+        super.viewWillMove(toWindow: newWindow)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        attachToCurrentWindow()
+    }
+
+    func attachToCurrentWindow() {
+        guard let window else { return }
+        if interceptedWindow !== window {
+            detach()
+            interceptedWindow = window
+        }
+        guard window.delegate !== self else { return }
+        forwardedDelegate = window.delegate
+        window.delegate = self
+    }
+
+    func detach() {
+        closeTask?.cancel()
+        closeTask = nil
+        if let interceptedWindow, interceptedWindow.delegate === self {
+            interceptedWindow.delegate = forwardedDelegate
+        }
+        interceptedWindow = nil
+        forwardedDelegate = nil
+        allowsNextClose = false
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        if allowsNextClose {
+            allowsNextClose = false
+            return true
+        }
+
+        guard closeTask == nil else { return false }
+        if forwardedDelegate?.windowShouldClose?(sender) == false {
+            return false
+        }
+
+        let closeRequest = onCloseRequest
+        closeTask = Task { @MainActor [weak self, weak sender] in
+            let shouldClose = await closeRequest()
+            if shouldClose {
+                self?.completeApprovedClose(sender: sender)
+            } else if !Task.isCancelled {
+                self?.closeTask = nil
+            }
+        }
+        return false
+    }
+
+    private func completeApprovedClose(sender: NSWindow?) {
+        closeTask = nil
+        guard let sender else { return }
+        allowsNextClose = true
+        sender.performClose(nil)
+    }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        super.responds(to: aSelector) || forwardedDelegate?.responds(to: aSelector) == true
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        if forwardedDelegate?.responds(to: aSelector) == true {
+            return forwardedDelegate
+        }
+        return super.forwardingTarget(for: aSelector)
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
@@ -174,7 +174,7 @@ extension VideoExportState {
 @Observable
 @MainActor
 final class VideoExportDriver {
-    var state = VideoExportState()
+    private(set) var state = VideoExportState()
 
     @ObservationIgnored private var renderVideo: (
         _ sourceURL: URL,

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -498,8 +498,6 @@ struct WindowCommandBridge: View {
 
     private func hideAppWindowsForCapture() {
         dismissCaptureWindows()
-        dismissWindow(id: "studio")
-        dismissWindow(id: "editor")
         NSApp.hide(nil)
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1,8 +1,42 @@
+import Combine
+import Observation
 import XCTest
 @testable import OpenRecorderMac
 
 @MainActor
 final class AppModelStateTests: XCTestCase {
+    func testDriverBackedFacadeParticipatesInObservationTracking() async {
+        let model = AppModel()
+        let changeObserved = expectation(description: "Driver-backed facade change observed")
+
+        withObservationTracking {
+            _ = model.includeCamera
+        } onChange: {
+            changeObserved.fulfill()
+        }
+
+        model.includeCamera = true
+
+        await fulfillment(of: [changeObserved], timeout: 1)
+    }
+
+    func testDriverBackedFacadePreservesObservableObjectNotifications() throws {
+        let suiteName = "AppModelStateTests.notifications.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let model = AppModel(recordingPreferences: RecordingPreferencesStore(defaults: defaults))
+        var emissionCount = 0
+        let observation = model.objectWillChange.sink {
+            emissionCount += 1
+        }
+
+        model.includeMicrophone.toggle()
+        model.createZoomsAutomatically.toggle()
+
+        XCTAssertEqual(emissionCount, 2)
+        withExtendedLifetime(observation) {}
+    }
+
     func testTimestampedFileNameUsesProvidedDate() {
         let date = Date(timeIntervalSince1970: 1_767_267_303)
         let formatter: DateFormatter = DateFormatter()
@@ -685,7 +719,7 @@ final class AppModelStateTests: XCTestCase {
             runRecordingCountdown: { _ in }
         )
         let source = makeSource()
-        model.captureOptions.state.includeCamera = true
+        model.includeCamera = true
         model.setCaptureStateForTesting(.ready(.recording, source))
 
         model.captureMachine.send(.recordingFilePrepared(source, outputURL))
@@ -1236,7 +1270,7 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(dismissedWindows, ["hud", "source-selector", "area-selector", "microphone-selector", "camera-selector"])
     }
 
-    func testAppWindowActionsHideAppWindowsForCaptureDismissesEditorsToo() {
+    func testAppWindowActionsHideAppWindowsForCapturePreservesEditorWindows() {
         let actions = AppWindowActions()
         var openedWindows: [String] = []
         var dismissedWindows: [String] = []
@@ -1257,9 +1291,7 @@ final class AppModelStateTests: XCTestCase {
             "source-selector",
             "area-selector",
             "microphone-selector",
-            "camera-selector",
-            "studio",
-            "editor"
+            "camera-selector"
         ])
         XCTAssertTrue(didHideApp)
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -258,7 +258,7 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
     }
 
-    func testFailedAutosaveRetainsSessionWorkspaceForRecovery() async {
+    func testFailedAutosaveRetainsSessionWorkspaceAndExportForRecovery() async {
         let shell = AppShellDriver()
         let projectPath = "/tmp/failed-save.openrecorder"
         let session = EditorSession(
@@ -270,6 +270,7 @@ final class AppShellStateMachineTests: XCTestCase {
         let snapshot = makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
         var statuses: [ProjectAutosaveStatus] = []
         let exportStarted = expectation(description: "Export started")
+        let exportCanceled = expectation(description: "Export is canceled explicitly")
         let temporaryURL = URL(fileURLWithPath: "/tmp/failed-save-export.mov")
         var cancellationToken: VideoExportCancellationToken?
         var deletedURLs: [URL] = []
@@ -288,6 +289,7 @@ final class AppShellStateMachineTests: XCTestCase {
                 while !token.isCancelled && !Task.isCancelled {
                     await Task.yield()
                 }
+                exportCanceled.fulfill()
                 throw CancellationError()
             },
             temporaryURL: { _ in temporaryURL },
@@ -314,8 +316,15 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
         XCTAssertTrue(workspace.state.isAutosaveRecoveryPresented)
         XCTAssertEqual(statuses.last, .failed("Save failed"))
+        XCTAssertFalse(cancellationToken?.isCancelled == true)
+        XCTAssertEqual(workspace.videoExport.state.phase, .exporting)
+        XCTAssertEqual(deletedURLs, [])
+
+        workspace.videoExport.cancelExport()
+        await fulfillment(of: [exportCanceled], timeout: 1)
+
         XCTAssertTrue(cancellationToken?.isCancelled == true)
-        XCTAssertEqual(workspace.videoExport.state.phase, .idle)
+        XCTAssertEqual(workspace.videoExport.state.phase, .failed)
         XCTAssertEqual(deletedURLs, [temporaryURL])
     }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -75,23 +75,23 @@ final class AppShellStateMachineTests: XCTestCase {
 
     func testShellDriverOwnsLongLivedChildDrivers() {
         let shell = AppShellDriver()
-        let workspace = shell.workspace
+        let workspace = shell.workspace(for: nil)
         let capture = shell.capture
         let captureOptions = shell.captureOptions
         let inlineSourceSelector = shell.inlineSourceSelector
         let floatingSourceSelector = shell.floatingSourceSelector
         let onboarding = shell.onboarding
         let settings = shell.settings
-        let videoExport = shell.videoExport
+        let videoExport = workspace.videoExport
 
-        XCTAssertTrue(shell.workspace === workspace)
+        XCTAssertTrue(shell.workspace(for: nil) === workspace)
         XCTAssertTrue(shell.capture === capture)
         XCTAssertTrue(shell.captureOptions === captureOptions)
         XCTAssertTrue(shell.inlineSourceSelector === inlineSourceSelector)
         XCTAssertTrue(shell.floatingSourceSelector === floatingSourceSelector)
         XCTAssertTrue(shell.onboarding === onboarding)
         XCTAssertTrue(shell.settings === settings)
-        XCTAssertTrue(shell.videoExport === videoExport)
+        XCTAssertTrue(shell.workspace(for: nil).videoExport === videoExport)
     }
 
     func testShellDriverKeepsEditorWindowWorkspacesIndependentBySession() {
@@ -102,7 +102,7 @@ final class AppShellStateMachineTests: XCTestCase {
         let firstWorkspace = shell.workspace(for: firstSession)
         let secondWorkspace = shell.workspace(for: secondSession)
 
-        XCTAssertTrue(shell.workspace(for: nil) === shell.workspace)
+        XCTAssertTrue(shell.workspace(for: nil) === shell.workspace(for: nil))
         XCTAssertTrue(shell.workspace(for: firstSession) === firstWorkspace)
         XCTAssertFalse(firstWorkspace === secondWorkspace)
 
@@ -111,6 +111,719 @@ final class AppShellStateMachineTests: XCTestCase {
 
         XCTAssertEqual(firstWorkspace.screenshot.state.screenshot.padding, 96)
         XCTAssertEqual(secondWorkspace.screenshot.state.screenshot.padding, 18)
+        XCTAssertFalse(firstWorkspace.videoExport === secondWorkspace.videoExport)
+    }
+
+    func testSessionWorkspaceNavigationDoesNotMutateGlobalSection() {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/session.mp4"))
+        let workspace = shell.workspace(for: session)
+        var forwardedSections: [AppSection] = []
+        workspace.configure(
+            setAppSection: { forwardedSections.append($0) },
+            setStatusMessage: { _ in }
+        )
+
+        workspace.send(.sectionSelected(.projects))
+
+        XCTAssertEqual(workspace.state.selectedSection, .projects)
+        XCTAssertTrue(forwardedSections.isEmpty)
+        XCTAssertEqual(shell.state.selectedSection, .capture)
+    }
+
+    func testDefaultWorkspaceMayForwardNavigationToAppShell() {
+        let shell = AppShellDriver()
+        var forwardedSections: [AppSection] = []
+        let workspace = shell.workspace(for: nil)
+        workspace.configure(
+            setAppSection: { forwardedSections.append($0) },
+            setStatusMessage: { _ in }
+        )
+
+        workspace.send(.sectionSelected(.projects))
+
+        XCTAssertEqual(forwardedSections, [.projects])
+    }
+
+    func testClosingSessionEvictsItsWorkspace() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .screenshot, url: URL(fileURLWithPath: "/tmp/close.png"))
+        let originalWorkspace = shell.workspace(for: session)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+
+        await shell.closeWorkspace(for: session)
+
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+        XCTAssertFalse(shell.workspace(for: session) === originalWorkspace)
+    }
+
+    func testClosingSessionFlushesBothEditorAutosavesBeforeEviction() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/autosave.mp4"))
+        let workspace = shell.workspace(for: session)
+        let videoSnapshot = makeWorkspaceAutosaveSnapshot(path: "/tmp/video.openrecorder", kind: .video)
+        let screenshotSnapshot = makeWorkspaceAutosaveSnapshot(path: "/tmp/screenshot.openrecorder", kind: .screenshot)
+        var savedSnapshots: [ProjectAutosaveSnapshot] = []
+
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                savedSnapshots.append(snapshot)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.screenshot.configure(
+            saveHandler: { snapshot in
+                savedSnapshots.append(snapshot)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            setWorkspaceStatus: { _ in }
+        )
+        workspace.video.send(.autosaveSnapshotChanged(videoSnapshot))
+        workspace.screenshot.send(.autosaveSnapshotChanged(screenshotSnapshot))
+
+        await shell.closeWorkspace(for: session)
+
+        XCTAssertEqual(savedSnapshots, [videoSnapshot, screenshotSnapshot])
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testReopeningSessionDuringCloseReusesWorkspaceAndCancelsEviction() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/reopen.mp4"))
+        let workspace = shell.workspace(for: session)
+        let snapshot = makeWorkspaceAutosaveSnapshot(path: "/tmp/reopen.openrecorder", kind: .video)
+        let gate = WorkspaceAutosaveGate()
+        let saveStarted = expectation(description: "Workspace save started")
+
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                saveStarted.fulfill()
+                await gate.wait()
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(snapshot))
+        let initialFlush = Task { @MainActor in
+            await workspace.video.flushPendingAutosave()
+        }
+        await fulfillment(of: [saveStarted], timeout: 1)
+
+        guard let closeRequest = shell.beginClosingWorkspace(for: session) else {
+            return XCTFail("Expected a close request")
+        }
+        let close = Task { @MainActor in
+            await shell.finishClosingWorkspace(closeRequest)
+        }
+
+        shell.activateWorkspace(for: session)
+        let reopenedWorkspace = shell.workspace(for: session)
+        await gate.open()
+        _ = await initialFlush.value
+        _ = await close.value
+
+        XCTAssertTrue(reopenedWorkspace === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+
+        await shell.closeWorkspace(for: session)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testActivationCancelsCloseBeforeAsyncCleanupStarts() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/delayed-close.mp4"))
+        let workspace = shell.workspace(for: session)
+        guard let closeRequest = shell.beginClosingWorkspace(for: session) else {
+            return XCTFail("Expected a close request")
+        }
+
+        shell.activateWorkspace(for: session)
+        let reopenedWorkspace = shell.workspace(for: session)
+        await shell.finishClosingWorkspace(closeRequest)
+
+        XCTAssertTrue(reopenedWorkspace === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+
+        await shell.closeWorkspace(for: session)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testFailedAutosaveRetainsSessionWorkspaceForRecovery() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/failed-save.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/failed-save.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        let snapshot = makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        var statuses: [ProjectAutosaveStatus] = []
+        let exportStarted = expectation(description: "Export started")
+        let temporaryURL = URL(fileURLWithPath: "/tmp/failed-save-export.mov")
+        var cancellationToken: VideoExportCancellationToken?
+        var deletedURLs: [URL] = []
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { _ in throw WorkspaceAutosaveError.failed },
+            statusHandler: { statuses.append($0) },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.videoExport.configure(
+            renderVideo: { _, _, _, token, _, _ in
+                cancellationToken = token
+                exportStarted.fulfill()
+                while !token.isCancelled && !Task.isCancelled {
+                    await Task.yield()
+                }
+                throw CancellationError()
+            },
+            temporaryURL: { _ in temporaryURL },
+            saveDestination: { _, _ -> URL? in nil },
+            copyFile: { _, _ in },
+            deleteFile: { deletedURLs.append($0) },
+            revealFile: { _ in },
+            setStatusMessage: { _ in }
+        )
+        workspace.video.send(.autosaveSnapshotChanged(snapshot))
+        workspace.videoExport.export(sourceURL: session.url, options: .default, edits: .empty)
+        await fulfillment(of: [exportStarted], timeout: 1)
+
+        let closeOutcome = await shell.closeWorkspace(for: session)
+
+        let reopenedSession = EditorSession(
+            kind: .video,
+            url: session.url,
+            projectPath: projectPath
+        )
+        XCTAssertNotEqual(reopenedSession.id, session.id)
+        XCTAssertEqual(closeOutcome, .autosaveFailed)
+        XCTAssertTrue(shell.workspace(for: reopenedSession) === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+        XCTAssertTrue(workspace.state.isAutosaveRecoveryPresented)
+        XCTAssertEqual(statuses.last, .failed("Save failed"))
+        XCTAssertTrue(cancellationToken?.isCancelled == true)
+        XCTAssertEqual(workspace.videoExport.state.phase, .idle)
+        XCTAssertEqual(deletedURLs, [temporaryURL])
+    }
+
+    func testMixedAutosaveOutcomePreservesTheFirstFailureReason() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/mixed-save.mp4"),
+            projectPath: "/tmp/mixed-save.openrecorder"
+        )
+        let workspace = shell.workspace(for: session)
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { _ in throw WorkspaceAutosaveError.failed },
+            statusHandler: { [weak workspace] status in
+                workspace?.handleProjectAutosaveStatus(status)
+            },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.screenshot.configure(
+            saveHandler: { snapshot in
+                makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { [weak workspace] status in
+                workspace?.handleProjectAutosaveStatus(status)
+            },
+            setWorkspaceStatus: { _ in }
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: session.projectPath!, kind: .video)
+        ))
+        workspace.screenshot.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: session.projectPath!, kind: .screenshot)
+        ))
+
+        let outcome = await shell.closeWorkspace(for: session)
+
+        XCTAssertEqual(outcome, .autosaveFailed)
+        XCTAssertEqual(workspace.state.statusSeverity, .failure)
+        XCTAssertEqual(workspace.state.autosaveFailureMessage, "Save failed")
+    }
+
+    func testCloseFlushesEditsCreatedWhileAnotherEditorAutosaveIsInFlight() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/quiescent-close.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/quiescent-close.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        let screenshotGate = WorkspaceAutosaveGate()
+        let screenshotSaveStarted = expectation(description: "Screenshot save started")
+        var savedVideoTitles: [String] = []
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                savedVideoTitles.append(snapshot.title)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { [weak workspace] status in
+                workspace?.handleProjectAutosaveStatus(status)
+            },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.screenshot.configure(
+            saveHandler: { snapshot in
+                screenshotSaveStarted.fulfill()
+                await screenshotGate.wait()
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { [weak workspace] status in
+                workspace?.handleProjectAutosaveStatus(status)
+            },
+            setWorkspaceStatus: { _ in }
+        )
+        var initialVideo = makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        initialVideo.title = "Initial video"
+        workspace.video.send(.autosaveSnapshotChanged(initialVideo))
+        workspace.screenshot.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .screenshot)
+        ))
+
+        let close = Task { @MainActor in
+            await shell.closeWorkspace(for: session)
+        }
+        await fulfillment(of: [screenshotSaveStarted], timeout: 1)
+        var updatedVideo = initialVideo
+        updatedVideo.title = "Updated during close"
+        workspace.video.send(.autosaveSnapshotChanged(updatedVideo))
+        await screenshotGate.open()
+
+        let closeOutcome = await close.value
+        XCTAssertEqual(closeOutcome, .closed)
+        XCTAssertEqual(savedVideoTitles, ["Initial video", "Updated during close"])
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testCloseJoinerStartsFreshFlushForEditAddedBeforeCoalescedFlushCompletes() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/coalesced-close.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/coalesced-close.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        let screenshotGate = WorkspaceAutosaveGate()
+        let screenshotSaveStarted = expectation(description: "Coalesced screenshot save started")
+        var savedVideoTitles: [String] = []
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                savedVideoTitles.append(snapshot.title)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.screenshot.configure(
+            saveHandler: { snapshot in
+                screenshotSaveStarted.fulfill()
+                await screenshotGate.wait()
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            setWorkspaceStatus: { _ in }
+        )
+        var initialVideo = makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        initialVideo.title = "Initial coalesced video"
+        workspace.video.send(.autosaveSnapshotChanged(initialVideo))
+        workspace.screenshot.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .screenshot)
+        ))
+
+        let originalFlush = Task { @MainActor in
+            await workspace.flushPendingAutosaves()
+        }
+        await fulfillment(of: [screenshotSaveStarted], timeout: 1)
+        let close = Task { @MainActor in
+            await shell.closeWorkspace(for: session)
+        }
+        await Task.yield()
+        var lateVideo = initialVideo
+        lateVideo.title = "Late coalesced video"
+        workspace.video.send(.autosaveSnapshotChanged(lateVideo))
+        await screenshotGate.open()
+
+        let originalFlushOutcome = await originalFlush.value
+        let closeOutcome = await close.value
+        XCTAssertTrue(originalFlushOutcome)
+        XCTAssertEqual(closeOutcome, .closed)
+        XCTAssertEqual(savedVideoTitles, ["Initial coalesced video", "Late coalesced video"])
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testCancelingCloseDuringAutosaveDoesNotEvictWorkspace() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/canceled-close.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/canceled-close.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        let gate = WorkspaceAutosaveGate()
+        let saveStarted = expectation(description: "Save started")
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                saveStarted.fulfill()
+                await gate.wait()
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        ))
+        guard let request = shell.beginClosingWorkspace(for: session) else {
+            return XCTFail("Expected a close request")
+        }
+        let close = Task { @MainActor in
+            await shell.finishClosingWorkspace(request)
+        }
+        await fulfillment(of: [saveStarted], timeout: 1)
+
+        close.cancel()
+        await gate.open()
+
+        let canceledOutcome = await close.value
+        XCTAssertEqual(canceledOutcome, .canceled)
+        XCTAssertTrue(shell.workspace(for: session) === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+        let finalCloseOutcome = await shell.closeWorkspace(for: session)
+        XCTAssertEqual(finalCloseOutcome, .closed)
+    }
+
+    func testRetryingRecoveredAutosaveAllowsCleanClose() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/retry-save.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/retry-save.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        var shouldFail = true
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                if shouldFail { throw WorkspaceAutosaveError.failed }
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        ))
+
+        let failedCloseOutcome = await shell.closeWorkspace(for: session)
+        XCTAssertEqual(failedCloseOutcome, .autosaveFailed)
+        shouldFail = false
+        let didRetrySave = await workspace.retryPendingAutosaves()
+        XCTAssertTrue(didRetrySave)
+        XCTAssertFalse(workspace.state.isAutosaveRecoveryPresented)
+        XCTAssertEqual(workspace.state.statusMessage, "Saved")
+
+        let successfulCloseOutcome = await shell.closeWorkspace(for: session)
+        XCTAssertEqual(successfulCloseOutcome, .closed)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testDiscardingRecoveredAutosaveAllowsExplicitDataLoss() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/discard-save.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/discard-save.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        var didDiscard = false
+        let saveAfterDiscard = expectation(description: "Discarded workspace must not save on disappear")
+        saveAfterDiscard.isInverted = true
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { _ in
+                if didDiscard { saveAfterDiscard.fulfill() }
+                throw WorkspaceAutosaveError.failed
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        ))
+
+        let failedCloseOutcome = await shell.closeWorkspace(for: session)
+        XCTAssertEqual(failedCloseOutcome, .autosaveFailed)
+        didDiscard = true
+        shell.discardWorkspace(for: session)
+        workspace.video.send(.disappeared(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        ))
+
+        await fulfillment(of: [saveAfterDiscard], timeout: 0.05)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+        XCTAssertFalse(shell.workspace(for: session) === workspace)
+    }
+
+    func testWorkspaceCannotBeDiscardedWhileAutosaveIsInFlight() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/in-flight-discard.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/in-flight-discard.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        let gate = WorkspaceAutosaveGate()
+        let saveStarted = expectation(description: "Autosave started before discard")
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                saveStarted.fulfill()
+                await gate.wait()
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        ))
+        let flush = Task { @MainActor in
+            await workspace.video.flushPendingAutosave()
+        }
+        await fulfillment(of: [saveStarted], timeout: 1)
+
+        XCTAssertFalse(shell.discardWorkspace(for: session))
+        XCTAssertTrue(shell.workspace(for: session) === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+
+        await gate.open()
+        _ = await flush.value
+        let closeOutcome = await shell.closeWorkspace(for: session)
+        XCTAssertEqual(closeOutcome, .closed)
+    }
+
+    func testDefaultWorkspaceFailedCloseCanRetryWithoutEviction() async {
+        let shell = AppShellDriver()
+        let workspace = shell.workspace(for: nil)
+        let snapshot = makeWorkspaceAutosaveSnapshot(path: "/tmp/default-retry.openrecorder", kind: .video)
+        var shouldFail = true
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                if shouldFail { throw WorkspaceAutosaveError.failed }
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(snapshot))
+
+        let failedCloseOutcome = await shell.closeWorkspace(for: nil)
+        XCTAssertEqual(failedCloseOutcome, .autosaveFailed)
+        XCTAssertTrue(workspace.state.isAutosaveRecoveryPresented)
+        XCTAssertTrue(shell.workspace(for: nil) === workspace)
+
+        shouldFail = false
+        let didRetrySave = await workspace.retryPendingAutosaves()
+        XCTAssertTrue(didRetrySave)
+        XCTAssertFalse(workspace.state.isAutosaveRecoveryPresented)
+
+        let successfulCloseOutcome = await shell.closeWorkspace(for: nil)
+        XCTAssertEqual(successfulCloseOutcome, .closed)
+        XCTAssertTrue(shell.workspace(for: nil) === workspace)
+    }
+
+    func testDefaultWorkspaceDiscardReplacesAbandonedState() async {
+        let shell = AppShellDriver()
+        let workspace = shell.workspace(for: nil)
+        let snapshot = makeWorkspaceAutosaveSnapshot(path: "/tmp/default-discard.openrecorder", kind: .video)
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { _ in throw WorkspaceAutosaveError.failed },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(snapshot))
+
+        let failedCloseOutcome = await shell.closeWorkspace(for: nil)
+        XCTAssertEqual(failedCloseOutcome, .autosaveFailed)
+        shell.discardWorkspace(for: nil)
+
+        let replacement = shell.workspace(for: nil)
+        XCTAssertFalse(replacement === workspace)
+        XCTAssertFalse(replacement.state.isAutosaveRecoveryPresented)
+    }
+
+    func testReactivatedFailedSessionCannotBeStolenByAnotherWindow() async {
+        let shell = AppShellDriver()
+        let projectPath = "/tmp/reactivated.openrecorder"
+        let session = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/reactivated.mp4"),
+            projectPath: projectPath
+        )
+        let workspace = shell.workspace(for: session)
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { _ in throw WorkspaceAutosaveError.failed },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: projectPath, kind: .video)
+        ))
+        await shell.closeWorkspace(for: session)
+
+        shell.activateWorkspace(for: session)
+        let secondSession = EditorSession(
+            kind: .video,
+            url: session.url,
+            projectPath: projectPath
+        )
+        let secondWorkspace = shell.workspace(for: secondSession)
+
+        XCTAssertTrue(shell.workspace(for: session) === workspace)
+        XCTAssertFalse(secondWorkspace === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 2)
+    }
+
+    func testSessionStatusStaysLocalWhileDefaultWorkspaceStatusForwards() {
+        let model = AppModel()
+        let originalStatus = model.statusMessage
+        let session = EditorSession(kind: .screenshot, url: URL(fileURLWithPath: "/tmp/local.png"))
+        let sessionWorkspace = model.appShell.workspace(for: session)
+        let defaultWorkspace = model.appShell.workspace(for: nil)
+
+        sessionWorkspace.send(.statusUpdated(EditorWorkspaceStatus(
+            message: "Session-only status",
+            severity: .informational
+        )))
+
+        XCTAssertEqual(sessionWorkspace.state.statusMessage, "Session-only status")
+        XCTAssertEqual(model.statusMessage, originalStatus)
+
+        defaultWorkspace.send(.statusUpdated(EditorWorkspaceStatus(
+            message: "Default workspace status",
+            severity: .informational
+        )))
+
+        XCTAssertEqual(model.statusMessage, "Default workspace status")
+    }
+
+    func testWorkspaceConfigurationCoversExistingAndFutureSessions() {
+        let shell = AppShellDriver()
+        let firstSession = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/first-config.mp4"))
+        let secondSession = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/second-config.mp4"))
+        let firstWorkspace = shell.workspace(for: firstSession)
+        var configuredWorkspaces: [ObjectIdentifier] = []
+
+        shell.configure(configureWorkspace: { workspace in
+            configuredWorkspaces.append(ObjectIdentifier(workspace))
+        })
+        let secondWorkspace = shell.workspace(for: secondSession)
+
+        XCTAssertEqual(Set(configuredWorkspaces), Set([
+            ObjectIdentifier(shell.workspace(for: nil)),
+            ObjectIdentifier(firstWorkspace),
+            ObjectIdentifier(secondWorkspace)
+        ]))
+        XCTAssertEqual(configuredWorkspaces.count, 3)
+    }
+
+    func testClosingOneSessionClearsOnlyItsActiveExport() async {
+        let shell = AppShellDriver()
+        var temporaryURLs: [ObjectIdentifier: URL] = [:]
+        var cancellationTokens: [ObjectIdentifier: VideoExportCancellationToken] = [:]
+        var deletedURLs: [URL] = []
+        let rendersStarted = expectation(description: "Both workspace exports started")
+        rendersStarted.expectedFulfillmentCount = 2
+        shell.configure(configureWorkspace: { workspace in
+            let workspaceID = ObjectIdentifier(workspace)
+            let temporaryURL = URL(fileURLWithPath: "/tmp/\(UUID().uuidString).mov")
+            temporaryURLs[workspaceID] = temporaryURL
+            workspace.videoExport.configure(
+                renderVideo: { _, _, _, token, _, _ in
+                    cancellationTokens[workspaceID] = token
+                    rendersStarted.fulfill()
+                    while !token.isCancelled && !Task.isCancelled {
+                        await Task.yield()
+                    }
+                    throw CancellationError()
+                },
+                temporaryURL: { _ in temporaryURL },
+                saveDestination: { _, _ -> URL? in nil },
+                copyFile: { _, _ in },
+                deleteFile: { deletedURLs.append($0) },
+                revealFile: { _ in },
+                setStatusMessage: { _ in }
+            )
+        })
+        let firstSession = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/first-export.mp4"))
+        let secondSession = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/second-export.mp4"))
+        let firstWorkspace = shell.workspace(for: firstSession)
+        let secondWorkspace = shell.workspace(for: secondSession)
+        let firstID = ObjectIdentifier(firstWorkspace)
+        let secondID = ObjectIdentifier(secondWorkspace)
+
+        firstWorkspace.videoExport.export(sourceURL: firstSession.url, options: .default, edits: .empty)
+        secondWorkspace.videoExport.export(sourceURL: secondSession.url, options: .default, edits: .empty)
+        await fulfillment(of: [rendersStarted], timeout: 1)
+
+        await shell.closeWorkspace(for: firstSession)
+
+        XCTAssertEqual(firstWorkspace.videoExport.state.phase, .idle)
+        XCTAssertTrue(cancellationTokens[firstID]?.isCancelled == true)
+        XCTAssertEqual(deletedURLs, temporaryURLs[firstID].map { [$0] } ?? [])
+        XCTAssertEqual(secondWorkspace.videoExport.state.phase, .exporting)
+        XCTAssertFalse(cancellationTokens[secondID]?.isCancelled ?? true)
+
+        await shell.closeWorkspace(for: secondSession)
     }
 
     func testAppModelFacadeMirrorsShellRouting() {
@@ -129,6 +842,29 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(model.appShell.state.lastEditorSession, session)
         XCTAssertEqual(model.windowCommand?.action, .showStudio)
         XCTAssertEqual(model.windowCommand?.editorSession, session)
+    }
+}
+
+@MainActor
+final class RecordingPreferencesStoreTests: XCTestCase {
+    func testPreferencesRoundTripThroughIsolatedDefaults() throws {
+        let suiteName = "RecordingPreferencesStoreTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = RecordingPreferencesStore(defaults: defaults)
+
+        XCTAssertEqual(store.load(), RecordingPreferences(
+            createsZoomsAutomatically: true,
+            autoZoomAnimationPreset: .balanced
+        ))
+
+        store.setCreatesZoomsAutomatically(false)
+        store.setAutoZoomAnimationPreset(.cinematic)
+
+        XCTAssertEqual(store.load(), RecordingPreferences(
+            createsZoomsAutomatically: false,
+            autoZoomAnimationPreset: .cinematic
+        ))
     }
 }
 
@@ -251,6 +987,24 @@ private func waitForCondition(
 
 @MainActor
 final class CaptureOptionsStateMachineTests: XCTestCase {
+    func testBooleanBindingsRouteThroughCaptureOptionEvents() {
+        let driver = CaptureOptionsDriver()
+
+        driver.binding(\.includeMicrophone).wrappedValue = true
+        driver.binding(\.includeSystemAudio).wrappedValue = true
+        driver.binding(\.includeCamera).wrappedValue = true
+        driver.binding(\.showCursor).wrappedValue = false
+        driver.binding(\.showClicks).wrappedValue = true
+        driver.binding(\.canChangeOptions).wrappedValue = false
+
+        XCTAssertTrue(driver.state.includeMicrophone)
+        XCTAssertTrue(driver.state.includeSystemAudio)
+        XCTAssertTrue(driver.state.includeCamera)
+        XCTAssertFalse(driver.state.showCursor)
+        XCTAssertTrue(driver.state.showClicks)
+        XCTAssertFalse(driver.state.canChangeOptions)
+    }
+
     func testDeviceSelectionAndLockedSystemAudioAreReducerDriven() {
         var state = CaptureOptionsState(
             microphoneDevices: [CaptureDeviceInfo(id: "mic-1", name: "Studio Mic", isDefault: false)],
@@ -279,6 +1033,10 @@ final class SourceSelectorStateMachineTests: XCTestCase {
 
         XCTAssertEqual(state.applying(.preferredSourceKindSynced(.area)), [])
         XCTAssertEqual(state.sourceTab, .area)
+
+        XCTAssertEqual(state.applying(.visibleTabsChanged([.screens])), [])
+        XCTAssertEqual(state.visibleTabs, [.screens])
+        XCTAssertEqual(state.sourceTab, .screens)
 
         XCTAssertEqual(state.applying(.heightMeasured(500)), [])
         XCTAssertEqual(state.preferredHeight, 532)
@@ -329,11 +1087,7 @@ final class OnboardingAndSettingsStateMachineTests: XCTestCase {
         XCTAssertEqual(state.autoZoomAnimationPreset, .guided)
         XCTAssertEqual(state.applying(.folderOpenRequested("/tmp")), [.openFolder("/tmp")])
 
-        let health = HealthPayload(service: "open-recorder", version: "1", platform: "macOS")
-        let paths = AppPaths(recordingsDir: "/r", screenshotsDir: "/s", projectsDir: "/p", supportDir: "/support")
-        XCTAssertEqual(state.applying(.serviceRefreshSucceeded(serviceHealth: health, paths: paths)), [])
-        XCTAssertEqual(state.serviceHealth, health)
-        XCTAssertEqual(state.paths, paths)
+        XCTAssertEqual(state.applying(.serviceRefreshSucceeded), [])
         XCTAssertFalse(state.isRefreshingService)
     }
 }
@@ -398,6 +1152,46 @@ private func makeProjectSummary(path: String) -> ProjectSummary {
         lastOpenedAt: "2026-05-19T00:00:00Z",
         missing: false
     )
+}
+
+private func makeWorkspaceAutosaveSnapshot(path: String, kind: EditorMediaKind) -> ProjectAutosaveSnapshot {
+    ProjectAutosaveSnapshot(
+        projectPath: path,
+        title: URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent,
+        recordingPath: kind == .video ? "/tmp/demo.mp4" : nil,
+        screenshotPath: kind == .screenshot ? "/tmp/demo.png" : nil,
+        sourceName: nil,
+        editorState: ProjectEditorState(
+            timelineEdits: .empty,
+            video: kind == .video ? .default : nil,
+            screenshot: kind == .screenshot ? .default : nil
+        ),
+        recordingSession: nil
+    )
+}
+
+private actor WorkspaceAutosaveGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private enum WorkspaceAutosaveError: LocalizedError {
+    case failed
+
+    var errorDescription: String? { "Save failed" }
 }
 
 private func makeCaptureSource(id: String, kind: CaptureSourceKind) -> CaptureSource {

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorStateMachineTests.swift
@@ -4,6 +4,49 @@ import XCTest
 @testable import OpenRecorderMac
 
 final class VideoEditorStateMachineTests: XCTestCase {
+    func testExplicitEditorSessionDoesNotInheritFallbackProjectMetadata() {
+        let fallback = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/project.mp4"),
+            title: "Project",
+            projectPath: "/tmp/project.openrecorder",
+            videoEditorState: .default
+        )
+        let explicit = EditorSession(
+            kind: .video,
+            url: URL(fileURLWithPath: "/tmp/raw.mp4")
+        )
+
+        let metadata = EditorSessionMetadata(
+            explicitSession: explicit,
+            fallbackSession: fallback
+        )
+
+        XCTAssertNil(metadata.projectPath)
+        XCTAssertEqual(metadata.title, explicit.title)
+        XCTAssertNil(metadata.videoEditorState)
+        XCTAssertNil(metadata.recordingSession)
+    }
+
+    func testDefaultEditorUsesFallbackSessionMetadata() {
+        let fallback = EditorSession(
+            kind: .screenshot,
+            url: URL(fileURLWithPath: "/tmp/project.png"),
+            title: "Project",
+            projectPath: "/tmp/project.openrecorder",
+            screenshotEditorState: .default
+        )
+
+        let metadata = EditorSessionMetadata(
+            explicitSession: nil,
+            fallbackSession: fallback
+        )
+
+        XCTAssertEqual(metadata.projectPath, fallback.projectPath)
+        XCTAssertEqual(metadata.title, fallback.title)
+        XCTAssertEqual(metadata.screenshotEditorState, fallback.screenshotEditorState)
+    }
+
     func testSessionAppliesInitialVideoStateAndTimelineSnapshot() {
         let videoURL = URL(fileURLWithPath: "/tmp/example.mp4")
         let projectPath = "/tmp/example.openrecorder"
@@ -210,6 +253,111 @@ final class VideoEditorStateMachineTests: XCTestCase {
 
         XCTAssertEqual(state.applying(.autosaveSnapshotChanged(snapshot)), [.scheduleAutosave(snapshot)])
         XCTAssertEqual(state.applying(.disappeared(snapshot)), [.flushAutosave(snapshot)])
+    }
+
+    @MainActor
+    func testDisappearedFlushSurvivesDriverRelease() async {
+        let snapshot = ProjectAutosaveSnapshot(
+            projectPath: "/tmp/release.openrecorder",
+            title: "Release",
+            recordingPath: "/tmp/release.mp4",
+            screenshotPath: nil,
+            sourceName: nil,
+            editorState: ProjectEditorState(video: .default),
+            recordingSession: nil
+        )
+        var savedSnapshots: [ProjectAutosaveSnapshot] = []
+        let saveCompleted = expectation(description: "Final autosave completed")
+        var driver: VideoEditorDriver? = VideoEditorDriver()
+        driver?.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                savedSnapshots.append(snapshot)
+                saveCompleted.fulfill()
+                return ProjectSummary(
+                    id: "release",
+                    title: snapshot.title,
+                    path: snapshot.projectPath,
+                    recordingPath: snapshot.recordingPath,
+                    screenshotPath: snapshot.screenshotPath,
+                    sourceName: snapshot.sourceName,
+                    createdAt: "now",
+                    updatedAt: "now",
+                    lastOpenedAt: "now",
+                    missing: false
+                )
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+
+        driver?.send(.disappeared(snapshot))
+        driver = nil
+
+        await fulfillment(of: [saveCompleted], timeout: 1)
+        XCTAssertEqual(savedSnapshots, [snapshot])
+    }
+
+    @MainActor
+    func testDismissingExportWhileAutosaveIsPendingPreventsLateExportLaunch() async {
+        let recordingURL = URL(fileURLWithPath: "/tmp/pending-export.mp4")
+        let snapshot = ProjectAutosaveSnapshot(
+            projectPath: "/tmp/pending-export.openrecorder",
+            title: "Pending Export",
+            recordingPath: recordingURL.path,
+            screenshotPath: nil,
+            sourceName: nil,
+            editorState: ProjectEditorState(video: .default),
+            recordingSession: nil
+        )
+        let gate = EditorAutosaveGate()
+        let saveStarted = expectation(description: "Pre-export autosave started")
+        let exportCalled = expectation(description: "Late export should not start")
+        exportCalled.isInverted = true
+        var clearCount = 0
+        let driver = VideoEditorDriver()
+        driver.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                saveStarted.fulfill()
+                await gate.wait()
+                return ProjectSummary(
+                    id: "pending-export",
+                    title: snapshot.title,
+                    path: snapshot.projectPath,
+                    recordingPath: snapshot.recordingPath,
+                    screenshotPath: snapshot.screenshotPath,
+                    sourceName: snapshot.sourceName,
+                    createdAt: "now",
+                    updatedAt: "now",
+                    lastOpenedAt: "now",
+                    missing: false
+                )
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in exportCalled.fulfill() },
+            clearVideoExportDialogState: { clearCount += 1 }
+        )
+        driver.send(.exportRequested)
+        driver.send(.exportConfirmed(
+            recordingURL: recordingURL,
+            edits: .empty,
+            snapshot: snapshot,
+            cursorTelemetryURL: nil,
+            facecamVideoURL: nil,
+            facecamOffsetMs: nil,
+            cameraFallback: nil
+        ))
+        await fulfillment(of: [saveStarted], timeout: 1)
+
+        driver.send(.sheetDismissed(exportIsBusy: false))
+        await gate.open()
+
+        await fulfillment(of: [exportCalled], timeout: 0.05)
+        XCTAssertEqual(clearCount, 1)
     }
 
     func testExportDraftInitializesMutatesAndConfirmsFromMachineState() {
@@ -587,10 +735,18 @@ final class ScreenshotEditorStateMachineTests: XCTestCase {
 
         XCTAssertEqual(state.applying(.autosaveSnapshotChanged(snapshot)), [.scheduleAutosave(snapshot)])
         XCTAssertEqual(state.applying(.disappeared(snapshot)), [.flushAutosave(snapshot)])
-        XCTAssertEqual(state.applying(.saveFailed("No image")), [.setStatusMessage("No image")])
-        XCTAssertEqual(state.applying(.saveSucceeded(exportURL)), [.setStatusMessage("Exported exported-shot.png")])
-        XCTAssertEqual(state.applying(.copyFailed("No image")), [.setStatusMessage("No image")])
-        XCTAssertEqual(state.applying(.copySucceeded), [.setStatusMessage("Screenshot PNG copied")])
+        XCTAssertEqual(state.applying(.saveFailed("No image")), [
+            .setWorkspaceStatus(EditorWorkspaceStatus(message: "No image", severity: .failure))
+        ])
+        XCTAssertEqual(state.applying(.saveSucceeded(exportURL)), [
+            .setWorkspaceStatus(EditorWorkspaceStatus(message: "Exported exported-shot.png", severity: .success))
+        ])
+        XCTAssertEqual(state.applying(.copyFailed("No image")), [
+            .setWorkspaceStatus(EditorWorkspaceStatus(message: "No image", severity: .failure))
+        ])
+        XCTAssertEqual(state.applying(.copySucceeded), [
+            .setWorkspaceStatus(EditorWorkspaceStatus(message: "Screenshot PNG copied", severity: .success))
+        ])
     }
 
     @MainActor
@@ -618,7 +774,7 @@ final class ScreenshotEditorStateMachineTests: XCTestCase {
                 )
             },
             statusHandler: { _ in },
-            setStatusMessage: { statusMessages.append($0) },
+            setWorkspaceStatus: { statusMessages.append($0.message) },
             renderPNG: { _, _ in Data([0x89, 0x50, 0x4E, 0x47]) },
             presentSaveURL: { _ in targetURL },
             writePNG: { _, url in savedURL = url },
@@ -668,7 +824,7 @@ final class ScreenshotEditorStateMachineTests: XCTestCase {
                 )
             },
             statusHandler: { _ in },
-            setStatusMessage: { _ in },
+            setWorkspaceStatus: { _ in },
             renderPNG: { _, state in
                 renderedState = state
                 return Data([0x89, 0x50, 0x4E, 0x47])
@@ -787,6 +943,69 @@ final class TimelineEditStateMachineTests: XCTestCase {
 }
 
 final class EditorWorkspaceStateMachineTests: XCTestCase {
+    func testAutosaveRecoveryPresentationAndResolutionStayWorkspaceLocal() {
+        var state = EditorWorkspaceState()
+
+        XCTAssertEqual(state.applying(.autosaveRecoveryRequired), [.setStatusMessage("Save failed")])
+        XCTAssertTrue(state.isAutosaveRecoveryPresented)
+
+        XCTAssertEqual(state.applying(.autosaveRecoveryPresented(false)), [])
+        XCTAssertFalse(state.isAutosaveRecoveryPresented)
+
+        XCTAssertEqual(state.applying(.autosaveRecoveryResolved("Saved")), [.setStatusMessage("Saved")])
+        XCTAssertFalse(state.isAutosaveRecoveryPresented)
+        XCTAssertEqual(state.statusMessage, "Saved")
+        XCTAssertEqual(state.statusSeverity, .success)
+        XCTAssertNil(state.autosaveFailureMessage)
+    }
+
+    func testAutosaveFailureKeepsTypedSeverityAndDetailedRecoveryReason() {
+        var state = EditorWorkspaceState()
+
+        XCTAssertEqual(state.applying(.statusUpdated(EditorWorkspaceStatus(
+            message: "Save failed",
+            severity: .failure,
+            domain: .autosave,
+            failureDetail: "The disk is full."
+        ))), [.setStatusMessage("Save failed")])
+        XCTAssertEqual(state.statusSeverity, .failure)
+        XCTAssertEqual(state.autosaveFailureMessage, "The disk is full.")
+
+        XCTAssertEqual(state.applying(.statusUpdated(EditorWorkspaceStatus(
+            message: "Exported demo.mov",
+            severity: .success
+        ))), [])
+        XCTAssertEqual(state.statusMessage, "Save failed")
+        XCTAssertEqual(state.statusSeverity, .failure)
+
+        XCTAssertEqual(state.applying(.autosaveRecoveryRequired), [])
+        XCTAssertTrue(state.isAutosaveRecoveryPresented)
+        XCTAssertEqual(state.autosaveFailureMessage, "The disk is full.")
+
+        XCTAssertEqual(state.applying(.autosaveRetryStarted), [.setStatusMessage("Retrying save…")])
+        XCTAssertTrue(state.isAutosaveRetryInProgress)
+        XCTAssertEqual(state.statusSeverity, .progress)
+        XCTAssertEqual(state.autosaveFailureMessage, "The disk is full.")
+        XCTAssertEqual(state.applying(.statusUpdated(EditorWorkspaceStatus(
+            message: "Save failed",
+            severity: .failure,
+            domain: .autosave,
+            failureDetail: "The disk is still full."
+        ))), [.setStatusMessage("Save failed")])
+        XCTAssertEqual(state.applying(.autosaveRetryFinished), [])
+        XCTAssertFalse(state.isAutosaveRetryInProgress)
+        XCTAssertEqual(state.statusSeverity, .failure)
+        XCTAssertEqual(state.autosaveFailureMessage, "The disk is still full.")
+
+        XCTAssertEqual(state.applying(.autosaveRecoveryResolved("Saved")), [.setStatusMessage("Saved")])
+        XCTAssertEqual(state.statusSeverity, .success)
+        XCTAssertNil(state.autosaveFailureMessage)
+
+        XCTAssertEqual(state.applying(.statusCleared), [.setStatusMessage("")])
+        XCTAssertEqual(state.statusSeverity, .none)
+        XCTAssertEqual(state.statusMessage, "")
+    }
+
     func testWorkspaceExportRequestsAreLocalEditorCommands() {
         var state = EditorWorkspaceState()
         let videoURL = URL(fileURLWithPath: "/tmp/video.mov")
@@ -825,4 +1044,22 @@ private func makeRecordingSession(hasCamera: Bool, showCursor: Bool) -> Recordin
         showCursorOverlay: showCursor,
         cursorTelemetryPath: nil
     )
+}
+
+private actor EditorAutosaveGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectAutosaveTests.swift
@@ -76,6 +76,44 @@ final class ProjectAutosaveCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(statuses, [.saving, .saved(summary)])
     }
+
+    func testFlushWaitsForInFlightSaveAndPersistsNewestSnapshot() async {
+        let first = makeAutosaveSnapshot(title: "First In Flight", splitTime: 1)
+        let second = makeAutosaveSnapshot(title: "Newest", splitTime: 2)
+        let gate = AutosaveTestGate()
+        let firstSaveStarted = expectation(description: "First save started")
+        var savedSnapshots: [ProjectAutosaveSnapshot] = []
+        let coordinator = ProjectAutosaveCoordinator(
+            debounceNanoseconds: 1,
+            saveHandler: { snapshot in
+                if snapshot == first {
+                    firstSaveStarted.fulfill()
+                    await gate.wait()
+                }
+                savedSnapshots.append(snapshot)
+                return makeProjectSummary(for: snapshot)
+            },
+            statusHandler: { _ in }
+        )
+
+        coordinator.schedule(first)
+        await fulfillment(of: [firstSaveStarted], timeout: 1)
+        coordinator.schedule(second)
+
+        var flushReturned = false
+        let flushTask = Task { @MainActor in
+            await coordinator.flush()
+            flushReturned = true
+        }
+        await Task.yield()
+        XCTAssertFalse(flushReturned)
+
+        await gate.open()
+        await flushTask.value
+
+        XCTAssertTrue(flushReturned)
+        XCTAssertEqual(savedSnapshots, [first, second])
+    }
 }
 
 final class ProjectEditorStateCodableTests: XCTestCase {
@@ -274,4 +312,22 @@ private func makeProjectSummary(for snapshot: ProjectAutosaveSnapshot) -> Projec
         lastOpenedAt: "200",
         missing: false
     )
+}
+
+private actor AutosaveTestGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RustServiceClientTests.swift
@@ -98,6 +98,27 @@ final class RustServiceClientTests: XCTestCase {
         }
     }
 
+    func testNonReturningServiceIsTerminatedAtConfiguredTimeout() throws {
+        let serviceURL = try makeServiceScript(
+            name: "stalled-service",
+            body: """
+            #!/bin/sh
+            exec /bin/sleep 60
+            """
+        )
+        let client = RustServiceClient(executableURL: serviceURL, callTimeout: 0.05)
+        let startedAt = Date()
+
+        XCTAssertThrowsError(try client.call("listProjects", as: String.self)) { error in
+            guard case RustServiceError.timedOut(let timeout) = error else {
+                XCTFail("Expected timedOut, got \(error).")
+                return
+            }
+            XCTAssertEqual(timeout, 0.05, accuracy: 0.001)
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(startedAt), 2)
+    }
+
     private func makeServiceScript(name: String, body: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenRecorderMacTests-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreenshotExportRendererTests.swift
@@ -481,7 +481,7 @@ final class ScreenshotEditorHistoryTests: XCTestCase {
         editor.configure(
             saveHandler: { _ in makeScreenshotProjectSummary() },
             statusHandler: { _ in },
-            setStatusMessage: { _ in },
+            setWorkspaceStatus: { _ in },
             renderPNG: { _, state in
                 renderedState = state
                 return Data("styled-png".utf8)
@@ -521,7 +521,7 @@ final class ScreenshotEditorHistoryTests: XCTestCase {
         editor.configure(
             saveHandler: { _ in makeScreenshotProjectSummary() },
             statusHandler: { _ in },
-            setStatusMessage: { _ in },
+            setWorkspaceStatus: { _ in },
             renderPNG: { _, state in
                 renderedState = state
                 return Data("copied-png".utf8)

--- a/apps/macos/Tests/OpenRecorderMacTests/StudioWindowCloseInterceptorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/StudioWindowCloseInterceptorTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+import XCTest
+@testable import OpenRecorderMac
+
+@MainActor
+final class StudioWindowCloseInterceptorTests: XCTestCase {
+    func testCloseRequestWaitsForAsyncDecisionAndCoalescesRepeatedRequests() async {
+        let firstRequestStarted = expectation(description: "First close request started")
+        let firstDecisionReturned = expectation(description: "First close decision returned")
+        let closePerformed = expectation(description: "Approved close performed")
+        let gate = WindowCloseDecisionGate()
+        var requestCount = 0
+        let interceptor = StudioWindowCloseInterceptionView()
+        let window = CloseRecordingWindow()
+        window.onPerformClose = {
+            closePerformed.fulfill()
+        }
+        interceptor.onCloseRequest = {
+            requestCount += 1
+            firstRequestStarted.fulfill()
+            await gate.wait()
+            firstDecisionReturned.fulfill()
+            return false
+        }
+
+        XCTAssertFalse(interceptor.windowShouldClose(window))
+        XCTAssertFalse(interceptor.windowShouldClose(window))
+        await fulfillment(of: [firstRequestStarted], timeout: 1)
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertEqual(window.performCloseCallCount, 0)
+
+        await gate.open()
+        await fulfillment(of: [firstDecisionReturned], timeout: 1)
+        await Task.yield()
+        XCTAssertEqual(window.performCloseCallCount, 0)
+
+        interceptor.onCloseRequest = {
+            requestCount += 1
+            return true
+        }
+        XCTAssertFalse(interceptor.windowShouldClose(window))
+        await fulfillment(of: [closePerformed], timeout: 1)
+        XCTAssertEqual(requestCount, 2)
+        XCTAssertEqual(window.performCloseCallCount, 1)
+        XCTAssertTrue(interceptor.windowShouldClose(window))
+    }
+
+    func testInterceptorHonorsAndRestoresExistingWindowDelegate() {
+        let window = NSWindow()
+        let originalDelegate = VetoingWindowDelegate()
+        window.delegate = originalDelegate
+        let interceptor = StudioWindowCloseInterceptionView()
+        window.contentView = interceptor
+        interceptor.attachToCurrentWindow()
+        var requestCount = 0
+        interceptor.onCloseRequest = {
+            requestCount += 1
+            return true
+        }
+
+        XCTAssertTrue(window.delegate === interceptor)
+        XCTAssertFalse(interceptor.windowShouldClose(window))
+        XCTAssertEqual(originalDelegate.requestCount, 1)
+        XCTAssertEqual(requestCount, 0)
+
+        interceptor.detach()
+        XCTAssertTrue(window.delegate === originalDelegate)
+    }
+
+}
+
+@MainActor
+private final class CloseRecordingWindow: NSWindow {
+    var onPerformClose: () -> Void = {}
+    private(set) var performCloseCallCount = 0
+
+    override func performClose(_ sender: Any?) {
+        performCloseCallCount += 1
+        onPerformClose()
+    }
+}
+
+@MainActor
+private final class VetoingWindowDelegate: NSObject, NSWindowDelegate {
+    private(set) var requestCount = 0
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        requestCount += 1
+        return false
+    }
+}
+
+private actor WindowCloseDecisionGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        continuation?.resume()
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## Description

- Make AppShell and its child drivers the authoritative owners of macOS application state, with AppModel acting as a compatibility façade.
- Isolate editor navigation, export, status, and autosave state per window through dedicated workspaces.
- Extract recording preference persistence and remove duplicated Settings backend state.
- Add deferred window closing, confirmed quiescent autosave flushing, retry/discard recovery, and typed accessible save status.
- Bound Rust helper calls so a stalled service cannot block editor close indefinitely.

## Motivation

AppModel, SwiftUI views, and shared drivers previously held overlapping mutable state. That allowed editor windows to affect one another and made autosave/export lifecycle races possible. This change establishes clear ownership boundaries while preserving Combine and Observation compatibility, and it keeps unsaved work recoverable when closing fails.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

None.

## Screenshots / Video

Not included. The visible UI change is limited to save status and an autosave-failure recovery banner/alert, which require an injected save failure to exercise reliably.

## Testing Guide

1. Run `make test-macos` (15 Rust tests and 484 Swift tests).
2. Run `cd apps/macos && swift build -c release`.
3. Open multiple video and screenshot editor windows and verify navigation, export state, status, and autosave remain isolated.
4. Exercise close during an in-flight autosave; the window should remain until all editor snapshots are durable.
5. Simulate an autosave failure and verify Retry and Close, Keep Editing, and Close Without Saving preserve the expected workspace state.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*