### PR TITLE
Improve native macOS recording workflows

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -4,6 +4,81 @@ import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
 
+struct BackendSnapshot: Sendable {
+    var health: HealthPayload
+    var paths: AppPaths
+    var projects: [ProjectSummary]
+}
+
+private enum BackendLoadOutcome: Sendable {
+    case success(BackendSnapshot)
+    case failure(String)
+}
+
+private enum ImportedMediaRegistrationOutcome: Sendable {
+    case success(ProjectSummary, projectData: Data?)
+    case failure(String)
+}
+
+private enum RecordingFilePreparationOutcome: Sendable {
+    case success(URL)
+    case failure(String)
+}
+
+private enum ProjectFileLoadOutcome: Sendable {
+    case success(Data)
+    case failure(String)
+}
+
+private struct ProjectRegistrationFailure: LocalizedError, Sendable {
+    var message: String
+    var errorDescription: String? { message }
+}
+
+private enum LocalProjectPersistenceOutcome: Sendable {
+    case success(projectURL: URL, projectData: Data)
+    case failure(String)
+}
+
+private enum CapturedProjectRegistrationOutcome: Sendable {
+    case indexed(ProjectSummary)
+    case locallyPersisted(ProjectSummary)
+    case failed(String)
+
+    var summary: ProjectSummary? {
+        switch self {
+        case .indexed(let summary), .locallyPersisted(let summary):
+            summary
+        case .failed:
+            nil
+        }
+    }
+
+    var needsScreenshotIndexRetry: Bool {
+        if case .locallyPersisted = self { return true }
+        return false
+    }
+}
+
+private nonisolated func serviceJSONObject<T: Encodable>(for value: T) -> Any? {
+    guard let data = try? JSONEncoder().encode(value) else { return nil }
+    return try? JSONSerialization.jsonObject(with: data)
+}
+
+private nonisolated func canonicalMediaIdentity(for url: URL) -> String {
+    let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+    if let attributes = try? FileManager.default.attributesOfItem(atPath: resolvedURL.path),
+       let volumeNumber = attributes[.systemNumber] as? NSNumber,
+       let fileNumber = attributes[.systemFileNumber] as? NSNumber {
+        return "file:\(volumeNumber.uint64Value):\(fileNumber.uint64Value)"
+    }
+    let isCaseSensitive = try? resolvedURL.resourceValues(
+        forKeys: [.volumeSupportsCaseSensitiveNamesKey]
+    ).volumeSupportsCaseSensitiveNames
+    let path = isCaseSensitive == false ? resolvedURL.path.lowercased() : resolvedURL.path
+    return "path:\(path)"
+}
+
 @MainActor
 final class AppModel: ObservableObject {
     var selectedSection: AppSection {
@@ -17,7 +92,10 @@ final class AppModel: ObservableObject {
     }
     var projects: [ProjectSummary] {
         get { appShell.state.projects }
-        set { sendAppShell(.projectsReplaced(newValue)) }
+        set {
+            noteLocalProjectReplacement(from: appShell.state.projects, to: newValue)
+            sendAppShell(.projectsReplaced(newValue))
+        }
     }
     var currentVideoURL: URL? {
         get { appShell.state.currentVideoURL }
@@ -36,6 +114,9 @@ final class AppModel: ObservableObject {
     }
     var serviceHealth: HealthPayload? {
         appShell.state.serviceHealth
+    }
+    var backendLoadPhase: LoadPhase {
+        appShell.state.backendLoadPhase
     }
     var includeMicrophone: Bool {
         get { captureOptions.state.includeMicrophone }
@@ -91,6 +172,12 @@ final class AppModel: ObservableObject {
     var accessibilityPermissionState: AccessibilityPermissionState {
         appShell.onboarding.state.accessibilityPermissionState
     }
+    var microphoneCaptureAuthorization: CaptureMediaAuthorizationState {
+        captureMediaAuthorizationState(for: .audio)
+    }
+    var cameraCaptureAuthorization: CaptureMediaAuthorizationState {
+        captureMediaAuthorizationState(for: .video)
+    }
     var onboardingStatusMessage: String {
         appShell.onboarding.state.statusMessage
     }
@@ -99,6 +186,22 @@ final class AppModel: ObservableObject {
     private var activeFacecamStartedAt: Date?
     private var activeFacecamURL: URL?
     private var facecamPrewarmTask: Task<Void, Never>?
+    private var backendRefreshTask: Task<Bool, Never>?
+    private var backendRefreshGeneration = 0
+    private var projectMutationVersion = 0
+    private var projectMutationVersionsByPath: [String: Int] = [:]
+    private var locallyPersistedProjectPaths: Set<String> = []
+    private var capturePreflightTask: Task<Void, Never>?
+    private var capturePreflightGeneration = 0
+    private var pendingRecordingOptions: RecordingCaptureOptions?
+    private var recordingFilePreparationTask: Task<Void, Never>?
+    private var captureDeviceRefreshTask: Task<Void, Never>?
+    private var captureDeviceRefreshGeneration = 0
+    private var sourceRefreshGeneration = 0
+    private var mediaImportTasksByPath: [String: Task<Void, Never>] = [:]
+    private var mediaImportRequestIDsByPath: [String: UUID] = [:]
+    @Published private(set) var isCapturePreflightRunning = false
+    @Published private(set) var isTerminationPending = false
     private var displayFlashWindows: [NSWindow] = []
     private let countdownOverlayController = RecordingCountdownOverlayController()
     private let captureUIHideDelayNanoseconds: UInt64
@@ -120,6 +223,10 @@ final class AppModel: ObservableObject {
     private let rememberScreenshot: @Sendable (URL) throws -> Void
     private let trashProjectFile: @MainActor (URL) throws -> Void
     private let forgetProject: @Sendable (String) throws -> Void
+    private let loadBackendSnapshot: @Sendable () async throws -> BackendSnapshot
+    private let registerImportedMedia: @Sendable (EditorMediaKind, String) throws -> ProjectSummary
+    private let registerCapturedMedia: @Sendable (String, Data) throws -> ProjectSummary
+    private let prepareRecordingFilePath: @Sendable (String) throws -> PreparedFile
     private let prepareCameraPermission: (@MainActor () async -> Bool)?
     private let prepareFacecamRecording: (@MainActor (String?) async throws -> Void)?
     private let startFacecamRecording: (@MainActor (URL, String?) async throws -> Date)?
@@ -148,7 +255,11 @@ final class AppModel: ObservableObject {
         runRecordingCountdown: (@MainActor (CaptureSource) async throws -> Void)? = nil,
         rememberScreenshot: (@Sendable (URL) throws -> Void)? = nil,
         trashProjectFile: (@MainActor (URL) throws -> Void)? = nil,
-        forgetProject: (@Sendable (String) throws -> Void)? = nil
+        forgetProject: (@Sendable (String) throws -> Void)? = nil,
+        loadBackendSnapshot: (@Sendable () async throws -> BackendSnapshot)? = nil,
+        registerImportedMedia: (@Sendable (EditorMediaKind, String) throws -> ProjectSummary)? = nil,
+        registerCapturedMedia: (@Sendable (String, Data) throws -> ProjectSummary)? = nil,
+        prepareRecordingFilePath: (@Sendable (String) throws -> PreparedFile)? = nil
     ) {
         let service = RustServiceClient()
         let capture = CaptureController(screenRecordingPermission: screenRecordingPermission)
@@ -191,6 +302,72 @@ final class AppModel: ObservableObject {
                 "forgetProject",
                 params: ["path": path],
                 as: ForgetProjectResult.self
+            )
+        }
+        self.loadBackendSnapshot = loadBackendSnapshot ?? {
+            async let health: HealthPayload = Task.detached(priority: .userInitiated) {
+                try service.call("health", as: HealthPayload.self)
+            }.value
+            async let paths: AppPaths = Task.detached(priority: .userInitiated) {
+                try service.call("paths", as: AppPaths.self)
+            }.value
+            async let projects: [ProjectSummary] = Task.detached(priority: .userInitiated) {
+                try service.call("listProjects", as: [ProjectSummary].self)
+            }.value
+            return try await BackendSnapshot(
+                health: health,
+                paths: paths,
+                projects: projects
+            )
+        }
+        self.registerImportedMedia = registerImportedMedia ?? { kind, path in
+            let title = URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
+            if let projects = try? service.call("listProjects", as: [ProjectSummary].self),
+               let existing = projects.first(where: { project in
+                   guard let mediaPath = project.mediaPath,
+                         FileManager.default.fileExists(atPath: project.path) else {
+                       return false
+                   }
+                   return canonicalMediaIdentity(for: URL(fileURLWithPath: mediaPath))
+                       == canonicalMediaIdentity(for: URL(fileURLWithPath: path))
+               }) {
+                return existing
+            }
+            switch kind {
+            case .video:
+                return try service.call(
+                    "registerRecording",
+                    params: [
+                        "path": path,
+                        "sourceName": "Imported Recording",
+                        "title": title,
+                        "editorState": serviceJSONObject(for: ProjectEditorState.empty) ?? [:]
+                    ],
+                    as: ProjectSummary.self
+                )
+            case .screenshot:
+                return try service.call(
+                    "registerScreenshot",
+                    params: [
+                        "path": path,
+                        "sourceName": "Imported Screenshot",
+                        "title": title,
+                        "editorState": serviceJSONObject(
+                            for: ProjectEditorState(screenshot: ScreenshotEditorState.default)
+                        ) ?? [:]
+                    ],
+                    as: ProjectSummary.self
+                )
+            }
+        }
+        self.registerCapturedMedia = registerCapturedMedia ?? { method, paramsData in
+            try service.call(method, paramsData: paramsData, as: ProjectSummary.self)
+        }
+        self.prepareRecordingFilePath = prepareRecordingFilePath ?? { fileName in
+            try service.call(
+                "prepareRecordingFile",
+                params: ["fileName": fileName],
+                as: PreparedFile.self
             )
         }
         self.runRecordingCountdown = runRecordingCountdown ?? { [countdownOverlayController] source in
@@ -312,12 +489,7 @@ final class AppModel: ObservableObject {
         )
         appShell.settings.configure(
             refreshService: { [weak self] in
-                guard let self else { return }
-                if self.refreshBackendState() {
-                    self.appShell.settings.send(.serviceRefreshSucceeded)
-                } else {
-                    self.appShell.settings.send(.serviceRefreshFailed(self.statusMessage))
-                }
+                self?.refreshBackendState()
             },
             persistAutoZoomPreference: { [weak self] value in
                 self?.recordingPreferences.setCreatesZoomsAutomatically(value)
@@ -398,6 +570,69 @@ final class AppModel: ObservableObject {
         )
     }
 
+    func prepareForTermination() async -> Bool {
+        guard !isTerminationPending else { return false }
+        guard !hasActiveCaptureWork else {
+            statusMessage = "Finish or cancel the current capture before quitting."
+            focusActiveCaptureWindow()
+            return false
+        }
+        isTerminationPending = true
+
+        while !mediaImportTasksByPath.isEmpty {
+            do {
+                try await Task.sleep(for: .milliseconds(20))
+            } catch {
+                isTerminationPending = false
+                return false
+            }
+            guard !hasActiveCaptureWork else {
+                isTerminationPending = false
+                statusMessage = "Finish or cancel the current capture before quitting."
+                focusActiveCaptureWindow()
+                return false
+            }
+        }
+
+        let canTerminate = await appShell.prepareForTermination()
+        guard canTerminate else {
+            isTerminationPending = false
+            requestWindow(
+                .showStudio,
+                editorSession: appShell.terminationBlockingEditorSession
+            )
+            return false
+        }
+        guard !hasActiveCaptureWork,
+              mediaImportTasksByPath.isEmpty else {
+            isTerminationPending = false
+            statusMessage = "Finish or cancel the current capture before quitting."
+            focusActiveCaptureWindow()
+            return false
+        }
+        // Keep mutations gated after the final fixed-point check. The app delegate
+        // immediately replies to AppKit and the process terminates from this state.
+        return true
+    }
+
+    private var hasActiveCaptureWork: Bool {
+        if capture.isRecording || isCapturePreflightRunning {
+            return true
+        }
+        switch captureState.phase {
+        case .countingDownRecording, .startingRecording, .recording, .stoppingRecording, .capturingScreenshot:
+            return true
+        case .idle, .choosingMode, .choosingSourceType, .screenSelecting, .selectingSource, .ready, .areaSelecting:
+            return false
+        }
+    }
+
+    private func rejectActionWhileTerminationIsPending() -> Bool {
+        guard isTerminationPending else { return false }
+        statusMessage = "Open Recorder is finishing pending work before quitting."
+        return true
+    }
+
     var captureMode: CaptureMode {
         captureState.mode ?? .recording
     }
@@ -459,7 +694,8 @@ final class AppModel: ObservableObject {
     }
 
     var canChangeRecordingOptions: Bool {
-        captureState.canChangeRecordingOptions(runtimeIsRecording: capture.isRecording)
+        !isCapturePreflightRunning &&
+            captureState.canChangeRecordingOptions(runtimeIsRecording: capture.isRecording)
     }
 
     func bootstrap() {
@@ -548,17 +784,55 @@ final class AppModel: ObservableObject {
     }
 
     @discardableResult
-    func refreshBackendState() -> Bool {
-        do {
-            let serviceHealth = try service.call("health", as: HealthPayload.self)
-            let paths = try service.call("paths", as: AppPaths.self)
-            let projects = try service.call("listProjects", as: [ProjectSummary].self)
-            sendAppShell(.backendRefreshed(paths: paths, projects: projects, health: serviceHealth))
-            return true
-        } catch {
-            sendAppShell(.backendRefreshFailed(error.localizedDescription))
-            return false
+    func refreshBackendState() -> Task<Bool, Never> {
+        backendRefreshGeneration += 1
+        let generation = backendRefreshGeneration
+        let projectVersionAtStart = projectMutationVersion
+        backendRefreshTask?.cancel()
+        sendAppShell(.backendRefreshStarted)
+        appShell.settings.send(.serviceRefreshStarted)
+
+        let loadBackendSnapshot = loadBackendSnapshot
+        let task = Task { [weak self] in
+            let outcome = await Task.detached(priority: .userInitiated) {
+                do {
+                    return BackendLoadOutcome.success(try await loadBackendSnapshot())
+                } catch {
+                    return BackendLoadOutcome.failure(error.localizedDescription)
+                }
+            }.value
+
+            guard !Task.isCancelled,
+                  let self,
+                  generation == self.backendRefreshGeneration else {
+                return false
+            }
+
+            switch outcome {
+            case .success(let snapshot):
+                self.locallyPersistedProjectPaths.subtract(snapshot.projects.map(\.path))
+                let projects = self.projectsMergingConcurrentMutations(
+                    into: snapshot.projects,
+                    since: projectVersionAtStart
+                )
+                self.sendAppShell(.backendRefreshed(
+                    paths: snapshot.paths,
+                    projects: projects,
+                    health: snapshot.health
+                ))
+                self.projectMutationVersionsByPath = self.projectMutationVersionsByPath.filter {
+                    $0.value > projectVersionAtStart
+                }
+                self.appShell.settings.send(.serviceRefreshSucceeded)
+                return true
+            case .failure(let message):
+                self.sendAppShell(.backendRefreshFailed(message))
+                self.appShell.settings.send(.serviceRefreshFailed(message))
+                return false
+            }
         }
+        backendRefreshTask = task
+        return task
     }
 
     func reloadSources() {
@@ -574,16 +848,18 @@ final class AppModel: ObservableObject {
     }
 
     func refreshSources(requestScreenRecordingPermission: Bool = false) async {
-        let previousSelection = selectedSource
+        sourceRefreshGeneration += 1
+        let generation = sourceRefreshGeneration
         await capture.reloadSources(requestScreenRecordingPermission: requestScreenRecordingPermission)
+        guard !Task.isCancelled, generation == sourceRefreshGeneration else { return }
 
-        let resolved = resolveSelection(previous: previousSelection, in: capture.sources)
+        let resolved = resolveSelection(previous: selectedSource, in: capture.sources)
         dispatch(.refreshSelectedSource(resolved))
     }
 
     private func resolveSelection(previous: CaptureSource?, in sources: [CaptureSource]) -> CaptureSource? {
         guard let previous else {
-            return sources.first
+            return nil
         }
         if previous.kind == .area {
             return previous
@@ -591,7 +867,7 @@ final class AppModel: ObservableObject {
         if let match = sources.first(where: { matchesIdentity($0, previous) }) {
             return match
         }
-        return sources.first
+        return nil
     }
 
     private func matchesIdentity(_ candidate: CaptureSource, _ reference: CaptureSource) -> Bool {
@@ -605,11 +881,9 @@ final class AppModel: ObservableObject {
             }
             return candidate.id == reference.id
         case .window:
-            if let candidateWindowID = candidate.windowID,
-               let referenceWindowID = reference.windowID,
-               candidateWindowID == referenceWindowID,
-               candidate.ownerBundleID == reference.ownerBundleID {
-                return true
+            if candidate.windowID != nil || reference.windowID != nil {
+                return candidate.windowID == reference.windowID
+                    && candidate.ownerBundleID == reference.ownerBundleID
             }
             if let bundleID = reference.ownerBundleID,
                candidate.ownerBundleID == bundleID,
@@ -629,16 +903,36 @@ final class AppModel: ObservableObject {
     }
 
     private func prepareRecordingFile(for source: CaptureSource) {
-        do {
-            let fileName = timestampedFileName(prefix: "recording", extension: "mp4")
-            let prepared: PreparedFile = try service.call(
-                "prepareRecordingFile",
-                params: ["fileName": fileName],
-                as: PreparedFile.self
-            )
-            dispatch(.recordingFilePrepared(source, URL(fileURLWithPath: prepared.path)))
-        } catch {
-            dispatch(.recordingFilePreparationFailed(source, message: error.localizedDescription))
+        recordingFilePreparationTask?.cancel()
+        statusMessage = "Preparing recording…"
+        let fileName = timestampedFileName(prefix: "recording", extension: "mp4")
+        let prepareRecordingFilePath = prepareRecordingFilePath
+        recordingFilePreparationTask = Task { [weak self] in
+            let outcome = await Task.detached(priority: .userInitiated) {
+                do {
+                    let prepared = try prepareRecordingFilePath(fileName)
+                    return RecordingFilePreparationOutcome.success(URL(fileURLWithPath: prepared.path))
+                } catch {
+                    return RecordingFilePreparationOutcome.failure(error.localizedDescription)
+                }
+            }.value
+
+            guard !Task.isCancelled, let self else { return }
+            self.recordingFilePreparationTask = nil
+            self.isCapturePreflightRunning = false
+            self.captureOptions.send(.availabilityChanged(self.canChangeRecordingOptions))
+            guard case .ready(.recording, let currentSource) = self.captureState.phase,
+                  currentSource.id == source.id else {
+                self.pendingRecordingOptions = nil
+                return
+            }
+            switch outcome {
+            case .success(let outputURL):
+                self.dispatch(.recordingFilePrepared(source, outputURL))
+            case .failure(let message):
+                self.pendingRecordingOptions = nil
+                self.dispatch(.recordingFilePreparationFailed(source, message: message))
+            }
         }
     }
 
@@ -647,6 +941,7 @@ final class AppModel: ObservableObject {
     }
 
     func beginCapture(_ mode: CaptureMode) {
+        guard !rejectActionWhileTerminationIsPending() else { return }
         dispatch(.beginCapture(mode, runtimeIsRecording: capture.isRecording))
     }
 
@@ -683,6 +978,16 @@ final class AppModel: ObservableObject {
         dispatch(.requestSourceSelector(kind))
         if case .screenSelecting = captureState.phase {
             presentCurrentScreenSelection()
+        }
+    }
+
+    func cancelSourceSelection() {
+        if case .ready(_, let source) = captureState.phase {
+            statusMessage = source.kind == .area ? "Selected area" : "Selected \(source.name)"
+            requestWindow(.closeSourceSelector)
+            showHUD()
+        } else {
+            cancelCapture()
         }
     }
 
@@ -741,12 +1046,27 @@ final class AppModel: ObservableObject {
     }
 
     func requestInteractiveAreaSelection() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        if captureMode == .screenshot,
+           !ensureScreenRecordingPermissionForCapture() {
+            showHUD()
+            return
+        }
         dispatch(.selectSource(interactiveAreaSource()))
         dispatch(.requestInteractiveAreaSelection)
     }
 
     func completeInteractiveAreaSelection(_ area: CaptureArea) {
-        dispatch(.completeInteractiveAreaSelection(interactiveAreaSource(area: area)))
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        let source = interactiveAreaSource(area: area)
+        if captureMode == .screenshot,
+           capture.screenRecordingPermissionState != .granted {
+            dispatch(.selectSource(source))
+            showHUD()
+            reportCaptureBlocker(.screenRecordingPermissionNeedsRestart)
+            return
+        }
+        dispatch(.completeInteractiveAreaSelection(source))
     }
 
     func cancelInteractiveAreaSelection() {
@@ -754,6 +1074,14 @@ final class AppModel: ObservableObject {
     }
 
     func cancelCapture() {
+        capturePreflightGeneration += 1
+        capturePreflightTask?.cancel()
+        capturePreflightTask = nil
+        recordingFilePreparationTask?.cancel()
+        recordingFilePreparationTask = nil
+        pendingRecordingOptions = nil
+        isCapturePreflightRunning = false
+        captureOptions.send(.availabilityChanged(canChangeRecordingOptions))
         dispatch(.cancelCapture)
     }
 
@@ -825,6 +1153,7 @@ final class AppModel: ObservableObject {
     }
 
     func toggleRecordingShortcut() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
         switch captureState.phase {
         case .ready(.recording, _):
             startRecording()
@@ -849,24 +1178,85 @@ final class AppModel: ObservableObject {
     }
 
     func startRecording() {
-        dispatch(.recordingStartRequested)
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        guard !isCapturePreflightRunning,
+              case .ready(.recording, _) = captureState.phase else {
+            return
+        }
+
+        capturePreflightTask?.cancel()
+        capturePreflightGeneration += 1
+        let generation = capturePreflightGeneration
+        let options = currentCaptureOptions
+        pendingRecordingOptions = options
+        isCapturePreflightRunning = true
+        captureOptions.send(.availabilityChanged(false))
+        statusMessage = "Checking capture readiness…"
+        capturePreflightTask = Task { [weak self] in
+            guard let self else { return }
+            guard self.ensureScreenRecordingPermissionForCapture() else {
+                self.finishCapturePreflight(generation: generation)
+                return
+            }
+
+            if self.captureState.source?.kind != .area {
+                await self.refreshSources()
+            }
+            guard !Task.isCancelled, generation == self.capturePreflightGeneration else {
+                self.finishCapturePreflight(generation: generation)
+                return
+            }
+
+            guard await self.preparePermissions(for: options) else {
+                self.finishCapturePreflight(generation: generation)
+                return
+            }
+            guard !Task.isCancelled, generation == self.capturePreflightGeneration else {
+                self.finishCapturePreflight(generation: generation)
+                return
+            }
+            if options.includeMicrophone || options.includeCamera {
+                await self.refreshCaptureDevicesForPreflight()
+            }
+            guard !Task.isCancelled, generation == self.capturePreflightGeneration else {
+                self.finishCapturePreflight(generation: generation)
+                return
+            }
+
+            let readiness = self.captureState.readiness(
+                availableSources: self.sourcesForReadiness,
+                screenRecordingPermissionState: self.capture.screenRecordingPermissionState,
+                options: self.captureOptions.state,
+                runtimeIsRecording: self.capture.isRecording,
+                microphoneAuthorization: self.microphoneCaptureAuthorization,
+                cameraAuthorization: self.cameraCaptureAuthorization
+            )
+            guard readiness.canCapture else {
+                if let blocker = readiness.primaryBlocker {
+                    self.reportCaptureBlocker(blocker)
+                }
+                self.finishCapturePreflight(generation: generation)
+                return
+            }
+
+            guard generation == self.capturePreflightGeneration else { return }
+            self.capturePreflightTask = nil
+            self.dispatch(.recordingStartRequested)
+        }
     }
 
     private func runRecordingStartFlow(source selectedSource: CaptureSource, outputURL: URL) async {
         do {
-            refreshCaptureDevices()
-            var options = currentCaptureOptions
-            guard await preparePermissions(for: options) else {
-                restoreRecordingSetup(source: selectedSource)
-                return
-            }
+            var options = pendingRecordingOptions ?? currentCaptureOptions
+            pendingRecordingOptions = nil
 
             if options.includeCamera {
                 do {
                     try await prepareFacecam(cameraDeviceID: options.cameraDeviceID)
                 } catch {
-                    captureOptions.send(.cameraDisabled)
-                    options = currentCaptureOptions
+                    captureOptions.send(.cameraDisabledForCaptureFailure)
+                    options.includeCamera = false
+                    options.cameraDeviceID = nil
                     statusMessage = "Recording without facecam: \(error.localizedDescription)"
                 }
             }
@@ -888,8 +1278,9 @@ final class AppModel: ObservableObject {
                     activeFacecamStartedAt = try await startFacecam(outputURL: url, cameraDeviceID: cameraDeviceID)
                     activeFacecamURL = url
                 } catch {
-                    captureOptions.send(.cameraDisabled)
-                    options = currentCaptureOptions
+                    captureOptions.send(.cameraDisabledForCaptureFailure)
+                    options.includeCamera = false
+                    options.cameraDeviceID = nil
                     try? FileManager.default.removeItem(at: url)
                     activeFacecamURL = nil
                     activeFacecamStartedAt = nil
@@ -982,21 +1373,26 @@ final class AppModel: ObservableObject {
                     screenStartedAt: activeScreenStartedAt,
                     facecamStartedAt: activeFacecamStartedAt
                 )
-                let summary = registerRecordingProject(
+                let summary = await registerRecordingProject(
                     outputURL,
                     sourceName: sourceName,
-                    timelineEdits: timelineEdits
+                    timelineEdits: timelineEdits,
+                    recordingSession: recordingSession
                 )
-                let title = summary?.title ?? outputURL.deletingPathExtension().lastPathComponent
+                let title = summary.summary?.title ?? outputURL.deletingPathExtension().lastPathComponent
                 showEditor(for: EditorSession(
                     kind: .video,
                     url: outputURL,
                     title: title,
-                    projectPath: summary?.path,
+                    projectPath: summary.summary?.path,
                     recordingSession: recordingSession,
                     timelineEditSnapshot: timelineEdits
                 ))
-                statusMessage = "Saved \(title)"
+                if case .failed(let message) = summary {
+                    statusMessage = "Saved \(title), but the editable project could not be created: \(message)"
+                } else {
+                    statusMessage = "Saved \(title)"
+                }
             } else {
                 dispatch(.recordingStopped(message: "Recording stopped before a file was written."))
             }
@@ -1014,9 +1410,28 @@ final class AppModel: ObservableObject {
     }
 
     func takeScreenshot() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
         guard !capture.isRecording else {
             statusMessage = "Finish or cancel the current capture before starting another."
             focusActiveCaptureWindow()
+            return
+        }
+        guard ensureScreenRecordingPermissionForCapture() else { return }
+        let readiness = captureState.readiness(
+            availableSources: sourcesForReadiness,
+            screenRecordingPermissionState: capture.screenRecordingPermissionState,
+            options: captureOptions.state,
+            runtimeIsRecording: capture.isRecording,
+            microphoneAuthorization: microphoneCaptureAuthorization,
+            cameraAuthorization: cameraCaptureAuthorization,
+            isChecking: capture.sourceCatalogState == .loading
+        )
+        guard readiness.canCapture else {
+            if let blocker = readiness.primaryBlocker {
+                reportCaptureBlocker(blocker)
+            } else if readiness.isChecking {
+                statusMessage = "Refreshing capture sources…"
+            }
             return
         }
         dispatch(.screenshotRequested)
@@ -1034,7 +1449,16 @@ final class AppModel: ObservableObject {
                 throw CancellationError()
             }
 
-            let ensuredPaths = try paths ?? service.call("paths", as: AppPaths.self)
+            let ensuredPaths: AppPaths
+            if let paths {
+                ensuredPaths = paths
+            } else {
+                ensuredPaths = try await loadAppPaths()
+            }
+            try Task.checkCancellation()
+            guard isActiveScreenshotCapture(for: selectedSource) else {
+                throw CancellationError()
+            }
             let outputURL = URL(fileURLWithPath: ensuredPaths.screenshotsDir)
                 .appendingPathComponent(timestampedFileName(prefix: "screenshot", extension: "png"))
             try screenshotCapture(selectedSource, outputURL)
@@ -1042,7 +1466,7 @@ final class AppModel: ObservableObject {
             guard isActiveScreenshotCapture(for: selectedSource) else {
                 throw CancellationError()
             }
-            let summary = registerScreenshotProject(outputURL, sourceName: selectedSource.name)
+            let registration = await registerScreenshotProject(outputURL, sourceName: selectedSource.name)
             try Task.checkCancellation()
             guard isActiveScreenshotCapture(for: selectedSource) else {
                 throw CancellationError()
@@ -1052,12 +1476,16 @@ final class AppModel: ObservableObject {
             showEditor(for: EditorSession(
                 kind: .screenshot,
                 url: outputURL,
-                title: summary?.title,
-                projectPath: summary?.path,
+                title: registration.summary?.title,
+                projectPath: registration.summary?.path,
                 screenshotEditorState: .default
             ))
-            statusMessage = "Captured \(outputURL.lastPathComponent)"
-            if summary == nil {
+            if case .failed(let message) = registration {
+                statusMessage = "Captured \(outputURL.lastPathComponent), but the editable project could not be created: \(message)"
+            } else {
+                statusMessage = "Captured \(outputURL.lastPathComponent)"
+            }
+            if registration.needsScreenshotIndexRetry {
                 rememberScreenshotInBackground(outputURL)
             }
         } catch is CancellationError {
@@ -1088,56 +1516,215 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func registerScreenshotProject(_ outputURL: URL, sourceName: String?) -> ProjectSummary? {
+    private func loadAppPaths() async throws -> AppPaths {
+        let service = service
+        return try await Task.detached(priority: .utility) {
+            try service.call("paths", as: AppPaths.self)
+        }.value
+    }
+
+    private func registerScreenshotProject(
+        _ outputURL: URL,
+        sourceName: String?
+    ) async -> CapturedProjectRegistrationOutcome {
         let title = outputURL.deletingPathExtension().lastPathComponent
+        let editorState = ProjectEditorState(screenshot: ScreenshotEditorState.default)
         do {
-            let summary: ProjectSummary = try service.call(
-                "registerScreenshot",
-                params: [
-                    "path": outputURL.path,
-                    "sourceName": sourceName ?? "Screenshot",
-                    "title": title,
-                    "editorState": jsonObject(for: ProjectEditorState(screenshot: ScreenshotEditorState.default)) ?? [:]
-                ],
-                as: ProjectSummary.self
-            )
+            let params: [String: Any] = [
+                "path": outputURL.path,
+                "sourceName": sourceName ?? "Screenshot",
+                "title": title,
+                "editorState": jsonObject(for: editorState) ?? [:]
+            ]
+            let paramsData = try JSONSerialization.data(withJSONObject: params)
+            let registerCapturedMedia = registerCapturedMedia
+            let summary: ProjectSummary = try await Task.detached(priority: .utility) {
+                try registerCapturedMedia("registerScreenshot", paramsData)
+            }.value
             upsertProjectSummary(summary)
-            return summary
-        } catch {
-            return nil
+            return .indexed(summary)
+        } catch let registrationError {
+            return await persistCapturedProjectLocally(
+                title: title,
+                recordingURL: nil,
+                screenshotURL: outputURL,
+                sourceName: sourceName,
+                editorState: editorState,
+                recordingSession: nil,
+                registrationError: registrationError
+            )
         }
     }
 
     private func registerRecordingProject(
         _ outputURL: URL,
         sourceName: String?,
-        timelineEdits: TimelineEditSnapshot
-    ) -> ProjectSummary? {
+        timelineEdits: TimelineEditSnapshot,
+        recordingSession: RecordingSession
+    ) async -> CapturedProjectRegistrationOutcome {
         let title = outputURL.deletingPathExtension().lastPathComponent
+        let editorState = ProjectEditorState(timelineEdits: timelineEdits)
         do {
-            let summary: ProjectSummary = try service.call(
-                "registerRecording",
-                params: [
-                    "path": outputURL.path,
-                    "sourceName": sourceName ?? "Screen Recording",
-                    "title": title,
-                    "editorState": jsonObject(for: ProjectEditorState(timelineEdits: timelineEdits)) ?? [:]
-                ],
-                as: ProjectSummary.self
+            let params: [String: Any] = [
+                "path": outputURL.path,
+                "sourceName": sourceName ?? "Screen Recording",
+                "title": title,
+                "editorState": jsonObject(for: editorState) ?? [:],
+                "recordingSession": jsonObject(for: recordingSession) ?? [:]
+            ]
+            let paramsData = try JSONSerialization.data(withJSONObject: params)
+            let registerCapturedMedia = registerCapturedMedia
+            let summary: ProjectSummary = try await Task.detached(priority: .utility) {
+                try registerCapturedMedia("registerRecording", paramsData)
+            }.value
+            upsertProjectSummary(summary)
+            return .indexed(summary)
+        } catch let registrationError {
+            return await persistCapturedProjectLocally(
+                title: title,
+                recordingURL: outputURL,
+                screenshotURL: nil,
+                sourceName: sourceName,
+                editorState: editorState,
+                recordingSession: recordingSession,
+                registrationError: registrationError
             )
-            if let projects = try? service.call("listProjects", as: [ProjectSummary].self) {
-                sendAppShell(.projectsReplaced(projects))
-            } else {
-                upsertProjectSummary(summary)
-            }
-            return summary
-        } catch {
-            return nil
         }
     }
 
-    func openProject(_ project: ProjectSummary) {
-        openProjectFile(at: URL(fileURLWithPath: project.path))
+    private func persistCapturedProjectLocally(
+        title: String,
+        recordingURL: URL?,
+        screenshotURL: URL?,
+        sourceName: String?,
+        editorState: ProjectEditorState,
+        recordingSession: RecordingSession?,
+        registrationError: Error
+    ) async -> CapturedProjectRegistrationOutcome {
+        let now = ISO8601DateFormatter().string(from: Date())
+        let projectsDirectory: URL
+        if let paths {
+            projectsDirectory = URL(fileURLWithPath: paths.projectsDir, isDirectory: true)
+        } else if let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first {
+            projectsDirectory = applicationSupport
+                .appendingPathComponent("Open Recorder", isDirectory: true)
+                .appendingPathComponent("Projects", isDirectory: true)
+        } else if let mediaURL = screenshotURL ?? recordingURL {
+            projectsDirectory = mediaURL.deletingLastPathComponent()
+        } else {
+            return .failed(registrationError.localizedDescription)
+        }
+        let newProjectURL = projectsDirectory
+            .appendingPathComponent("recovered-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("openrecorder")
+        let newRecoveryMarkerURL = newProjectURL.appendingPathExtension("recovery")
+        let document = ProjectDocument(
+            schemaVersion: 2,
+            title: title,
+            recordingPath: recordingURL?.path,
+            screenshotPath: screenshotURL?.path,
+            sourceName: sourceName,
+            createdAt: now,
+            updatedAt: now,
+            editorState: editorState,
+            recordingSession: recordingSession
+        )
+
+        let documentData: Data
+        do {
+            documentData = try JSONEncoder().encode(document)
+        } catch {
+            return .failed("\(registrationError.localizedDescription); local recovery failed: \(error.localizedDescription)")
+        }
+
+        let mediaURL = screenshotURL ?? recordingURL
+        let targetMediaIdentity = mediaURL.map { canonicalMediaIdentity(for: $0) }
+        let persistence = await Task.detached(priority: .utility) {
+            do {
+                try FileManager.default.createDirectory(
+                    at: projectsDirectory,
+                    withIntermediateDirectories: true
+                )
+                if let targetMediaIdentity,
+                   let candidates = try? FileManager.default.contentsOfDirectory(
+                       at: projectsDirectory,
+                       includingPropertiesForKeys: nil,
+                       options: [.skipsHiddenFiles]
+                   ) {
+                    for candidateURL in candidates {
+                        guard candidateURL.pathExtension == "recovery" else { continue }
+                        let candidateProjectURL = candidateURL.deletingPathExtension()
+                        guard candidateProjectURL.pathExtension == "openrecorder",
+                              let candidateData = try? Data(contentsOf: candidateProjectURL),
+                              let candidateDocument = try? JSONDecoder().decode(
+                                  ProjectDocument.self,
+                                  from: candidateData
+                              ),
+                              let candidateMediaPath = candidateDocument.screenshotPath
+                                  ?? candidateDocument.recordingPath,
+                              canonicalMediaIdentity(for: URL(fileURLWithPath: candidateMediaPath))
+                                  == targetMediaIdentity else {
+                            continue
+                        }
+                        return LocalProjectPersistenceOutcome.success(
+                            projectURL: candidateProjectURL.resolvingSymlinksInPath().standardizedFileURL,
+                            projectData: candidateData
+                        )
+                    }
+                }
+
+                try Data().write(to: newRecoveryMarkerURL, options: .atomic)
+                do {
+                    try documentData.write(to: newProjectURL, options: .atomic)
+                } catch {
+                    try? FileManager.default.removeItem(at: newRecoveryMarkerURL)
+                    throw error
+                }
+                return LocalProjectPersistenceOutcome.success(
+                    projectURL: newProjectURL.resolvingSymlinksInPath().standardizedFileURL,
+                    projectData: documentData
+                )
+            } catch {
+                return LocalProjectPersistenceOutcome.failure(error.localizedDescription)
+            }
+        }.value
+
+        switch persistence {
+        case .success(let projectURL, let persistedData):
+            guard let persistedDocument = try? JSONDecoder().decode(
+                ProjectDocument.self,
+                from: persistedData
+            ) else {
+                return .failed("\(registrationError.localizedDescription); local recovery project is invalid")
+            }
+            let summary = ProjectSummary(
+                id: "project-local-\(projectURL.deletingPathExtension().lastPathComponent)",
+                title: persistedDocument.title,
+                path: projectURL.path,
+                recordingPath: persistedDocument.recordingPath,
+                screenshotPath: persistedDocument.screenshotPath,
+                sourceName: persistedDocument.sourceName,
+                createdAt: persistedDocument.createdAt,
+                updatedAt: persistedDocument.updatedAt,
+                lastOpenedAt: persistedDocument.updatedAt,
+                missing: false,
+                availability: .available
+            )
+            locallyPersistedProjectPaths.insert(summary.path)
+            upsertProjectSummary(summary)
+            return .locallyPersisted(summary)
+        case .failure(let message):
+            return .failed("\(registrationError.localizedDescription); local recovery failed: \(message)")
+        }
+    }
+
+    @discardableResult
+    func openProject(_ project: ProjectSummary) -> Task<Void, Never> {
+        guard !rejectActionWhileTerminationIsPending() else { return Task {} }
+        return openProjectFile(at: URL(fileURLWithPath: project.path))
     }
 
     func deleteProject(_ project: ProjectSummary) {
@@ -1147,6 +1734,8 @@ final class AppModel: ObservableObject {
                 try trashProjectFile(projectURL)
             }
             try forgetProject(project.path)
+            locallyPersistedProjectPaths.remove(project.path)
+            noteLocalProjectMutation(path: project.path)
             sendAppShell(.projectSummaryRemoved(path: project.path))
             statusMessage = "Deleted \(project.title)"
         } catch {
@@ -1155,6 +1744,7 @@ final class AppModel: ObservableObject {
     }
 
     func openProjectFile() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
         let panel = NSOpenPanel()
         if let projectType = UTType(filenameExtension: "openrecorder") {
             panel.allowedContentTypes = [projectType]
@@ -1169,71 +1759,238 @@ final class AppModel: ObservableObject {
         openProjectFile(at: projectURL)
     }
 
-    func openEditorFile(at url: URL) {
+    @discardableResult
+    func openEditorFile(at url: URL) -> Task<Void, Never>? {
+        guard !rejectActionWhileTerminationIsPending() else { return nil }
         if url.pathExtension.lowercased() == "openrecorder" {
-            openProjectFile(at: url)
-            return
+            return openProjectFile(at: url)
         }
 
+        let kind: EditorMediaKind
         if EditorMediaKind.screenshot.supports(url) {
-            currentScreenshotURL = url
-            currentVideoURL = nil
-            showEditor(for: EditorSession(kind: .screenshot, url: url))
-            statusMessage = "Opened \(url.lastPathComponent)"
-            return
+            kind = .screenshot
+        } else if EditorMediaKind.video.supports(url) {
+            kind = .video
+        } else {
+            statusMessage = "Unsupported file: \(url.lastPathComponent)"
+            return nil
         }
 
-        if EditorMediaKind.video.supports(url) {
-            currentVideoURL = url
-            currentScreenshotURL = nil
-            showEditor(for: EditorSession(kind: .video, url: url))
-            statusMessage = "Opened \(url.lastPathComponent)"
-            return
+        let resolvedMediaURL = url.resolvingSymlinksInPath().standardizedFileURL
+        let standardizedMediaPath = resolvedMediaURL.path
+        let mediaIdentity = canonicalMediaIdentity(for: resolvedMediaURL)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: standardizedMediaPath, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              FileManager.default.isReadableFile(atPath: standardizedMediaPath) else {
+            statusMessage = "Could not import \(url.lastPathComponent): the file is missing or unreadable."
+            return nil
         }
 
-        statusMessage = "Unsupported file: \(url.lastPathComponent)"
+        if let pendingImport = mediaImportTasksByPath[mediaIdentity] {
+            return pendingImport
+        }
+
+        if let existingProject = projects.first(where: { project in
+            guard let mediaPath = project.mediaPath else { return false }
+            return canonicalMediaIdentity(for: URL(fileURLWithPath: mediaPath)) == mediaIdentity
+                && FileManager.default.fileExists(atPath: project.path)
+        }) {
+            return openProject(existingProject)
+        }
+
+        statusMessage = "Importing \(url.lastPathComponent)…"
+        let registerImportedMedia = registerImportedMedia
+        let requestID = UUID()
+        mediaImportRequestIDsByPath[mediaIdentity] = requestID
+        let task = Task { [weak self] in
+            defer {
+                self?.finishMediaImport(path: mediaIdentity, requestID: requestID)
+            }
+            let outcome = await Task.detached(priority: .userInitiated) {
+                do {
+                    let summary = try registerImportedMedia(kind, standardizedMediaPath)
+                    let projectData = try? Data(contentsOf: URL(fileURLWithPath: summary.path))
+                    return ImportedMediaRegistrationOutcome.success(summary, projectData: projectData)
+                } catch {
+                    return ImportedMediaRegistrationOutcome.failure(error.localizedDescription)
+                }
+            }.value
+
+            guard !Task.isCancelled, let self else { return }
+            switch outcome {
+            case .success(let summary, let projectData):
+                self.upsertProjectSummary(summary)
+                switch kind {
+                case .screenshot:
+                    self.currentScreenshotURL = url
+                    self.currentVideoURL = nil
+                case .video:
+                    self.currentVideoURL = url
+                    self.currentScreenshotURL = nil
+                }
+                let document = projectData.flatMap { try? JSONDecoder().decode(ProjectDocument.self, from: $0) }
+                self.showEditor(for: self.importedEditorSession(
+                    kind: kind,
+                    url: url,
+                    summary: summary,
+                    document: document
+                ))
+                self.statusMessage = "Opened \(url.lastPathComponent)"
+            case .failure(let message):
+                let editorState: ProjectEditorState = kind == .screenshot
+                    ? ProjectEditorState(screenshot: .default)
+                    : .empty
+                let fallback = await self.persistCapturedProjectLocally(
+                    title: url.deletingPathExtension().lastPathComponent,
+                    recordingURL: kind == .video ? url : nil,
+                    screenshotURL: kind == .screenshot ? url : nil,
+                    sourceName: kind == .video ? "Imported Recording" : "Imported Screenshot",
+                    editorState: editorState,
+                    recordingSession: nil,
+                    registrationError: ProjectRegistrationFailure(message: message)
+                )
+                guard let summary = fallback.summary else {
+                    if case .failed(let fallbackMessage) = fallback {
+                        self.statusMessage = "Could not import \(url.lastPathComponent): \(fallbackMessage)"
+                    }
+                    return
+                }
+                let persistedData = await Task.detached(priority: .utility) {
+                    try? Data(contentsOf: URL(fileURLWithPath: summary.path))
+                }.value
+                let document = persistedData
+                    .flatMap { try? JSONDecoder().decode(ProjectDocument.self, from: $0) }
+                    ?? ProjectDocument(
+                    schemaVersion: 2,
+                    title: summary.title,
+                    recordingPath: summary.recordingPath,
+                    screenshotPath: summary.screenshotPath,
+                    sourceName: summary.sourceName,
+                    createdAt: summary.createdAt,
+                    updatedAt: summary.updatedAt,
+                    editorState: editorState,
+                    recordingSession: nil
+                    )
+                switch kind {
+                case .screenshot:
+                    self.currentScreenshotURL = url
+                    self.currentVideoURL = nil
+                case .video:
+                    self.currentVideoURL = url
+                    self.currentScreenshotURL = nil
+                }
+                self.showEditor(for: self.importedEditorSession(
+                    kind: kind,
+                    url: url,
+                    summary: summary,
+                    document: document
+                ))
+                self.statusMessage = "Opened \(url.lastPathComponent)"
+            }
+        }
+        mediaImportTasksByPath[mediaIdentity] = task
+        return task
     }
 
-    func openProjectFile(at projectURL: URL) {
-        do {
-            let document: ProjectDocument = try service.call(
-                "loadProject",
-                params: ["path": projectURL.path],
-                as: ProjectDocument.self
+    private func finishMediaImport(path: String, requestID: UUID) {
+        guard mediaImportRequestIDsByPath[path] == requestID else { return }
+        mediaImportRequestIDsByPath.removeValue(forKey: path)
+        mediaImportTasksByPath.removeValue(forKey: path)
+    }
+
+    private func importedEditorSession(
+        kind: EditorMediaKind,
+        url: URL,
+        summary: ProjectSummary,
+        document: ProjectDocument?
+    ) -> EditorSession {
+        switch kind {
+        case .video:
+            return EditorSession(
+                kind: .video,
+                url: url,
+                title: document?.title ?? summary.title,
+                projectPath: summary.path,
+                recordingSession: document.map { recordingSession(for: $0, recordingURL: url) },
+                timelineEditSnapshot: document?.editorState?.timelineEdits ?? .empty,
+                videoEditorState: document?.editorState?.video
             )
+        case .screenshot:
+            return EditorSession(
+                kind: .screenshot,
+                url: url,
+                title: document?.title ?? summary.title,
+                projectPath: summary.path,
+                screenshotEditorState: document?.editorState?.screenshot ?? .default
+            )
+        }
+    }
+
+    @discardableResult
+    func openProjectFile(at projectURL: URL) -> Task<Void, Never> {
+        statusMessage = "Opening \(projectURL.lastPathComponent)…"
+        return Task { [weak self] in
+            let outcome = await Task.detached(priority: .userInitiated) {
+                do {
+                    return ProjectFileLoadOutcome.success(try Data(contentsOf: projectURL))
+                } catch {
+                    return ProjectFileLoadOutcome.failure(error.localizedDescription)
+                }
+            }.value
+
+            guard !Task.isCancelled, let self else { return }
+            let document: ProjectDocument
+            switch outcome {
+            case .success(let data):
+                do {
+                    document = try JSONDecoder().decode(ProjectDocument.self, from: data)
+                } catch {
+                    self.statusMessage = "Could not open \(projectURL.lastPathComponent): \(error.localizedDescription)"
+                    return
+                }
+            case .failure(let message):
+                self.statusMessage = "Could not open \(projectURL.lastPathComponent): \(message)"
+                return
+            }
+
             if let screenshotPath = document.screenshotPath {
                 let screenshotURL = URL(fileURLWithPath: screenshotPath)
-                currentScreenshotURL = screenshotURL
-                currentVideoURL = nil
-                showEditor(for: EditorSession(
+                guard FileManager.default.isReadableFile(atPath: screenshotURL.path) else {
+                    self.statusMessage = "Could not open \(document.title): the screenshot file is missing or unreadable."
+                    return
+                }
+                self.currentScreenshotURL = screenshotURL
+                self.currentVideoURL = nil
+                self.showEditor(for: EditorSession(
                     kind: .screenshot,
                     url: screenshotURL,
                     title: document.title,
                     projectPath: projectURL.path,
                     screenshotEditorState: document.editorState?.screenshot
                 ))
-                statusMessage = "Opened \(document.title)"
-                refreshBackendState()
+                self.statusMessage = "Opened \(document.title)"
             } else if let recordingPath = document.recordingPath {
                 let recordingURL = URL(fileURLWithPath: recordingPath)
-                currentVideoURL = recordingURL
-                currentScreenshotURL = nil
-                showEditor(for: EditorSession(
+                guard FileManager.default.isReadableFile(atPath: recordingURL.path) else {
+                    self.statusMessage = "Could not open \(document.title): the recording file is missing or unreadable."
+                    return
+                }
+                self.currentVideoURL = recordingURL
+                self.currentScreenshotURL = nil
+                self.showEditor(for: EditorSession(
                     kind: .video,
                     url: recordingURL,
                     title: document.title,
                     projectPath: projectURL.path,
-                    recordingSession: recordingSession(for: document, recordingURL: recordingURL),
+                    recordingSession: self.recordingSession(for: document, recordingURL: recordingURL),
                     timelineEditSnapshot: document.editorState?.timelineEdits,
                     videoEditorState: document.editorState?.video
                 ))
-                statusMessage = "Opened \(document.title)"
-                refreshBackendState()
+                self.statusMessage = "Opened \(document.title)"
             } else {
-                statusMessage = "Project has no recording path."
+                self.statusMessage = "Project has no recording or screenshot path."
             }
-        } catch {
-            statusMessage = error.localizedDescription
         }
     }
 
@@ -1331,7 +2088,46 @@ final class AppModel: ObservableObject {
     }
 
     private func upsertProjectSummary(_ summary: ProjectSummary) {
+        if !summary.id.hasPrefix("project-local-") {
+            locallyPersistedProjectPaths.remove(summary.path)
+        }
+        noteLocalProjectMutation(path: summary.path)
         sendAppShell(.projectSummaryUpserted(summary))
+    }
+
+    private func noteLocalProjectMutation(path: String) {
+        projectMutationVersion += 1
+        projectMutationVersionsByPath[path] = projectMutationVersion
+    }
+
+    private func noteLocalProjectReplacement(
+        from previousProjects: [ProjectSummary],
+        to nextProjects: [ProjectSummary]
+    ) {
+        let previousByPath = Dictionary(previousProjects.map { ($0.path, $0) }, uniquingKeysWith: { _, latest in latest })
+        let nextByPath = Dictionary(nextProjects.map { ($0.path, $0) }, uniquingKeysWith: { _, latest in latest })
+        let changedPaths = Set(previousByPath.keys).union(nextByPath.keys).filter {
+            previousByPath[$0] != nextByPath[$0]
+        }
+        guard !changedPaths.isEmpty else { return }
+        projectMutationVersion += 1
+        for path in changedPaths {
+            projectMutationVersionsByPath[path] = projectMutationVersion
+        }
+    }
+
+    private func projectsMergingConcurrentMutations(
+        into refreshedProjects: [ProjectSummary],
+        since version: Int
+    ) -> [ProjectSummary] {
+        let changedPaths = Set(projectMutationVersionsByPath.compactMap { path, mutationVersion in
+            mutationVersion > version ? path : nil
+        }).union(locallyPersistedProjectPaths)
+        guard !changedPaths.isEmpty else { return refreshedProjects }
+
+        let locallyChangedProjects = projects.filter { changedPaths.contains($0.path) }
+        let unchangedRefreshedProjects = refreshedProjects.filter { !changedPaths.contains($0.path) }
+        return locallyChangedProjects + unchangedRefreshedProjects
     }
 
     private func jsonObject<T: Encodable>(for value: T) -> Any? {
@@ -1402,10 +2198,43 @@ final class AppModel: ObservableObject {
         openPrivacyPane("Privacy_Accessibility")
     }
 
-    func refreshCaptureDevices() {
-        let microphones = captureDeviceProvider.devices(for: .audio)
-        let cameras = captureDeviceProvider.devices(for: .video)
-        captureOptions.send(.devicesRefreshed(microphones: microphones, cameras: cameras))
+    @discardableResult
+    func refreshCaptureDevices() -> Task<Void, Never> {
+        captureDeviceRefreshGeneration += 1
+        let generation = captureDeviceRefreshGeneration
+        captureDeviceRefreshTask?.cancel()
+        captureOptions.send(.deviceRefreshStarted)
+        let provider = captureDeviceProvider
+        let task = Task { [weak self] in
+            let devices = await Task.detached(priority: .userInitiated) {
+                let microphones = provider.devices(for: .audio)
+                let cameras = provider.devices(for: .video)
+                return (microphones, cameras)
+            }.value
+            guard !Task.isCancelled,
+                  let self,
+                  generation == self.captureDeviceRefreshGeneration else {
+                return
+            }
+            self.captureOptions.send(.devicesRefreshed(
+                microphones: devices.0,
+                cameras: devices.1
+            ))
+            self.captureDeviceRefreshTask = nil
+        }
+        captureDeviceRefreshTask = task
+        return task
+    }
+
+    private func refreshCaptureDevicesForPreflight() async {
+        var refreshTask = refreshCaptureDevices()
+        await refreshTask.value
+        while !Task.isCancelled,
+              captureOptions.state.deviceLoadPhase == .loading,
+              let latestRefreshTask = captureDeviceRefreshTask {
+            refreshTask = latestRefreshTask
+            await refreshTask.value
+        }
     }
 
     func requestMicrophoneSelection(refreshDevices: Bool = true) {
@@ -1473,6 +2302,66 @@ final class AppModel: ObservableObject {
 
     private var currentCaptureOptions: RecordingCaptureOptions {
         captureOptions.state.recordingOptions
+    }
+
+    private func captureMediaAuthorizationState(for mediaType: AVMediaType) -> CaptureMediaAuthorizationState {
+        switch AVCaptureDevice.authorizationStatus(for: mediaType) {
+        case .authorized:
+            .authorized
+        case .notDetermined:
+            .undetermined
+        case .denied, .restricted:
+            .denied
+        @unknown default:
+            .denied
+        }
+    }
+
+    private var sourcesForReadiness: [CaptureSource] {
+        if capture.sourceCatalogState == .idle, let selectedSource {
+            return [selectedSource]
+        }
+        return capture.sources
+    }
+
+    @discardableResult
+    private func ensureScreenRecordingPermissionForCapture() -> Bool {
+        if capture.screenRecordingPermissionState == .granted {
+            return true
+        }
+
+        if capture.screenRecordingPermissionState == .requestAvailable {
+            _ = requestScreenRecordingPermission()
+            refreshOnboardingPermissionStates()
+        }
+
+        let state = capture.screenRecordingPermissionState
+        guard state == .granted else {
+            reportCaptureBlocker(
+                state == .requestAvailable
+                    ? .screenRecordingPermissionRequired
+                    : .screenRecordingPermissionNeedsRestart
+            )
+            return false
+        }
+        return true
+    }
+
+    private func reportCaptureBlocker(_ blocker: CaptureBlocker) {
+        statusMessage = blocker.message
+        if blocker.recoveryAction == .waitForCurrentCapture {
+            focusActiveCaptureWindow()
+        } else {
+            showHUD()
+        }
+    }
+
+    private func finishCapturePreflight(generation: Int) {
+        guard generation == capturePreflightGeneration else { return }
+        capturePreflightTask = nil
+        pendingRecordingOptions = nil
+        isCapturePreflightRunning = false
+        captureOptions.send(.availabilityChanged(canChangeRecordingOptions))
     }
 
     private func preparePermissions(for options: RecordingCaptureOptions) async -> Bool {

--- a/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
@@ -4,6 +4,13 @@ import Foundation
 import Observation
 import SwiftUI
 
+enum CaptureDeviceLoadPhase: Equatable {
+    case idle
+    case loading
+    case loaded
+    case failed(String)
+}
+
 struct CaptureOptionsState: Equatable {
     var includeMicrophone = false
     var includeSystemAudio = false
@@ -16,21 +23,34 @@ struct CaptureOptionsState: Equatable {
     var selectedCameraDeviceID: String?
     var canChangeOptions = true
     var statusMessage: String?
+    var deviceLoadPhase: CaptureDeviceLoadPhase = .idle
 
     var selectedMicrophoneDeviceName: String {
-        guard let selectedMicrophoneDeviceID,
-              let device = microphoneDevices.first(where: { $0.id == selectedMicrophoneDeviceID }) else {
+        guard let selectedMicrophoneDeviceID else {
             return "System Default"
         }
-        return device.name
+        return microphoneDevices.first(where: { $0.id == selectedMicrophoneDeviceID })?.name
+            ?? "Previously Selected (Unavailable)"
     }
 
     var selectedCameraDeviceName: String {
-        guard let selectedCameraDeviceID,
-              let device = cameraDevices.first(where: { $0.id == selectedCameraDeviceID }) else {
+        guard let selectedCameraDeviceID else {
             return "System Default"
         }
-        return device.name
+        return cameraDevices.first(where: { $0.id == selectedCameraDeviceID })?.name
+            ?? "Previously Selected (Unavailable)"
+    }
+
+    var hasAvailableMicrophoneSelection: Bool {
+        guard !microphoneDevices.isEmpty else { return false }
+        guard let selectedMicrophoneDeviceID else { return true }
+        return microphoneDevices.contains { $0.id == selectedMicrophoneDeviceID }
+    }
+
+    var hasAvailableCameraSelection: Bool {
+        guard !cameraDevices.isEmpty else { return false }
+        guard let selectedCameraDeviceID else { return true }
+        return cameraDevices.contains { $0.id == selectedCameraDeviceID }
     }
 
     var recordingOptions: RecordingCaptureOptions {
@@ -51,7 +71,9 @@ enum CaptureOptionsEvent: Equatable {
     case microphoneEnabledChanged(Bool)
     case systemAudioChanged(Bool)
     case cameraEnabledChanged(Bool)
+    case deviceRefreshStarted
     case devicesRefreshed(microphones: [CaptureDeviceInfo], cameras: [CaptureDeviceInfo])
+    case deviceRefreshFailed(String)
     case systemAudioToggled
     case microphoneSelectionRequested
     case cameraSelectionRequested
@@ -59,6 +81,7 @@ enum CaptureOptionsEvent: Equatable {
     case cameraSelected(String?)
     case microphoneDisabled
     case cameraDisabled
+    case cameraDisabledForCaptureFailure
     case cursorVisibilityChanged(Bool)
     case clickVisibilityChanged(Bool)
     case statusCleared
@@ -81,28 +104,32 @@ extension CaptureOptionsState {
             return []
 
         case .microphoneEnabledChanged(let isEnabled):
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeMicrophone = isEnabled
             return []
 
         case .systemAudioChanged(let isEnabled):
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeSystemAudio = isEnabled
             return []
 
         case .cameraEnabledChanged(let isEnabled):
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeCamera = isEnabled
+            return []
+
+        case .deviceRefreshStarted:
+            deviceLoadPhase = .loading
             return []
 
         case .devicesRefreshed(let microphones, let cameras):
             microphoneDevices = microphones
             cameraDevices = cameras
-            if let selectedMicrophoneDeviceID,
-               !microphones.contains(where: { $0.id == selectedMicrophoneDeviceID }) {
-                self.selectedMicrophoneDeviceID = nil
-            }
-            if let selectedCameraDeviceID,
-               !cameras.contains(where: { $0.id == selectedCameraDeviceID }) {
-                self.selectedCameraDeviceID = nil
-            }
+            deviceLoadPhase = .loaded
+            return []
+
+        case .deviceRefreshFailed(let message):
+            deviceLoadPhase = .failed(message)
             return []
 
         case .systemAudioToggled:
@@ -117,12 +144,15 @@ extension CaptureOptionsState {
             return [.setStatusMessage(message)]
 
         case .microphoneSelectionRequested:
-            return [.refreshDevices, .showMicrophoneSelector]
+            guard canChangeOptions else { return lockedMutationEffects() }
+            return [.showMicrophoneSelector]
 
         case .cameraSelectionRequested:
-            return [.refreshDevices, .showCameraSelector]
+            guard canChangeOptions else { return lockedMutationEffects() }
+            return [.showCameraSelector]
 
         case .microphoneSelected(let deviceID):
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeMicrophone = true
             selectedMicrophoneDeviceID = deviceID
             let message = "Microphone set to \(selectedMicrophoneDeviceName)"
@@ -130,6 +160,7 @@ extension CaptureOptionsState {
             return [.setStatusMessage(message), .closeMicrophoneSelector]
 
         case .cameraSelected(let deviceID):
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeCamera = true
             selectedCameraDeviceID = deviceID
             let message = "Camera set to \(selectedCameraDeviceName)"
@@ -137,22 +168,30 @@ extension CaptureOptionsState {
             return [.setStatusMessage(message), .closeCameraSelector]
 
         case .microphoneDisabled:
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeMicrophone = false
             let message = "Microphone off"
             statusMessage = message
             return [.setStatusMessage(message)]
 
         case .cameraDisabled:
+            guard canChangeOptions else { return lockedMutationEffects() }
             includeCamera = false
             let message = "Camera off"
             statusMessage = message
             return [.setStatusMessage(message)]
 
+        case .cameraDisabledForCaptureFailure:
+            includeCamera = false
+            return []
+
         case .cursorVisibilityChanged(let isVisible):
+            guard canChangeOptions else { return lockedMutationEffects() }
             showCursor = isVisible
             return []
 
         case .clickVisibilityChanged(let isVisible):
+            guard canChangeOptions else { return lockedMutationEffects() }
             showClicks = isVisible
             return []
 
@@ -160,6 +199,12 @@ extension CaptureOptionsState {
             statusMessage = nil
             return []
         }
+    }
+
+    private mutating func lockedMutationEffects() -> [CaptureOptionsEffect] {
+        let message = "Recording options are locked while capture is starting."
+        statusMessage = message
+        return [.setStatusMessage(message)]
     }
 }
 
@@ -240,10 +285,30 @@ final class CaptureOptionsDriver {
     }
 }
 
+enum SourceSelectorLoadPhase: Equatable {
+    case idle
+    case loading
+    case loaded
+    case failed(String)
+}
+
+struct SourceSelectorRefreshResult: Equatable {
+    var sourceIDs: [String]
+    var errorMessage: String?
+
+    static func loaded(sourceIDs: [String]) -> SourceSelectorRefreshResult {
+        SourceSelectorRefreshResult(sourceIDs: sourceIDs, errorMessage: nil)
+    }
+}
+
 struct SourceSelectorState: Equatable {
     var sourceTab: SourceSelectorTab
     var preferredHeight: CGFloat = SourceSelectorWindowMetrics.compactHeight
     var visibleTabs: [SourceSelectorTab]
+    var committedSourceID: String?
+    var pendingSourceID: String?
+    var availableSourceIDs: Set<String> = []
+    var loadPhase: SourceSelectorLoadPhase = .idle
 
     init(sourceTab: SourceSelectorTab = .screens, visibleTabs: [SourceSelectorTab] = SourceSelectorTab.allCases) {
         self.sourceTab = sourceTab
@@ -260,14 +325,23 @@ struct SourceSelectorState: Equatable {
             return allSources.filter { $0.kind == .area }
         }
     }
+
+    var canSharePendingSource: Bool {
+        guard let pendingSourceID else { return false }
+        return availableSourceIDs.contains(pendingSourceID)
+    }
 }
 
 enum SourceSelectorEvent: Equatable {
     case visibleTabsChanged([SourceSelectorTab])
     case tabSelected(SourceSelectorTab)
     case preferredSourceKindSynced(CaptureSourceKind?)
+    case committedSelectionSynced(String?)
+    case sourceSelected(String)
+    case sourcesChanged([String])
     case heightMeasured(CGFloat)
     case refreshRequested
+    case refreshCompleted(SourceSelectorRefreshResult)
     case cancelRequested
     case shareRequested
     case drawAreaRequested
@@ -276,7 +350,7 @@ enum SourceSelectorEvent: Equatable {
 enum SourceSelectorEffect: Equatable {
     case refreshSources
     case cancel
-    case share
+    case share(String)
     case drawArea
 }
 
@@ -301,6 +375,20 @@ extension SourceSelectorState {
             sourceTab = visibleTabs.contains(nextTab) ? nextTab : sourceTab
             return []
 
+        case .committedSelectionSynced(let sourceID):
+            committedSourceID = sourceID
+            pendingSourceID = sourceID
+            return []
+
+        case .sourceSelected(let sourceID):
+            guard availableSourceIDs.contains(sourceID) else { return [] }
+            pendingSourceID = sourceID
+            return []
+
+        case .sourcesChanged(let sourceIDs):
+            availableSourceIDs = Set(sourceIDs)
+            return []
+
         case .heightMeasured(let cardHeight):
             let nextHeight = ceil(cardHeight + (SourceSelectorWindowMetrics.outerPadding * 2))
             guard abs(preferredHeight - nextHeight) > 0.5 else { return [] }
@@ -308,11 +396,30 @@ extension SourceSelectorState {
             return []
 
         case .refreshRequested:
+            loadPhase = .loading
             return [.refreshSources]
+        case .refreshCompleted(let result):
+            let sourceIDs = Set(result.sourceIDs)
+            availableSourceIDs = sourceIDs
+            if let pendingSourceID, !sourceIDs.contains(pendingSourceID) {
+                self.pendingSourceID = nil
+            }
+            if let committedSourceID, !sourceIDs.contains(committedSourceID) {
+                self.committedSourceID = nil
+            }
+            if let errorMessage = result.errorMessage {
+                loadPhase = .failed(errorMessage)
+            } else {
+                loadPhase = .loaded
+            }
+            return []
         case .cancelRequested:
+            pendingSourceID = committedSourceID
             return [.cancel]
         case .shareRequested:
-            return [.share]
+            guard canSharePendingSource, let pendingSourceID else { return [] }
+            committedSourceID = pendingSourceID
+            return [.share(pendingSourceID)]
         case .drawAreaRequested:
             return [.drawArea]
         }
@@ -324,19 +431,20 @@ extension SourceSelectorState {
 final class SourceSelectorDriver {
     private(set) var state: SourceSelectorState
 
-    @ObservationIgnored private var refreshSources: () -> Void = {}
+    @ObservationIgnored private var refreshSources: () async -> SourceSelectorRefreshResult = { .loaded(sourceIDs: []) }
     @ObservationIgnored private var cancel: () -> Void = {}
-    @ObservationIgnored private var share: () -> Void = {}
+    @ObservationIgnored private var share: (String) -> Void = { _ in }
     @ObservationIgnored private var drawArea: () -> Void = {}
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
 
     init(sourceTab: SourceSelectorTab = .screens, visibleTabs: [SourceSelectorTab] = SourceSelectorTab.allCases) {
         state = SourceSelectorState(sourceTab: sourceTab, visibleTabs: visibleTabs)
     }
 
     func configure(
-        refreshSources: @escaping () -> Void = {},
+        refreshSources: @escaping () async -> SourceSelectorRefreshResult = { .loaded(sourceIDs: []) },
         cancel: @escaping () -> Void = {},
-        share: @escaping () -> Void = {},
+        share: @escaping (String) -> Void = { _ in },
         drawArea: @escaping () -> Void = {}
     ) {
         self.refreshSources = refreshSources
@@ -360,12 +468,23 @@ final class SourceSelectorDriver {
         for effect in effects {
             switch effect {
             case .refreshSources:
-                refreshSources()
+                refreshTask?.cancel()
+                refreshTask = Task { [weak self] in
+                    guard let self else { return }
+                    let result = await refreshSources()
+                    guard !Task.isCancelled else { return }
+                    send(.refreshCompleted(result))
+                    refreshTask = nil
+                }
             case .cancel:
+                refreshTask?.cancel()
+                refreshTask = nil
                 cancel()
-            case .share:
-                share()
+            case .share(let sourceID):
+                share(sourceID)
             case .drawArea:
+                refreshTask?.cancel()
+                refreshTask = nil
                 drawArea()
             }
         }
@@ -444,15 +563,15 @@ extension OnboardingMachineState {
             switch outcome {
             case .granted:
                 accessibilityPermissionState = .granted
-                statusMessage = "Accessibility access is enabled."
+                statusMessage = "Optional Accessibility enhancements are enabled."
                 return [.refreshPermissions]
             case .promptAlreadyShown:
                 accessibilityPermissionState = .requestAlreadyShown
-                statusMessage = "Enable Accessibility access in System Settings to capture shortcuts and cursor details."
+                statusMessage = "Optional: enable Accessibility in System Settings for shortcuts and additional cursor details."
                 return [.openAccessibilitySettings, .refreshPermissions]
             case .promptShownWithoutGrant:
                 accessibilityPermissionState = .requestAlreadyShown
-                statusMessage = "Enable Accessibility access in System Settings to capture shortcuts and cursor details."
+                statusMessage = "Optional: enable Accessibility in System Settings for shortcuts and additional cursor details."
                 return [.refreshPermissions]
             }
 
@@ -560,6 +679,7 @@ struct SettingsMachineState: Equatable {
 
 enum SettingsEvent: Equatable {
     case serviceRefreshRequested
+    case serviceRefreshStarted
     case serviceRefreshSucceeded
     case serviceRefreshFailed(String)
     case autoZoomPreferenceSynced(Bool)
@@ -589,6 +709,11 @@ extension SettingsMachineState {
             isRefreshingService = true
             statusMessage = "Checking service..."
             return [.refreshService]
+
+        case .serviceRefreshStarted:
+            isRefreshingService = true
+            statusMessage = "Checking service..."
+            return []
 
         case .serviceRefreshSucceeded:
             isRefreshingService = false

--- a/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
@@ -25,6 +25,7 @@ struct AppShellState: Equatable {
     var projects: [ProjectSummary] = []
     var paths: AppPaths?
     var serviceHealth: HealthPayload?
+    var backendLoadPhase: LoadPhase = .idle
 
     var activeEditorKind: EditorMediaKind? {
         if let lastEditorSession {
@@ -49,6 +50,7 @@ enum AppShellEvent: Equatable {
     case currentScreenshotURLChanged(URL?)
     case windowCommandRequested(NativeWindowCommandAction, editorSession: EditorSession? = nil)
     case windowCommandConsumed(UUID?)
+    case backendRefreshStarted
     case backendRefreshed(paths: AppPaths?, projects: [ProjectSummary], health: HealthPayload?)
     case backendRefreshFailed(String)
     case editorSessionShown(EditorSession)
@@ -106,14 +108,22 @@ extension AppShellState {
             windowCommand = nil
             return []
 
+        case .backendRefreshStarted:
+            guard backendLoadPhase != .loading else { return [] }
+            backendLoadPhase = .loading
+            statusMessage = "Loading projects…"
+            return [.setStatusMessage(statusMessage)]
+
         case .backendRefreshed(let paths, let projects, let health):
             self.paths = paths
             self.projects = projects
             serviceHealth = health
+            backendLoadPhase = .loaded
             statusMessage = "Rust service ready"
             return [.setStatusMessage(statusMessage)]
 
         case .backendRefreshFailed(let message):
+            backendLoadPhase = .failed(message)
             statusMessage = message
             return [.setStatusMessage(message)]
 
@@ -200,6 +210,14 @@ final class AppShellDriver {
 
     func activateWorkspace(for editorSession: EditorSession?) {
         workspaces.activate(sessionID: editorSession?.id)
+    }
+
+    func prepareForTermination() async -> Bool {
+        await workspaces.prepareForTermination()
+    }
+
+    var terminationBlockingEditorSession: EditorSession? {
+        workspaces.terminationBlockingSession
     }
 
     @discardableResult

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -31,6 +31,25 @@ enum CaptureControllerError: LocalizedError {
     }
 }
 
+enum CaptureSourceCatalogState: Equatable {
+    case idle
+    case loading
+    case loaded
+    case permissionRequired
+    case failed(String)
+
+    var issueMessage: String? {
+        switch self {
+        case .idle, .loading, .loaded:
+            nil
+        case .permissionRequired:
+            "Screen Recording permission is required to list current screens and windows."
+        case .failed(let message):
+            message
+        }
+    }
+}
+
 struct WindowSourceMetadata: Equatable {
     var title: String?
     var ownerName: String?
@@ -215,6 +234,7 @@ enum WindowSourceFilter {
 @MainActor
 final class CaptureController: ObservableObject {
     @Published private(set) var sources: [CaptureSource] = []
+    @Published private(set) var sourceCatalogState: CaptureSourceCatalogState = .idle
     @Published private(set) var isRecording = false
     @Published private(set) var activeRecordingURL: URL?
 
@@ -222,9 +242,14 @@ final class CaptureController: ObservableObject {
     private var recordingProcess: Process?
     private var nativeRecorder: NativeScreenRecorder?
     private var activeStagedRecordingURL: URL?
+    private var sourceReloadGeneration = 0
 
     init(screenRecordingPermission: ScreenRecordingPermission = ScreenRecordingPermission()) {
         self.screenRecordingPermission = screenRecordingPermission
+    }
+
+    var screenRecordingPermissionState: ScreenRecordingPermissionState {
+        screenRecordingPermission.currentState()
     }
 
     #if DEBUG
@@ -234,6 +259,7 @@ final class CaptureController: ObservableObject {
 
     func setSourcesForTesting(_ sources: [CaptureSource]) {
         self.sources = sources
+        sourceCatalogState = .loaded
     }
 
     func ensureScreenRecordingPermissionForTesting() throws {
@@ -242,10 +268,16 @@ final class CaptureController: ObservableObject {
     #endif
 
     func reloadSources(requestScreenRecordingPermission: Bool = false) async {
+        sourceReloadGeneration += 1
+        let generation = sourceReloadGeneration
+        sourceCatalogState = .loading
+
         guard canLoadPreviewSources(requestScreenRecordingPermission: requestScreenRecordingPermission) else {
             var nextSources = legacyDisplaySources()
             nextSources.append(contentsOf: legacyWindowSources())
+            guard generation == sourceReloadGeneration else { return }
             sources = nextSources
+            sourceCatalogState = .permissionRequired
             return
         }
 
@@ -253,11 +285,15 @@ final class CaptureController: ObservableObject {
             let content = try await shareableContent()
             var nextSources = await displaySources(from: content)
             nextSources.append(contentsOf: await windowSources(from: content))
+            guard generation == sourceReloadGeneration else { return }
             sources = nextSources
+            sourceCatalogState = .loaded
         } catch {
             var nextSources = legacyDisplaySources()
             nextSources.append(contentsOf: legacyWindowSources())
+            guard generation == sourceReloadGeneration else { return }
             sources = nextSources
+            sourceCatalogState = .failed("Couldn’t refresh capture sources. \(error.localizedDescription)")
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/CaptureDeviceProvider.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureDeviceProvider.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import Foundation
 
-struct CaptureDeviceProvider {
+struct CaptureDeviceProvider: Sendable {
     func devices(for mediaType: AVMediaType) -> [CaptureDeviceInfo] {
         let deviceTypes: [AVCaptureDevice.DeviceType] = mediaType == .video
             ? [.builtInWideAngleCamera, .external]

--- a/apps/macos/Sources/OpenRecorderMac/CaptureDeviceSelectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureDeviceSelectorViews.swift
@@ -7,7 +7,7 @@ enum CaptureDeviceSelectorWindowMetrics {
     static let minHeight: CGFloat = 260
 }
 
-private enum CaptureDeviceDialogSelection: Equatable {
+private enum CaptureDeviceDialogSelection: Hashable {
     case noInput
     case systemDefault
     case device(String)
@@ -47,46 +47,52 @@ struct MicrophoneSelectorWindowView: View {
             .padding(14)
 
             ScrollView(.vertical) {
-                VStack(spacing: 6) {
-                    StudioButton(hitTarget: .rounded(8)) {
-                        pendingSelection = .noInput
-                    } label: {
-                        microphoneRow(
+                VStack(alignment: .leading, spacing: 10) {
+                    if options.deviceLoadPhase == .loading {
+                        ProgressView("Checking microphones…")
+                            .controlSize(.small)
+                    }
+
+                    Picker("Microphone", selection: $pendingSelection) {
+                        CaptureDevicePickerLabel(
                             title: "No Microphone",
-                            subtitle: "Do not record microphone audio",
-                            isSelected: pendingSelection == .noInput
+                            subtitle: "Do not record microphone audio"
                         )
-                    }
+                        .tag(CaptureDeviceDialogSelection.noInput)
 
-                    StudioButton(hitTarget: .rounded(8)) {
-                        pendingSelection = .systemDefault
-                    } label: {
-                        microphoneRow(
+                        CaptureDevicePickerLabel(
                             title: "System Default",
-                            subtitle: "Use the current macOS default",
-                            isSelected: pendingSelection == .systemDefault
+                            subtitle: options.microphoneDevices.isEmpty
+                                ? "No default microphone is currently available"
+                                : "Follow the current macOS default"
                         )
-                    }
+                        .tag(CaptureDeviceDialogSelection.systemDefault)
+                        .disabled(options.microphoneDevices.isEmpty)
 
-                    ForEach(options.microphoneDevices) { device in
-                        StudioButton(hitTarget: .rounded(8)) {
-                            pendingSelection = .device(device.id)
-                        } label: {
-                            microphoneRow(
-                                title: device.name,
-                                subtitle: device.isDefault ? "Current macOS default" : "Microphone",
-                                isSelected: pendingSelection == .device(device.id)
+                        if case .device(let selectedID) = pendingSelection,
+                           !options.microphoneDevices.contains(where: { $0.id == selectedID }) {
+                            CaptureDevicePickerLabel(
+                                title: "Previously Selected Microphone",
+                                subtitle: "This device is no longer available"
                             )
+                            .tag(CaptureDeviceDialogSelection.device(selectedID))
+                            .disabled(true)
+                        }
+
+                        ForEach(options.microphoneDevices) { device in
+                            CaptureDevicePickerLabel(
+                                title: device.name,
+                                subtitle: device.isDefault ? "Current macOS default" : "Microphone"
+                            )
+                            .tag(CaptureDeviceDialogSelection.device(device.id))
                         }
                     }
+                    .pickerStyle(.radioGroup)
+                    .labelsHidden()
+                    .accessibilityLabel("Microphone")
+                    .disabled(!options.canChangeOptions)
 
-                    if options.microphoneDevices.isEmpty {
-                        Text("No devices found")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 18)
-                    }
+                    deviceLoadMessage(emptyMessage: "No microphones are available.")
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 12)
@@ -110,6 +116,7 @@ struct MicrophoneSelectorWindowView: View {
                         .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
                 }
                 .foregroundStyle(.secondary)
+                .keyboardShortcut(.cancelAction)
 
                 StudioButton(hitTarget: .rounded(8)) {
                     applyMicrophoneSelection()
@@ -121,6 +128,8 @@ struct MicrophoneSelectorWindowView: View {
                         .background(Theme.accent, in: RoundedRectangle(cornerRadius: 8))
                         .foregroundStyle(.white)
                 }
+                .disabled(!canApplyMicrophoneSelection)
+                .keyboardShortcut(.defaultAction)
             }
             .padding(14)
         }
@@ -149,9 +158,21 @@ struct MicrophoneSelectorWindowView: View {
         dismissWindow(id: "microphone-selector")
     }
 
+    private var canApplyMicrophoneSelection: Bool {
+        guard options.canChangeOptions else { return false }
+        return switch pendingSelection {
+        case .noInput:
+            true
+        case .systemDefault:
+            !options.microphoneDevices.isEmpty
+        case .device(let deviceID):
+            options.microphoneDevices.contains { $0.id == deviceID }
+        }
+    }
+
     private func resetPendingMicrophoneSelection() {
         guard options.includeMicrophone else {
-            pendingSelection = .systemDefault
+            pendingSelection = .noInput
             return
         }
         if let selectedMicrophoneDeviceID = options.selectedMicrophoneDeviceID {
@@ -161,30 +182,19 @@ struct MicrophoneSelectorWindowView: View {
         }
     }
 
-    private func microphoneRow(title: String, subtitle: String, isSelected: Bool) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(isSelected ? Theme.accent : Theme.fgSubtle)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 13, weight: .semibold))
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(.system(size: 11))
-                    .lineLimit(1)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 48)
-        .background(isSelected ? Theme.accent.opacity(0.14) : Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 8))
-        .overlay {
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(isSelected ? Theme.accent.opacity(0.36) : Theme.overlay, lineWidth: 1)
+    @ViewBuilder
+    private func deviceLoadMessage(emptyMessage: String) -> some View {
+        switch options.deviceLoadPhase {
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        case .loaded where options.microphoneDevices.isEmpty:
+            Label(emptyMessage, systemImage: "mic.slash")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        case .idle, .loading, .loaded:
+            EmptyView()
         }
     }
 }
@@ -223,46 +233,52 @@ struct CameraSelectorWindowView: View {
             .padding(14)
 
             ScrollView(.vertical) {
-                VStack(spacing: 6) {
-                    StudioButton(hitTarget: .rounded(8)) {
-                        pendingSelection = .noInput
-                    } label: {
-                        cameraRow(
+                VStack(alignment: .leading, spacing: 10) {
+                    if options.deviceLoadPhase == .loading {
+                        ProgressView("Checking cameras…")
+                            .controlSize(.small)
+                    }
+
+                    Picker("Camera", selection: $pendingSelection) {
+                        CaptureDevicePickerLabel(
                             title: "No Camera",
-                            subtitle: "Do not record facecam video",
-                            isSelected: pendingSelection == .noInput
+                            subtitle: "Do not record facecam video"
                         )
-                    }
+                        .tag(CaptureDeviceDialogSelection.noInput)
 
-                    StudioButton(hitTarget: .rounded(8)) {
-                        pendingSelection = .systemDefault
-                    } label: {
-                        cameraRow(
+                        CaptureDevicePickerLabel(
                             title: "System Default",
-                            subtitle: "Use the current macOS default",
-                            isSelected: pendingSelection == .systemDefault
+                            subtitle: options.cameraDevices.isEmpty
+                                ? "No default camera is currently available"
+                                : "Follow the current macOS default"
                         )
-                    }
+                        .tag(CaptureDeviceDialogSelection.systemDefault)
+                        .disabled(options.cameraDevices.isEmpty)
 
-                    ForEach(options.cameraDevices) { device in
-                        StudioButton(hitTarget: .rounded(8)) {
-                            pendingSelection = .device(device.id)
-                        } label: {
-                            cameraRow(
-                                title: device.name,
-                                subtitle: device.isDefault ? "Current macOS default" : "Camera",
-                                isSelected: pendingSelection == .device(device.id)
+                        if case .device(let selectedID) = pendingSelection,
+                           !options.cameraDevices.contains(where: { $0.id == selectedID }) {
+                            CaptureDevicePickerLabel(
+                                title: "Previously Selected Camera",
+                                subtitle: "This device is no longer available"
                             )
+                            .tag(CaptureDeviceDialogSelection.device(selectedID))
+                            .disabled(true)
+                        }
+
+                        ForEach(options.cameraDevices) { device in
+                            CaptureDevicePickerLabel(
+                                title: device.name,
+                                subtitle: device.isDefault ? "Current macOS default" : "Camera"
+                            )
+                            .tag(CaptureDeviceDialogSelection.device(device.id))
                         }
                     }
+                    .pickerStyle(.radioGroup)
+                    .labelsHidden()
+                    .accessibilityLabel("Camera")
+                    .disabled(!options.canChangeOptions)
 
-                    if options.cameraDevices.isEmpty {
-                        Text("No devices found")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 18)
-                    }
+                    deviceLoadMessage(emptyMessage: "No cameras are available.")
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 12)
@@ -286,6 +302,7 @@ struct CameraSelectorWindowView: View {
                         .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
                 }
                 .foregroundStyle(.secondary)
+                .keyboardShortcut(.cancelAction)
 
                 StudioButton(hitTarget: .rounded(8)) {
                     applyCameraSelection()
@@ -297,6 +314,8 @@ struct CameraSelectorWindowView: View {
                         .background(Theme.accent, in: RoundedRectangle(cornerRadius: 8))
                         .foregroundStyle(.white)
                 }
+                .disabled(!canApplyCameraSelection)
+                .keyboardShortcut(.defaultAction)
             }
             .padding(14)
         }
@@ -325,9 +344,21 @@ struct CameraSelectorWindowView: View {
         dismissWindow(id: "camera-selector")
     }
 
+    private var canApplyCameraSelection: Bool {
+        guard options.canChangeOptions else { return false }
+        return switch pendingSelection {
+        case .noInput:
+            true
+        case .systemDefault:
+            !options.cameraDevices.isEmpty
+        case .device(let deviceID):
+            options.cameraDevices.contains { $0.id == deviceID }
+        }
+    }
+
     private func resetPendingCameraSelection() {
         guard options.includeCamera else {
-            pendingSelection = .systemDefault
+            pendingSelection = .noInput
             return
         }
         if let selectedCameraDeviceID = options.selectedCameraDeviceID {
@@ -337,30 +368,37 @@ struct CameraSelectorWindowView: View {
         }
     }
 
-    private func cameraRow(title: String, subtitle: String, isSelected: Bool) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(isSelected ? Theme.accent : Theme.fgSubtle)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 13, weight: .semibold))
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(.system(size: 11))
-                    .lineLimit(1)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
+    @ViewBuilder
+    private func deviceLoadMessage(emptyMessage: String) -> some View {
+        switch options.deviceLoadPhase {
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        case .loaded where options.cameraDevices.isEmpty:
+            Label(emptyMessage, systemImage: "video.slash")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        case .idle, .loading, .loaded:
+            EmptyView()
         }
-        .padding(.horizontal, 10)
-        .frame(height: 48)
-        .background(isSelected ? Theme.accent.opacity(0.14) : Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 8))
-        .overlay {
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(isSelected ? Theme.accent.opacity(0.36) : Theme.overlay, lineWidth: 1)
+    }
+}
+
+private struct CaptureDevicePickerLabel: View {
+    var title: String
+    var subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+            Text(subtitle)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
         }
+        .padding(.vertical, 3)
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -51,6 +51,7 @@ struct CaptureHUD: View {
                 ) {
                     toggleRecording()
                 }
+                .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
             }
         }
     }
@@ -75,6 +76,7 @@ struct CaptureHUD: View {
                 ) {
                     toggleRecording()
                 }
+                .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
             }
         }
     }
@@ -94,6 +96,7 @@ struct CaptureHUD: View {
             ) {
                 toggleRecording()
             }
+            .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
         }
     }
 
@@ -109,7 +112,7 @@ struct CaptureHUD: View {
             sharedLeadingControls
 
             FlowLabel(
-                tone: model.statusMessage.localizedCaseInsensitiveContains("permission") ? .red : .blue,
+                tone: captureReadiness.canCapture ? .blue : .red,
                 label: "Screenshot",
                 value: model.selectedSource == nil ? "Source" : "Ready"
             )
@@ -129,6 +132,7 @@ struct CaptureHUD: View {
             ) {
                 model.takeScreenshot()
             }
+            .disabled(!captureReadiness.canCapture)
         }
     }
 
@@ -137,7 +141,7 @@ struct CaptureHUD: View {
             compactLeadingControls
 
             CompactFlowLabel(
-                tone: model.statusMessage.localizedCaseInsensitiveContains("permission") ? .red : .blue,
+                tone: captureReadiness.canCapture ? .blue : .red,
                 value: model.selectedSource == nil ? "Source" : "Ready"
             )
 
@@ -153,6 +157,7 @@ struct CaptureHUD: View {
             ) {
                 model.takeScreenshot()
             }
+            .disabled(!captureReadiness.canCapture)
         }
     }
 
@@ -341,9 +346,30 @@ struct CaptureHUD: View {
 
     @ViewBuilder
     private var permissionControls: some View {
-        if model.statusMessage.localizedCaseInsensitiveContains("permission") {
-            HUDPermissionGroup {
-                openRelevantPrivacySettings()
+        if let blocker = captureReadiness.primaryBlocker {
+            switch blocker.recoveryAction {
+            case .openScreenRecordingSettings:
+                HUDPermissionGroup {
+                    model.openPrivacySettings()
+                }
+            case .openMicrophoneSettings:
+                HUDIconActionButton(symbolName: "mic.badge.xmark", title: blocker.message, tint: .red) {
+                    model.openMicrophoneSettings()
+                }
+            case .openCameraSettings:
+                HUDIconActionButton(symbolName: "video.badge.xmark", title: blocker.message, tint: .red) {
+                    model.openCameraSettings()
+                }
+            case .chooseMicrophone:
+                HUDIconActionButton(symbolName: "mic.badge.xmark", title: blocker.message, tint: .red) {
+                    openMicrophoneSelector()
+                }
+            case .chooseCamera:
+                HUDIconActionButton(symbolName: "video.badge.xmark", title: blocker.message, tint: .red) {
+                    openCameraSelector()
+                }
+            case .chooseSource, .drawArea, .waitForCurrentCapture:
+                CaptureStatusChip(message: blocker.message, isError: true)
             }
         } else if let captureStatusMessage {
             CaptureStatusChip(message: captureStatusMessage, isError: false)
@@ -352,9 +378,9 @@ struct CaptureHUD: View {
 
     @ViewBuilder
     private var compactPermissionControls: some View {
-        if model.statusMessage.localizedCaseInsensitiveContains("permission") {
-            HUDIconActionButton(symbolName: "exclamationmark.triangle.fill", title: "Open Privacy Settings", tint: .red) {
-                openRelevantPrivacySettings()
+        if let blocker = captureReadiness.primaryBlocker {
+            HUDIconActionButton(symbolName: "exclamationmark.triangle.fill", title: blocker.message, tint: .red) {
+                performRecovery(for: blocker)
             }
         } else if let captureStatusMessage {
             CaptureStatusChip(message: captureStatusMessage, isError: false, maxWidth: 96)
@@ -384,6 +410,39 @@ struct CaptureHUD: View {
             return "Choose source"
         }
         return message
+    }
+
+    private var captureReadiness: CaptureReadiness {
+        model.captureState.readiness(
+            availableSources: model.capture.sources,
+            screenRecordingPermissionState: model.capture.screenRecordingPermissionState,
+            options: options.state,
+            runtimeIsRecording: model.capture.isRecording,
+            microphoneAuthorization: model.microphoneCaptureAuthorization,
+            cameraAuthorization: model.cameraCaptureAuthorization,
+            isChecking: model.capture.sourceCatalogState == .loading || model.isCapturePreflightRunning
+        )
+    }
+
+    private func performRecovery(for blocker: CaptureBlocker) {
+        switch blocker.recoveryAction {
+        case .waitForCurrentCapture:
+            break
+        case .chooseSource:
+            model.requestSourceSelector()
+        case .drawArea:
+            model.requestInteractiveAreaSelection()
+        case .openScreenRecordingSettings:
+            model.openPrivacySettings()
+        case .openMicrophoneSettings:
+            model.openMicrophoneSettings()
+        case .openCameraSettings:
+            model.openCameraSettings()
+        case .chooseMicrophone:
+            openMicrophoneSelector()
+        case .chooseCamera:
+            openCameraSelector()
+        }
     }
 
     private func openRelevantPrivacySettings() {

--- a/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
@@ -9,6 +9,96 @@ enum HUDPresentationState: Hashable {
     }
 }
 
+enum CaptureRecoveryAction: Hashable {
+    case waitForCurrentCapture
+    case chooseSource
+    case drawArea
+    case openScreenRecordingSettings
+    case openMicrophoneSettings
+    case openCameraSettings
+    case chooseMicrophone
+    case chooseCamera
+}
+
+enum CaptureMediaAuthorizationState: Hashable {
+    case undetermined
+    case authorized
+    case denied
+}
+
+enum CaptureBlocker: Hashable {
+    case captureAlreadyRunning
+    case sourceRequired
+    case sourceUnavailable(name: String)
+    case areaSelectionRequired
+    case screenRecordingPermissionRequired
+    case screenRecordingPermissionNeedsRestart
+    case microphonePermissionDenied
+    case cameraPermissionDenied
+    case microphoneUnavailable(deviceID: String?)
+    case cameraUnavailable(deviceID: String?)
+
+    var recoveryAction: CaptureRecoveryAction {
+        switch self {
+        case .captureAlreadyRunning:
+            .waitForCurrentCapture
+        case .sourceRequired, .sourceUnavailable:
+            .chooseSource
+        case .areaSelectionRequired:
+            .drawArea
+        case .screenRecordingPermissionRequired, .screenRecordingPermissionNeedsRestart:
+            .openScreenRecordingSettings
+        case .microphonePermissionDenied:
+            .openMicrophoneSettings
+        case .cameraPermissionDenied:
+            .openCameraSettings
+        case .microphoneUnavailable:
+            .chooseMicrophone
+        case .cameraUnavailable:
+            .chooseCamera
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .captureAlreadyRunning:
+            "Finish or cancel the current capture before starting another."
+        case .sourceRequired:
+            "Choose a source first."
+        case .sourceUnavailable(let name):
+            "\(name) is no longer available. Choose another source."
+        case .areaSelectionRequired:
+            "Draw the area you want to capture."
+        case .screenRecordingPermissionRequired:
+            "Screen Recording permission is required."
+        case .screenRecordingPermissionNeedsRestart:
+            "Screen Recording permission is still unavailable. You may need to restart Open Recorder after enabling it."
+        case .microphonePermissionDenied:
+            "Microphone permission is denied. Open System Settings to record narration."
+        case .cameraPermissionDenied:
+            "Camera permission is denied. Open System Settings to record facecam video."
+        case .microphoneUnavailable:
+            "The selected microphone is unavailable. Choose another microphone or turn it off."
+        case .cameraUnavailable:
+            "The selected camera is unavailable. Choose another camera or turn it off."
+        }
+    }
+}
+
+struct CaptureReadiness: Hashable {
+    var source: CaptureSource?
+    var blockers: [CaptureBlocker]
+    var isChecking: Bool
+
+    var canCapture: Bool {
+        !isChecking && blockers.isEmpty
+    }
+
+    var primaryBlocker: CaptureBlocker? {
+        blockers.first
+    }
+}
+
 enum CapturePhase: Hashable {
     case idle
     case choosingMode
@@ -327,6 +417,66 @@ struct CaptureState: Hashable {
             !isCaptureOccupied
     }
 
+    func readiness(
+        availableSources: [CaptureSource],
+        screenRecordingPermissionState: ScreenRecordingPermissionState,
+        options: CaptureOptionsState,
+        runtimeIsRecording: Bool,
+        microphoneAuthorization: CaptureMediaAuthorizationState = .authorized,
+        cameraAuthorization: CaptureMediaAuthorizationState = .authorized,
+        isChecking: Bool = false
+    ) -> CaptureReadiness {
+        let selectedSource = source
+        var blockers: [CaptureBlocker] = []
+
+        if runtimeIsRecording || recordingPhase != .idle {
+            blockers.append(.captureAlreadyRunning)
+        }
+
+        switch screenRecordingPermissionState {
+        case .granted:
+            break
+        case .requestAvailable:
+            blockers.append(.screenRecordingPermissionRequired)
+        case .requestAlreadyShown:
+            blockers.append(.screenRecordingPermissionNeedsRestart)
+        }
+
+        if let selectedSource {
+            switch selectedSource.kind {
+            case .area:
+                if selectedSource.area == nil {
+                    blockers.append(.areaSelectionRequired)
+                }
+            case .display, .window:
+                if !availableSources.contains(where: { $0.representsSameCaptureSource(as: selectedSource) }) {
+                    blockers.append(.sourceUnavailable(name: selectedSource.name))
+                }
+            }
+        } else {
+            blockers.append(.sourceRequired)
+        }
+
+        if mode == .recording {
+            if options.includeMicrophone {
+                if microphoneAuthorization == .denied {
+                    blockers.append(.microphonePermissionDenied)
+                } else if !options.hasAvailableMicrophoneSelection {
+                    blockers.append(.microphoneUnavailable(deviceID: options.selectedMicrophoneDeviceID))
+                }
+            }
+            if options.includeCamera {
+                if cameraAuthorization == .denied {
+                    blockers.append(.cameraPermissionDenied)
+                } else if !options.hasAvailableCameraSelection {
+                    blockers.append(.cameraUnavailable(deviceID: options.selectedCameraDeviceID))
+                }
+            }
+        }
+
+        return CaptureReadiness(source: selectedSource, blockers: blockers, isChecking: isChecking)
+    }
+
     func isDirectStopState(runtimeIsRecording: Bool) -> Bool {
         switch phase {
         case .countingDownRecording, .startingRecording, .recording:
@@ -472,7 +622,7 @@ struct CaptureState: Hashable {
             statusMessage = "Selected area"
             switch mode {
             case .recording:
-                effects.append(.prepareRecordingFile(source))
+                effects.append(.showHUD)
             case .screenshot:
                 next.setPhase(.capturingScreenshot(source))
                 effects.append(.dismissScreenSelection)
@@ -641,13 +791,45 @@ struct CaptureState: Hashable {
             effects.append(.showHUD)
 
         case .refreshSelectedSource(let source):
-            next.selectedSource = source
-            if let source {
-                next.preferredSourceKind = source.kind
-                if case .ready(let mode, let previousSource) = next.phase,
-                   previousSource.id == source.id || previousSource.kind == source.kind {
-                    next.setPhase(.ready(mode, source))
+            switch next.phase {
+            case .countingDownRecording,
+                 .startingRecording,
+                 .recording,
+                 .stoppingRecording,
+                 .capturingScreenshot:
+                // A catalog refresh must not rewrite the source of in-flight runtime work.
+                return finish(self)
+            case .idle,
+                 .choosingMode,
+                 .choosingSourceType,
+                 .screenSelecting,
+                 .selectingSource,
+                 .ready,
+                 .areaSelecting:
+                break
+            }
+            guard let previousSource = next.selectedSource else {
+                // Refreshing the catalog must never choose a source on the user's behalf.
+                return finish(self)
+            }
+            guard previousSource.kind != .area else {
+                // Interactive areas are local selections and do not appear in the source catalog.
+                return finish(self)
+            }
+            guard let source,
+                  source.representsSameCaptureSource(as: previousSource) else {
+                next.selectedSource = nil
+                if case .ready(let mode, _) = next.phase {
+                    next.setPhase(.selectingSource(mode), clearSource: true)
                 }
+                statusMessage = "\(previousSource.name) is no longer available. Choose another source."
+                return finish()
+            }
+
+            next.selectedSource = source
+            next.preferredSourceKind = source.kind
+            if case .ready(let mode, _) = next.phase {
+                next.setPhase(.ready(mode, source))
             }
         }
 
@@ -686,6 +868,31 @@ struct CaptureState: Hashable {
              .stoppingRecording,
              .capturingScreenshot:
             return false
+        }
+    }
+}
+
+private extension CaptureSource {
+    func representsSameCaptureSource(as other: CaptureSource) -> Bool {
+        guard kind == other.kind else { return false }
+        if id == other.id { return true }
+
+        switch kind {
+        case .display:
+            if let displayID, let otherDisplayID = other.displayID {
+                return displayID == otherDisplayID
+            }
+            return id == other.id
+        case .window:
+            if windowID != nil || other.windowID != nil {
+                return windowID == other.windowID && ownerBundleID == other.ownerBundleID
+            }
+            return ownerBundleID != nil &&
+                ownerBundleID == other.ownerBundleID &&
+                !name.isEmpty &&
+                name == other.name
+        case .area:
+            return id == other.id
         }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/CaptureViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureViews.swift
@@ -40,6 +40,7 @@ struct CaptureStudioView: View {
                         allSources: model.capture.sources,
                         selectedSourceID: model.selectedSource?.id,
                         captureMode: model.captureMode,
+                        loadPhase: sourceSelector.state.loadPhase,
                         onRefresh: {
                             sourceSelector.send(.refreshRequested)
                         },
@@ -58,13 +59,22 @@ struct CaptureStudioView: View {
                 .background(Theme.appBgMuted)
                 .onAppear {
                     sourceSelector.configure(refreshSources: {
-                        model.reloadSourcesForPreview()
+                        await model.refreshSources(requestScreenRecordingPermission: true)
+                        return SourceSelectorRefreshResult(
+                            sourceIDs: model.capture.sources.map(\.id),
+                            errorMessage: model.capture.sourceCatalogState.issueMessage
+                        )
                     })
                     sourceSelector.send(.visibleTabsChanged(visibleTabs))
-                    model.reloadSourcesForPreview()
+                    sourceSelector.send(.committedSelectionSynced(model.selectedSource?.id))
+                    sourceSelector.send(.sourcesChanged(model.capture.sources.map(\.id)))
+                    sourceSelector.send(.refreshRequested)
                 }
                 .onChange(of: model.preferredSourceSelectorKind) { _, kind in
                     sourceSelector.send(.preferredSourceKindSynced(kind))
+                }
+                .onChange(of: model.capture.sources.map(\.id)) { _, sourceIDs in
+                    sourceSelector.send(.sourcesChanged(sourceIDs))
                 }
             }
         }

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -38,7 +38,7 @@ struct EditorStudioView: View {
                 editor: workspace.screenshot,
                 exportRequest: workspace.state.screenshotExportRequest
             )
-        } else {
+        } else if videoURL != nil {
             VideoEditorStudioView(
                 videoURL: videoURL,
                 projectPath: projectPath,
@@ -53,6 +53,22 @@ struct EditorStudioView: View {
                 videoExport: workspace.videoExport,
                 exportRequest: workspace.state.videoExportRequest
             )
+        } else {
+            ContentUnavailableView {
+                Label("No Capture Open", systemImage: "rectangle.on.rectangle.slash")
+            } description: {
+                Text("Open an Open Recorder project or start a new recording to edit it here.")
+            } actions: {
+                Button("Open Project…") {
+                    model.openProjectFile()
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("New Recording") {
+                    model.beginCapture(.recording)
+                }
+                .disabled(!model.canStartNewCapture)
+            }
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
@@ -29,11 +29,13 @@ final class EditorWorkspaceRegistry {
     private(set) var defaultWorkspace = EditorWorkspaceDriver(synchronizesAppShell: true)
 
     private var workspacesBySessionID: [UUID: EditorWorkspaceDriver] = [:]
+    private var sessionsByID: [UUID: EditorSession] = [:]
     private var defaultCloseGeneration: UUID?
     private var closeGenerationBySessionID: [UUID: UUID] = [:]
     private var recoverableSessionIDsByKey: [EditorWorkspaceRecoveryKey: [UUID]] = [:]
     private var recoveryKeyBySessionID: [UUID: EditorWorkspaceRecoveryKey] = [:]
     private var configureWorkspace: (EditorWorkspaceDriver) -> Void = { _ in }
+    private(set) var terminationBlockingSession: EditorSession?
 
     func configure(_ configureWorkspace: @escaping (EditorWorkspaceDriver) -> Void) {
         self.configureWorkspace = configureWorkspace
@@ -46,6 +48,7 @@ final class EditorWorkspaceRegistry {
             return defaultWorkspace
         }
         let sessionID = session.id
+        sessionsByID[sessionID] = session
 
         if let workspace = workspacesBySessionID[sessionID] {
             return workspace
@@ -69,6 +72,62 @@ final class EditorWorkspaceRegistry {
         }
         closeGenerationBySessionID.removeValue(forKey: sessionID)
         removeRecoveryRecord(for: sessionID)
+    }
+
+    func prepareForTermination() async -> Bool {
+        terminationBlockingSession = nil
+        while !Task.isCancelled {
+            let workspaces = uniqueWorkspaces
+
+            if workspaces.contains(where: { $0.videoExport.state.phase.isBusy }) {
+                do {
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                } catch {
+                    return false
+                }
+                continue
+            }
+
+            if let workspace = workspaces.first(where: { $0.videoExport.state.pendingTempURL != nil }) {
+                terminationBlockingSession = session(for: workspace)
+                workspace.send(.statusUpdated(EditorWorkspaceStatus(
+                    message: "Save or cancel the finished export before quitting.",
+                    severity: .failure
+                )))
+                return false
+            }
+
+            for workspace in workspaces {
+                var didFlush = false
+                repeat {
+                    didFlush = await workspace.flushPendingAutosaves()
+                    guard !Task.isCancelled else { return false }
+                    guard didFlush else {
+                        terminationBlockingSession = session(for: workspace)
+                        workspace.send(.autosaveRecoveryRequired)
+                        return false
+                    }
+                } while workspace.hasPendingAutosaves
+            }
+
+            // Autosaving one workspace can suspend while another window changes or
+            // opens. Re-snapshot at a fixed point and repeat until every current
+            // workspace is quiescent in the same main-actor turn.
+            await Task.yield()
+            let currentWorkspaces = uniqueWorkspaces
+            let snapshotIDs = Set(workspaces.map(ObjectIdentifier.init))
+            let currentIDs = Set(currentWorkspaces.map(ObjectIdentifier.init))
+            if snapshotIDs != currentIDs
+                || currentWorkspaces.contains(where: {
+                    $0.hasPendingAutosaves
+                        || $0.videoExport.state.phase.isBusy
+                        || $0.videoExport.state.pendingTempURL != nil
+                }) {
+                continue
+            }
+            return true
+        }
+        return false
     }
 
     func beginClose(session: EditorSession?) -> EditorWorkspaceCloseRequest? {
@@ -115,6 +174,10 @@ final class EditorWorkspaceRegistry {
                 request.workspace.send(.autosaveRecoveryRequired)
                 return .autosaveFailed
             }
+            guard canCloseWithoutDiscardingExport(request.workspace) else {
+                cancelClose(request)
+                return .canceled
+            }
             request.workspace.discardTransientState()
             if request.workspace.state.isAutosaveRecoveryPresented {
                 request.workspace.send(.autosaveRecoveryResolved("Saved"))
@@ -132,8 +195,13 @@ final class EditorWorkspaceRegistry {
             request.workspace.send(.autosaveRecoveryRequired)
             return .autosaveFailed
         }
+        guard canCloseWithoutDiscardingExport(request.workspace) else {
+            cancelClose(request)
+            return .canceled
+        }
         request.workspace.discardTransientState()
         workspacesBySessionID.removeValue(forKey: sessionID)
+        sessionsByID.removeValue(forKey: sessionID)
         closeGenerationBySessionID.removeValue(forKey: sessionID)
         removeRecoveryRecord(for: sessionID)
         return .closed
@@ -149,6 +217,7 @@ final class EditorWorkspaceRegistry {
     func discard(session: EditorSession?) -> Bool {
         guard let session else {
             let discardedWorkspace = defaultWorkspace
+            guard canCloseWithoutDiscardingExport(discardedWorkspace) else { return false }
             guard discardedWorkspace.abandonPendingAutosaves() else { return false }
             discardedWorkspace.discardTransientState()
             defaultCloseGeneration = nil
@@ -158,8 +227,10 @@ final class EditorWorkspaceRegistry {
             return true
         }
         guard let workspace = workspacesBySessionID[session.id] else { return false }
+        guard canCloseWithoutDiscardingExport(workspace) else { return false }
         guard workspace.abandonPendingAutosaves() else { return false }
         workspacesBySessionID.removeValue(forKey: session.id)
+        sessionsByID.removeValue(forKey: session.id)
         workspace.discardTransientState()
         closeGenerationBySessionID.removeValue(forKey: session.id)
         removeRecoveryRecord(for: session.id)
@@ -191,6 +262,21 @@ final class EditorWorkspaceRegistry {
         }
     }
 
+    private func canCloseWithoutDiscardingExport(_ workspace: EditorWorkspaceDriver) -> Bool {
+        let exportState = workspace.videoExport.state
+        guard !exportState.phase.isBusy, exportState.pendingTempURL == nil else {
+            let message = exportState.phase.isBusy
+                ? "Finish or cancel the active export before closing this editor."
+                : "Save or cancel the finished export before closing this editor."
+            workspace.send(.statusUpdated(EditorWorkspaceStatus(
+                message: message,
+                severity: .failure
+            )))
+            return false
+        }
+        return true
+    }
+
     private func recoverWorkspace(
         for recoveryKey: EditorWorkspaceRecoveryKey,
         newSessionID: UUID
@@ -203,6 +289,7 @@ final class EditorWorkspaceRegistry {
             }
             closeGenerationBySessionID.removeValue(forKey: recoverableSessionID)
             recoveryKeyBySessionID.removeValue(forKey: recoverableSessionID)
+            sessionsByID.removeValue(forKey: recoverableSessionID)
             recoverableSessionIDsByKey[recoveryKey] = sessionIDs.isEmpty ? nil : sessionIDs
             workspacesBySessionID[newSessionID] = workspace
             return workspace
@@ -218,6 +305,20 @@ final class EditorWorkspaceRegistry {
         }
         sessionIDs.removeAll { $0 == sessionID }
         recoverableSessionIDsByKey[recoveryKey] = sessionIDs.isEmpty ? nil : sessionIDs
+    }
+
+    private var uniqueWorkspaces: [EditorWorkspaceDriver] {
+        var seen: Set<ObjectIdentifier> = []
+        return ([defaultWorkspace] + Array(workspacesBySessionID.values)).filter { workspace in
+            seen.insert(ObjectIdentifier(workspace)).inserted
+        }
+    }
+
+    private func session(for workspace: EditorWorkspaceDriver) -> EditorSession? {
+        guard let sessionID = workspacesBySessionID.first(where: { $0.value === workspace })?.key else {
+            return nil
+        }
+        return sessionsByID[sessionID]
     }
 
     #if DEBUG

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -74,7 +74,7 @@ struct SettingsInspector: View {
     private var inspectorRail: some View {
         ZStack(alignment: .topLeading) {
             VStack(spacing: railButtonSpacing) {
-                ForEach(InspectorTab.allCases) { tab in
+                ForEach(InspectorTab.availableCases) { tab in
                     InspectorRailButton(
                         tab: tab,
                         isActive: activeTab == tab,
@@ -103,7 +103,7 @@ struct SettingsInspector: View {
     }
 
     private func railItemOffset(for tab: InspectorTab) -> CGFloat {
-        let index = InspectorTab.allCases.firstIndex(of: tab) ?? 0
+        let index = InspectorTab.availableCases.firstIndex(of: tab) ?? 0
         return railVerticalPadding + CGFloat(index) * (railButtonSize + railButtonSpacing)
     }
 
@@ -281,6 +281,10 @@ struct InspectorRailButton: View {
             .animation(.snappy(duration: 0.18), value: isActive)
         }
         .buttonStyle(.plain)
+        .help(tab.title)
+        .accessibilityLabel(tab.title)
+        .accessibilityValue(isActive ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
         .onHover { hovering in
             isHovering = hovering
             onHoverChanged(hovering)
@@ -336,6 +340,10 @@ enum InspectorTab: CaseIterable, Identifiable {
     case cursor
     case camera
     case audio
+
+    // Audio preview controls are not implemented yet. Keep the case for source
+    // and state compatibility, but do not advertise controls that cannot work.
+    static let availableCases: [InspectorTab] = [.appearance, .cursor, .camera]
 
     var id: String { title }
 
@@ -946,22 +954,15 @@ struct InspectorSwitch: View {
     var isInteractive = true
 
     var body: some View {
-        HStack {
+        Toggle(isOn: $isOn) {
             Text(title)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(Theme.fgMuted)
-            Spacer()
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .allowsHitTesting(isInteractive)
         }
+        .toggleStyle(.switch)
+        .disabled(!isInteractive)
         .frame(maxWidth: .infinity, alignment: .leading)
         .rectangularHitTarget()
-        .onTapGesture {
-            guard isInteractive else { return }
-            isOn.toggle()
-        }
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+enum LoadPhase: Equatable, Sendable {
+    case idle
+    case loading
+    case loaded
+    case failed(String)
+
+    var isLoading: Bool {
+        self == .loading
+    }
+}
+
 struct CaptureArea: Codable, Hashable {
     var x: Int
     var y: Int
@@ -19,7 +30,7 @@ enum RecordingPhase: String, Codable, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
-struct CaptureDeviceInfo: Identifiable, Codable, Hashable {
+struct CaptureDeviceInfo: Identifiable, Codable, Hashable, Sendable {
     var id: String
     var name: String
     var isDefault: Bool
@@ -97,19 +108,31 @@ struct CaptureSource: Identifiable, Codable, Hashable {
     var ownerName: String? = nil
 }
 
-struct AppPaths: Codable, Equatable {
+struct AppPaths: Codable, Equatable, Sendable {
     var recordingsDir: String
     var screenshotsDir: String
     var projectsDir: String
     var supportDir: String
 }
 
-struct PreparedFile: Codable {
+struct PreparedFile: Codable, Sendable {
     var path: String
 }
 
 struct ForgetProjectResult: Codable {
     var removed: Bool
+}
+
+enum ProjectAvailability: String, Codable, CaseIterable, Sendable {
+    case available
+    case missingProject
+    case missingMedia
+    case missingProjectAndMedia
+    case unavailable
+
+    var isAvailable: Bool {
+        self == .available
+    }
 }
 
 struct ProjectSummary: Codable, Identifiable, Hashable, Sendable {
@@ -123,6 +146,33 @@ struct ProjectSummary: Codable, Identifiable, Hashable, Sendable {
     var updatedAt: String
     var lastOpenedAt: String
     var missing: Bool
+    var availability: ProjectAvailability
+
+    init(
+        id: String,
+        title: String,
+        path: String,
+        recordingPath: String?,
+        screenshotPath: String? = nil,
+        sourceName: String?,
+        createdAt: String,
+        updatedAt: String,
+        lastOpenedAt: String,
+        missing: Bool,
+        availability: ProjectAvailability? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.path = path
+        self.recordingPath = recordingPath
+        self.screenshotPath = screenshotPath
+        self.sourceName = sourceName
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.lastOpenedAt = lastOpenedAt
+        self.missing = missing
+        self.availability = availability ?? (missing ? .unavailable : .available)
+    }
 
     var mediaKind: EditorMediaKind {
         screenshotPath == nil ? .video : .screenshot
@@ -130,6 +180,51 @@ struct ProjectSummary: Codable, Identifiable, Hashable, Sendable {
 
     var mediaPath: String? {
         screenshotPath ?? recordingPath
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case path
+        case recordingPath
+        case screenshotPath
+        case sourceName
+        case createdAt
+        case updatedAt
+        case lastOpenedAt
+        case missing
+        case availability
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        path = try container.decode(String.self, forKey: .path)
+        recordingPath = try container.decodeIfPresent(String.self, forKey: .recordingPath)
+        screenshotPath = try container.decodeIfPresent(String.self, forKey: .screenshotPath)
+        sourceName = try container.decodeIfPresent(String.self, forKey: .sourceName)
+        createdAt = try container.decode(String.self, forKey: .createdAt)
+        updatedAt = try container.decode(String.self, forKey: .updatedAt)
+        lastOpenedAt = try container.decode(String.self, forKey: .lastOpenedAt)
+        missing = try container.decodeIfPresent(Bool.self, forKey: .missing) ?? false
+        availability = try container.decodeIfPresent(ProjectAvailability.self, forKey: .availability)
+            ?? (missing ? .unavailable : .available)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(path, forKey: .path)
+        try container.encodeIfPresent(recordingPath, forKey: .recordingPath)
+        try container.encodeIfPresent(screenshotPath, forKey: .screenshotPath)
+        try container.encodeIfPresent(sourceName, forKey: .sourceName)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encode(lastOpenedAt, forKey: .lastOpenedAt)
+        try container.encode(missing, forKey: .missing)
+        try container.encode(availability, forKey: .availability)
     }
 }
 
@@ -263,7 +358,7 @@ struct ProjectVideoEditorState: Codable, Equatable, Hashable {
     }
 }
 
-enum EditorMediaKind: String, Codable, Hashable {
+enum EditorMediaKind: String, Codable, Hashable, Sendable {
     case video
     case screenshot
 
@@ -809,7 +904,7 @@ struct NativeWindowCommand: Identifiable {
     var editorSession: EditorSession?
 }
 
-struct HealthPayload: Codable {
+struct HealthPayload: Codable, Sendable {
     var service: String
     var version: String
     var platform: String

--- a/apps/macos/Sources/OpenRecorderMac/OnboardingView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OnboardingView.swift
@@ -23,7 +23,7 @@ struct OnboardingView: View {
                 .foregroundStyle(.white)
                 .padding(.bottom, 8)
 
-            Text("Before you can start recording, Open Recorder needs a couple of macOS permissions.")
+            Text("Screen Recording is required. Accessibility is an optional enhancement for shortcuts and cursor details.")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(Color.white.opacity(0.58))
                 .multilineTextAlignment(.center)
@@ -32,6 +32,7 @@ struct OnboardingView: View {
                 OnboardingPermissionRow(
                     title: "Screen Recording Permission",
                     description: "Open Recorder needs to capture video of your screen. You might need to restart the app after granting it.",
+                    requirement: .required,
                     buttonTitle: screenRecordingButtonTitle,
                     buttonState: screenRecordingButtonState
                 ) {
@@ -40,7 +41,8 @@ struct OnboardingView: View {
 
                 OnboardingPermissionRow(
                     title: "Accessibility Permission",
-                    description: "Open Recorder uses Accessibility to capture cursor movement and shortcut keystrokes while you are recording.",
+                    description: "Optional: lets Open Recorder capture shortcut keystrokes and additional cursor details while recording.",
+                    requirement: .optional,
                     buttonTitle: accessibilityButtonTitle,
                     buttonState: accessibilityButtonState
                 ) {
@@ -166,9 +168,22 @@ private enum OnboardingPermissionButtonState {
     case enabled
 }
 
+private enum OnboardingPermissionRequirement {
+    case required
+    case optional
+
+    var title: String {
+        switch self {
+        case .required: "Required"
+        case .optional: "Optional"
+        }
+    }
+}
+
 private struct OnboardingPermissionRow: View {
     var title: String
     var description: String
+    var requirement: OnboardingPermissionRequirement
     var buttonTitle: String
     var buttonState: OnboardingPermissionButtonState
     var action: () -> Void
@@ -176,9 +191,17 @@ private struct OnboardingPermissionRow: View {
     var body: some View {
         HStack(alignment: .top, spacing: 34) {
             VStack(alignment: .leading, spacing: 5) {
-                Text(title)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color.white.opacity(0.90))
+                HStack(spacing: 7) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.white.opacity(0.90))
+                    Text(requirement.title)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Theme.overlay, in: Capsule())
+                }
 
                 Text(description)
                     .font(.system(size: 12, weight: .regular))
@@ -188,27 +211,44 @@ private struct OnboardingPermissionRow: View {
             }
             .frame(width: 240, alignment: .leading)
 
-            StudioButton(hitTarget: .rounded(6), action: action) {
-                HStack(spacing: 9) {
-                    if buttonState == .enabled {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 15, weight: .semibold))
-                    }
-                    Text(buttonTitle)
-                        .font(.system(size: 13, weight: .semibold))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.82)
-                }
-                .frame(width: 242, height: 36)
-                .foregroundStyle(foregroundColor)
-                .background(backgroundColor, in: RoundedRectangle(cornerRadius: 5))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 5)
-                        .stroke(borderColor, lineWidth: 1)
+            if buttonState == .enabled {
+                permissionStatusLabel
+            } else {
+                StudioButton(hitTarget: .rounded(6), action: action) {
+                    permissionActionLabel
                 }
             }
         }
         .frame(width: 516, alignment: .leading)
+    }
+
+    private var permissionActionLabel: some View {
+        Text(buttonTitle)
+            .font(.system(size: 13, weight: .semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.82)
+            .frame(width: 242, height: 36)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundColor, in: RoundedRectangle(cornerRadius: 5))
+            .overlay {
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(borderColor, lineWidth: 1)
+            }
+    }
+
+    private var permissionStatusLabel: some View {
+        Label(buttonTitle, systemImage: "checkmark")
+            .font(.system(size: 13, weight: .semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.82)
+            .frame(width: 242, height: 36)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundColor, in: RoundedRectangle(cornerRadius: 5))
+            .overlay {
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(borderColor, lineWidth: 1)
+            }
+            .accessibilityLabel("\(buttonTitle), \(requirement.title)")
     }
 
     private var foregroundColor: Color {

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -11,6 +11,7 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
     private let statusItemController = OpenRecorderStatusItemController()
     private let hotKeyController = GlobalRecordingHotKeyController()
     private let updateChecker = UpdateChecker.shared
+    private var terminationTask: Task<Void, Never>?
 
     func attach(model: AppModel) {
         if self.model !== model {
@@ -41,6 +42,21 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
         pendingFileURLs.append(contentsOf: filenames.map { URL(fileURLWithPath: $0) })
         flushPendingFileURLs()
         sender.reply(toOpenOrPrint: .success)
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard let model else { return .terminateNow }
+        guard terminationTask == nil else { return .terminateLater }
+
+        terminationTask = Task { [weak self, weak model] in
+            let canTerminate = await model?.prepareForTermination() ?? true
+            self?.terminationTask = nil
+            if !canTerminate {
+                sender.activate(ignoringOtherApps: true)
+            }
+            sender.reply(toApplicationShouldTerminate: canTerminate)
+        }
+        return .terminateLater
     }
 
     private func flushPendingFileURLs() {

--- a/apps/macos/Sources/OpenRecorderMac/ProjectLibraryViewState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectLibraryViewState.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+enum ProjectLibrarySortField: String, CaseIterable, Identifiable, Sendable {
+    case title
+    case source
+    case lastOpened
+    case path
+
+    var id: String { rawValue }
+}
+
+struct ProjectLibraryComparator: SortComparator, Equatable, Sendable {
+    typealias Compared = ProjectSummary
+
+    var field: ProjectLibrarySortField
+    var order: SortOrder = .forward
+
+    func compare(_ lhs: ProjectSummary, _ rhs: ProjectSummary) -> ComparisonResult {
+        if field == .lastOpened {
+            return compareDates(lhs.lastOpenedAt, rhs.lastOpenedAt)
+        }
+
+        let result: ComparisonResult
+
+        switch field {
+        case .title:
+            result = compareText(lhs.title, rhs.title)
+        case .source:
+            result = compareText(projectSourceDisplayName(lhs), projectSourceDisplayName(rhs))
+        case .lastOpened:
+            result = .orderedSame
+        case .path:
+            result = compareText(lhs.path, rhs.path)
+        }
+
+        guard order == .reverse else { return result }
+        switch result {
+        case .orderedAscending:
+            return .orderedDescending
+        case .orderedDescending:
+            return .orderedAscending
+        case .orderedSame:
+            return .orderedSame
+        }
+    }
+
+    private func compareText(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        lhs.localizedCaseInsensitiveCompare(rhs)
+    }
+
+    private func compareDates(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        switch (projectDate(lhs), projectDate(rhs)) {
+        case let (left?, right?):
+            let result: ComparisonResult
+            if left < right {
+                result = .orderedAscending
+            } else if left > right {
+                result = .orderedDescending
+            } else {
+                result = .orderedSame
+            }
+            guard order == .reverse else { return result }
+            if result == .orderedAscending { return .orderedDescending }
+            if result == .orderedDescending { return .orderedAscending }
+            return .orderedSame
+        case (nil, nil):
+            return .orderedSame
+        case (nil, _?):
+            return .orderedDescending
+        case (_?, nil):
+            return .orderedAscending
+        }
+    }
+}
+
+enum ProjectLibraryQuery {
+    static func projects(
+        from projects: [ProjectSummary],
+        tab: ProjectLibraryTab,
+        searchText: String,
+        sortOrder: [ProjectLibraryComparator]
+    ) -> [ProjectSummary] {
+        let terms = normalizedTerms(searchText)
+        let filtered = projects.filter { project in
+            guard project.mediaKind == tab.mediaKind else { return false }
+            guard !terms.isEmpty else { return true }
+
+            let haystack = normalizedText([
+                project.title,
+                projectSourceDisplayName(project),
+                project.path,
+                project.mediaPath ?? "",
+            ].joined(separator: " "))
+            return terms.allSatisfy(haystack.contains)
+        }
+
+        let comparators = sortOrder.isEmpty
+            ? [ProjectLibraryComparator(field: .lastOpened, order: .reverse)]
+            : sortOrder
+        return filtered.sorted(using: comparators)
+    }
+
+    private static func normalizedTerms(_ query: String) -> [String] {
+        normalizedText(query)
+            .split(whereSeparator: \Character.isWhitespace)
+            .map(String.init)
+    }
+
+    private static func normalizedText(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .lowercased(with: Locale(identifier: "en_US_POSIX"))
+    }
+}
+
+enum SettingsServicePresentationState: Equatable, Sendable {
+    case notChecked
+    case checking(previousValue: String?)
+    case available(String)
+    case unavailable(String?)
+
+    var value: String {
+        switch self {
+        case .notChecked:
+            return "Not checked"
+        case .checking(let previousValue):
+            return previousValue ?? "Checking…"
+        case .available(let value):
+            return value
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+
+    var detail: String? {
+        switch self {
+        case .notChecked:
+            return "Check the local service when you need to diagnose a connection problem."
+        case .checking:
+            return "Checking the local service…"
+        case .available:
+            return nil
+        case .unavailable(let message):
+            return message
+        }
+    }
+
+    var isChecking: Bool {
+        if case .checking = self { return true }
+        return false
+    }
+}
+
+func settingsServicePresentationState(
+    health: HealthPayload?,
+    isRefreshing: Bool,
+    statusMessage: String
+) -> SettingsServicePresentationState {
+    let availableValue = health.map { "\($0.service) \($0.version)" }
+    if isRefreshing {
+        return .checking(previousValue: availableValue)
+    }
+
+    let trimmedMessage = statusMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let availableValue, trimmedMessage.isEmpty || trimmedMessage == "Rust service ready" {
+        return .available(availableValue)
+    }
+    if trimmedMessage.isEmpty {
+        return .notChecked
+    }
+    return .unavailable(trimmedMessage)
+}
+
+func projectDate(_ value: String) -> Date? {
+    if let seconds = TimeInterval(value), seconds.isFinite {
+        return Date(timeIntervalSince1970: seconds)
+    }
+    return ISO8601DateFormatter().date(from: value)
+}
+
+func projectSourceDisplayName(_ project: ProjectSummary) -> String {
+    if let sourceName = project.sourceName?.trimmingCharacters(in: .whitespacesAndNewlines), !sourceName.isEmpty {
+        return sourceName
+    }
+    return URL(fileURLWithPath: project.mediaPath ?? project.path).lastPathComponent
+}
+
+extension ProjectSummary {
+    var isOpenableFromLibrary: Bool {
+        !missing && availability.isAvailable
+    }
+
+    var libraryAvailabilityLabel: String? {
+        switch availability {
+        case .available:
+            return missing ? "Unavailable" : nil
+        case .missingProject:
+            return "Project missing"
+        case .missingMedia:
+            return "Media missing"
+        case .missingProjectAndMedia:
+            return "Project and media missing"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ProjectsViews.swift
@@ -8,6 +8,9 @@ struct ProjectsStudioView: View {
     @EnvironmentObject private var model: AppModel
     @State private var selectedTab: ProjectLibraryTab = .screenRecordings
     @State private var projectPendingDeletion: ProjectSummary?
+    @State private var selectedProjectID: ProjectSummary.ID?
+    @State private var searchText = ""
+    @State private var sortOrder = [ProjectLibraryComparator(field: .lastOpened, order: .reverse)]
 
     var body: some View {
         ScrollView {
@@ -31,15 +34,23 @@ struct ProjectsStudioView: View {
 
                     Spacer()
 
-                    StudioButton(hitTarget: .rounded(7)) {
-                        model.refreshBackendState()
-                    } label: {
-                        Label("Refresh", systemImage: "arrow.clockwise")
-                            .font(.system(size: 12, weight: .semibold))
-                            .frame(height: 32)
-                            .padding(.horizontal, 12)
-                            .background(Theme.accent, in: RoundedRectangle(cornerRadius: 7))
-                            .foregroundStyle(.white)
+                    HStack(spacing: 8) {
+                        if isRefreshing {
+                            ProgressView()
+                                .controlSize(.small)
+                                .accessibilityLabel("Refreshing projects")
+                        }
+
+                        Button {
+                            model.refreshBackendState()
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                        .disabled(isRefreshing)
+                        .help(isRefreshing ? "Refreshing projects" : "Refresh projects")
                     }
                 }
 
@@ -105,29 +116,37 @@ struct ProjectsStudioView: View {
                         Text(selectedTab.listTitle)
                             .font(.system(size: 13, weight: .medium))
                             .foregroundStyle(.secondary)
+                        if !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            Text("\(selectedProjects.count) found")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.tertiary)
+                        }
                         Spacer()
                     }
 
-                    if selectedProjects.isEmpty {
+                    if let backendFailureMessage, !model.projects.isEmpty {
+                        ProjectLibraryFailureBanner(message: backendFailureMessage) {
+                            model.refreshBackendState()
+                        }
+                    }
+
+                    if isInitialLoadPending {
+                        ProjectLibraryIdlePanel {
+                            model.refreshBackendState()
+                        }
+                    } else if isLoadingWithoutProjects {
+                        ProjectLibraryLoadingPanel()
+                    } else if selectedProjects.isEmpty, isFailedWithoutProjects {
+                        ProjectLibraryFailurePanel(message: backendFailureMessage ?? "The project library could not be loaded.") {
+                            model.refreshBackendState()
+                        }
+                    } else if selectedProjects.isEmpty, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        ContentUnavailableView.search(text: searchText)
+                            .frame(maxWidth: .infinity, minHeight: 240)
+                    } else if selectedProjects.isEmpty {
                         EmptyProjectsPanel(tab: selectedTab)
                     } else {
-                        VStack(spacing: 0) {
-                            ForEach(selectedProjects) { project in
-                                ProjectListRow(project: project) { project in
-                                    projectPendingDeletion = project
-                                }
-                                if project.id != selectedProjects.last?.id {
-                                    Rectangle()
-                                        .fill(Theme.border)
-                                        .frame(height: 1)
-                                }
-                            }
-                        }
-                        .background(Theme.surface.opacity(0.78), in: RoundedRectangle(cornerRadius: 10))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Theme.border)
-                        }
+                        projectTable
                     }
                 }
             }
@@ -136,6 +155,16 @@ struct ProjectsStudioView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Theme.appBgMuted)
+        .searchable(text: $searchText, prompt: "Search projects")
+        .onChange(of: selectedTab) {
+            selectedProjectID = nil
+        }
+        .onChange(of: searchText) {
+            if let selectedProjectID,
+               !selectedProjects.contains(where: { $0.id == selectedProjectID }) {
+                self.selectedProjectID = nil
+            }
+        }
         .confirmationDialog(
             "Delete Project?",
             isPresented: deleteConfirmationPresented,
@@ -164,12 +193,128 @@ struct ProjectsStudioView: View {
     }
 
     private var selectedProjects: [ProjectSummary] {
-        switch selectedTab {
-        case .screenRecordings:
-            recordingProjects
-        case .screenshots:
-            screenshotProjects
+        ProjectLibraryQuery.projects(
+            from: model.projects,
+            tab: selectedTab,
+            searchText: searchText,
+            sortOrder: sortOrder
+        )
+    }
+
+    @ViewBuilder
+    private var projectTable: some View {
+        Table(selectedProjects, selection: $selectedProjectID, sortOrder: $sortOrder) {
+            TableColumn("Project", sortUsing: ProjectLibraryComparator(field: .title)) { project in
+                HStack(spacing: 8) {
+                    Image(systemName: project.mediaKind.titleIconSystemName)
+                        .foregroundStyle(Theme.accent)
+                        .accessibilityHidden(true)
+                    Text(project.title)
+                        .lineLimit(1)
+                    if let availabilityLabel = project.libraryAvailabilityLabel {
+                        Text(availabilityLabel)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.red)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+            }
+            .width(min: 180, ideal: 260)
+
+            TableColumn("Source", sortUsing: ProjectLibraryComparator(field: .source)) { project in
+                Text(projectSourceDisplayName(project))
+                    .lineLimit(1)
+            }
+            .width(min: 140, ideal: 220)
+
+            TableColumn("Last opened", sortUsing: ProjectLibraryComparator(field: .lastOpened)) { project in
+                Text(formattedProjectDate(project.lastOpenedAt))
+                    .lineLimit(1)
+            }
+            .width(min: 130, ideal: 160)
+
+            TableColumn("Project file", sortUsing: ProjectLibraryComparator(field: .path)) { project in
+                Text(project.path)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 170, ideal: 260)
         }
+        .frame(height: min(max(CGFloat(selectedProjects.count * 34 + 44), 240), 480))
+        .contextMenu(forSelectionType: ProjectSummary.ID.self) { selection in
+            if let project = onlyProject(in: selection) {
+                Button {
+                    open(project)
+                } label: {
+                    Label("Open", systemImage: "folder")
+                }
+                .disabled(!project.isOpenableFromLibrary)
+
+                Divider()
+
+                Button(role: .destructive) {
+                    projectPendingDeletion = project
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        } primaryAction: { selection in
+            guard let project = onlyProject(in: selection) else { return }
+            open(project)
+        }
+        .onKeyPress(.return) {
+            guard let project = selectedProject, project.isOpenableFromLibrary else { return .ignored }
+            open(project)
+            return .handled
+        }
+        .onDeleteCommand {
+            guard let project = selectedProject else { return }
+            projectPendingDeletion = project
+        }
+    }
+
+    private func onlyProject(in selection: Set<ProjectSummary.ID>) -> ProjectSummary? {
+        guard selection.count == 1, let id = selection.first else { return nil }
+        return model.projects.first { $0.id == id }
+    }
+
+    private var selectedProject: ProjectSummary? {
+        guard let selectedProjectID else { return nil }
+        return model.projects.first { $0.id == selectedProjectID }
+    }
+
+    private func open(_ project: ProjectSummary) {
+        guard project.isOpenableFromLibrary else { return }
+        model.openProject(project)
+    }
+
+    private var isRefreshing: Bool {
+        if case .loading = model.backendLoadPhase { return true }
+        return false
+    }
+
+    private var isInitialLoadPending: Bool {
+        guard model.projects.isEmpty else { return false }
+        if case .idle = model.backendLoadPhase { return true }
+        return false
+    }
+
+    private var isLoadingWithoutProjects: Bool {
+        isRefreshing && model.projects.isEmpty
+    }
+
+    private var isFailedWithoutProjects: Bool {
+        guard model.projects.isEmpty else { return false }
+        if case .failed = model.backendLoadPhase { return true }
+        return false
+    }
+
+    private var backendFailureMessage: String? {
+        if case .failed(let message) = model.backendLoadPhase {
+            return message
+        }
+        return nil
     }
 
     private var deleteConfirmationPresented: Binding<Bool> {
@@ -210,6 +355,13 @@ enum ProjectLibraryTab: String, CaseIterable, Identifiable {
         case .screenshots: "Recent screenshots"
         }
     }
+
+    var mediaKind: EditorMediaKind {
+        switch self {
+        case .screenRecordings: .video
+        case .screenshots: .screenshot
+        }
+    }
 }
 
 struct ProjectLibraryTabBar: View {
@@ -218,38 +370,16 @@ struct ProjectLibraryTabBar: View {
     var screenshotCount: Int
 
     var body: some View {
-        HStack(spacing: 4) {
+        Picker("Project type", selection: $selection) {
             ForEach(ProjectLibraryTab.allCases) { tab in
-                StudioButton(hitTarget: .rounded(8), help: tab.title) {
-                    selection = tab
-                } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: tab.symbolName)
-                            .font(.system(size: 13, weight: .semibold))
-                        Text(tab.title)
-                            .font(.system(size: 12, weight: .semibold))
-                            .lineLimit(1)
-                        Text("\(count(for: tab))")
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(selection == tab ? Color.white.opacity(0.75) : Color.secondary)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Color.white.opacity(selection == tab ? 0.16 : 0.06), in: Capsule())
-                    }
-                    .frame(height: 34)
-                    .padding(.horizontal, 12)
-                    .foregroundStyle(selection == tab ? Color.white : Color.secondary)
-                    .background(selection == tab ? Theme.accent : Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
-                }
+                Label("\(tab.title) (\(count(for: tab)))", systemImage: tab.symbolName)
+                    .tag(tab)
             }
-            Spacer()
         }
-        .padding(4)
-        .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 10))
-        .overlay {
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Theme.border.opacity(0.9))
-        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 480, alignment: .leading)
+        .accessibilityLabel("Project type")
     }
 
     private func count(for tab: ProjectLibraryTab) -> Int {
@@ -312,7 +442,7 @@ struct ProjectListRow: View {
 
     var body: some View {
         StudioButton(hitTarget: .rectangle) {
-            if !project.missing {
+            if project.isOpenableFromLibrary {
                 model.openProject(project)
             }
         } label: {
@@ -332,8 +462,8 @@ struct ProjectListRow: View {
                         Text(project.title)
                             .font(.system(size: 14, weight: .medium))
                             .lineLimit(1)
-                        if project.missing {
-                            Text("Missing")
+                        if let availabilityLabel = project.libraryAvailabilityLabel {
+                            Text(availabilityLabel)
                                 .font(.system(size: 10, weight: .semibold))
                                 .foregroundStyle(.red)
                                 .padding(.horizontal, 6)
@@ -371,7 +501,7 @@ struct ProjectListRow: View {
             } label: {
                 Label("Open", systemImage: "folder")
             }
-            .disabled(project.missing)
+            .disabled(!project.isOpenableFromLibrary)
 
             Button(role: .destructive) {
                 requestDelete(project)
@@ -379,7 +509,7 @@ struct ProjectListRow: View {
                 Label("Delete", systemImage: "trash")
             }
         }
-        .opacity(project.missing ? 0.55 : 1)
+        .opacity(project.isOpenableFromLibrary ? 1 : 0.55)
     }
 }
 
@@ -387,17 +517,13 @@ struct EmptyProjectsPanel: View {
     var tab: ProjectLibraryTab
 
     var body: some View {
-        VStack(spacing: 12) {
-            Image(systemName: tab.symbolName)
-                .font(.system(size: 30))
-                .frame(width: 64, height: 64)
-                .foregroundStyle(Theme.accent)
-                .background(Theme.accent.opacity(0.10), in: RoundedRectangle(cornerRadius: 16))
-            Text(tab == .screenRecordings ? "No recent recordings yet" : "No recent screenshots yet")
-                .font(.system(size: 16, weight: .semibold))
+        ContentUnavailableView {
+            Label(
+                tab == .screenRecordings ? "No recent recordings yet" : "No recent screenshots yet",
+                systemImage: tab.symbolName
+            )
+        } description: {
             Text(tab == .screenRecordings ? "Screen recording projects will appear here after you save or open one." : "Screenshot projects will appear here after you capture or open one.")
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, minHeight: 240)
         .background(Theme.surface.opacity(0.60), in: RoundedRectangle(cornerRadius: 10))
@@ -408,15 +534,77 @@ struct EmptyProjectsPanel: View {
     }
 }
 
+private struct ProjectLibraryLoadingPanel: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.regular)
+            Text("Loading projects…")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct ProjectLibraryIdlePanel: View {
+    var load: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Projects not loaded", systemImage: "rectangle.stack")
+        } description: {
+            Text("Load projects saved on this Mac.")
+        } actions: {
+            Button("Load Projects", action: load)
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+    }
+}
+
+private struct ProjectLibraryFailurePanel: View {
+    var message: String
+    var retry: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Projects unavailable", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Try Again", action: retry)
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+    }
+}
+
+private struct ProjectLibraryFailureBanner: View {
+    var message: String
+    var retry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Label(message, systemImage: "exclamationmark.triangle")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Spacer()
+            Button("Try Again", action: retry)
+                .controlSize(.small)
+                .disabled(false)
+        }
+        .padding(10)
+        .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+    }
+}
+
 
 func formattedProjectDate(_ value: String) -> String {
-    let date: Date
-    if let seconds = TimeInterval(value) {
-        date = Date(timeIntervalSince1970: seconds)
-    } else {
-        let formatter = ISO8601DateFormatter()
-        date = formatter.date(from: value) ?? Date()
-    }
+    guard let date = projectDate(value) else { return "Unknown" }
 
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
@@ -48,6 +48,12 @@ struct ScreenshotEditorStudioView: View {
                 },
                 onExport: {
                     editor.send(.exportRequested)
+                },
+                onSave: {
+                    editor.saveComposedPNG(image: image, suggestedFileName: suggestedExportFileName)
+                },
+                onCopy: {
+                    editor.copyComposedPNG(image: image)
                 }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -150,6 +156,7 @@ struct ScreenshotExportDialog: View {
     @Environment(\.dismiss) private var dismiss
     var onSave: () -> Void
     var onCopy: () -> Void
+    @State private var pendingChoice: ScreenshotExportChoice?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -162,11 +169,10 @@ struct ScreenshotExportDialog: View {
                     symbolName: "square.and.arrow.down",
                     isPrimary: true
                 ) {
+                    pendingChoice = .save
                     dismiss()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                        onSave()
-                    }
                 }
+                .keyboardShortcut(.defaultAction)
 
                 ScreenshotExportActionCard(
                     title: "Copy",
@@ -174,12 +180,13 @@ struct ScreenshotExportDialog: View {
                     symbolName: "doc.on.doc",
                     isPrimary: false
                 ) {
-                    onCopy()
+                    pendingChoice = .copy
                     dismiss()
                 }
+                .keyboardShortcut("c", modifiers: .command)
             }
 
-            StudioButton(hitTarget: .rectangle) {
+            Button(role: .cancel) {
                 dismiss()
             } label: {
                 Text("Cancel")
@@ -188,6 +195,8 @@ struct ScreenshotExportDialog: View {
                     .frame(maxWidth: .infinity)
                     .frame(height: 28)
             }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
         }
         .padding(22)
         .background {
@@ -202,6 +211,20 @@ struct ScreenshotExportDialog: View {
                     endPoint: .bottom
                 )
             }
+        }
+        .onDisappear(perform: performPendingChoice)
+    }
+
+    private func performPendingChoice() {
+        let choice = pendingChoice
+        pendingChoice = nil
+        switch choice {
+        case .save:
+            onSave()
+        case .copy:
+            onCopy()
+        case nil:
+            break
         }
     }
 
@@ -224,6 +247,11 @@ struct ScreenshotExportDialog: View {
             Spacer(minLength: 0)
         }
     }
+}
+
+enum ScreenshotExportChoice: Equatable {
+    case save
+    case copy
 }
 
 private struct ScreenshotExportActionCard: View {
@@ -386,6 +414,8 @@ struct ScreenshotSettingsPanel: View {
     var onEditingChanged: (Bool) -> Void = { _ in }
     var onRevealFile: () -> Void = {}
     var onExport: () -> Void
+    var onSave: (() -> Void)? = nil
+    var onCopy: (() -> Void)? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -414,8 +444,12 @@ struct ScreenshotSettingsPanel: View {
                 InspectorFooterButton(title: "Reveal File", symbolName: "folder") {
                     onRevealFile()
                 }
-                InspectorFooterButton(title: "Export", symbolName: "square.and.arrow.up") {
-                    onExport()
+                if let onSave, let onCopy {
+                    ScreenshotExportMenu(onSave: onSave, onCopy: onCopy)
+                } else {
+                    InspectorFooterButton(title: "Export", symbolName: "square.and.arrow.up") {
+                        onExport()
+                    }
                 }
             }
             .padding(12)
@@ -451,6 +485,40 @@ struct ScreenshotSettingsPanel: View {
         }
     }
 
+}
+
+private struct ScreenshotExportMenu: View {
+    var onSave: () -> Void
+    var onCopy: () -> Void
+
+    var body: some View {
+        Menu {
+            Button(action: onSave) {
+                Label("Save PNG…", systemImage: "square.and.arrow.down")
+            }
+            .keyboardShortcut("s", modifiers: [.command, .shift])
+
+            Button(action: onCopy) {
+                Label("Copy PNG", systemImage: "doc.on.doc")
+            }
+            .keyboardShortcut("c", modifiers: [.command, .shift])
+        } label: {
+            Label("Export", systemImage: "square.and.arrow.up")
+                .font(.system(size: 10, weight: .medium))
+                .frame(maxWidth: .infinity)
+                .frame(height: 30)
+                .foregroundStyle(Theme.fgMuted)
+                .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(Theme.borderSubtle, lineWidth: 1)
+                }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .accessibilityLabel("Export screenshot")
+        .help("Export screenshot")
+    }
 }
 
 struct Checkerboard: View {

--- a/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
@@ -8,6 +8,7 @@ struct SettingsStudioView: View {
     var driver: SettingsDriver
     var serviceHealth: HealthPayload?
     var paths: AppPaths?
+    var serviceState: SettingsServicePresentationState? = nil
 
     var body: some View {
         ScrollView {
@@ -16,17 +17,16 @@ struct SettingsStudioView: View {
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(Theme.fg)
                 SettingsSection(title: "Service") {
-                    SettingsRow(title: "Status", value: serviceHealth.map { "\($0.service) \($0.version)" } ?? "Unavailable")
+                    SettingsServiceStatusRow(state: resolvedServiceState)
                     SettingsRow(title: "Platform", value: serviceHealth?.platform ?? "macOS")
-                    StudioButton(hitTarget: .rounded(8)) {
+                    Button {
                         driver.send(.serviceRefreshRequested)
                     } label: {
-                        Label("Check Service", systemImage: "bolt.horizontal")
-                            .frame(height: 34)
-                            .padding(.horizontal, 12)
-                            .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
-                            .foregroundStyle(Theme.fg)
+                        Label(resolvedServiceState.isChecking ? "Checking Service…" : "Check Service", systemImage: "bolt.horizontal")
                     }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                    .disabled(resolvedServiceState.isChecking)
                 }
 
                 SettingsSection(title: "Folders") {
@@ -48,37 +48,28 @@ struct SettingsStudioView: View {
 
                 SettingsSection(title: "Permissions") {
                     VStack(alignment: .leading, spacing: 10) {
-                        HStack(spacing: 10) {
-                            StudioButton(hitTarget: .rounded(8)) {
+                        ControlGroup {
+                            Button {
                                 driver.send(.screenRecordingSettingsRequested)
                             } label: {
                                 Label("Screen Recording", systemImage: "lock.shield")
-                                    .frame(height: 34)
-                                    .padding(.horizontal, 12)
-                                    .background(Theme.accent, in: RoundedRectangle(cornerRadius: 8))
-                                    .foregroundStyle(.white)
                             }
 
-                            StudioButton(hitTarget: .rounded(8)) {
+                            Button {
                                 driver.send(.accessibilitySettingsRequested)
                             } label: {
                                 Label("Accessibility", systemImage: "accessibility")
-                                    .frame(height: 34)
-                                    .padding(.horizontal, 12)
-                                    .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
-                                    .foregroundStyle(Color.white.opacity(0.86))
                             }
                         }
+                        .controlSize(.regular)
 
-                        StudioButton(hitTarget: .rounded(8)) {
+                        Button {
                             driver.send(.onboardingReviewRequested)
                         } label: {
                             Label("Review Permissions", systemImage: "checklist")
-                                .frame(height: 34)
-                                .padding(.horizontal, 12)
-                                .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
-                                .foregroundStyle(Color.white.opacity(0.86))
                         }
+                        .buttonStyle(.bordered)
+                        .controlSize(.regular)
                     }
                 }
             }
@@ -89,48 +80,29 @@ struct SettingsStudioView: View {
         .background(Theme.appBgMuted)
         .foregroundStyle(Theme.fg)
     }
+
+    private var resolvedServiceState: SettingsServicePresentationState {
+        serviceState ?? settingsServicePresentationState(
+            health: serviceHealth,
+            isRefreshing: driver.state.isRefreshingService,
+            statusMessage: driver.state.statusMessage
+        )
+    }
 }
 
 private struct SettingsZoomPresetPicker: View {
     @Binding var selection: TimelineZoomAnimationPreset
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Auto zoom style")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(Theme.fg)
-                Spacer()
-                Text(selection.title)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-            }
-
-            HStack(spacing: 6) {
-                ForEach(TimelineZoomAnimationPreset.allCases) { preset in
-                    let isSelected = selection == preset
-                    StudioButton(hitTarget: .rounded(7)) {
-                        selection = preset
-                    } label: {
-                        Text(preset.shortTitle)
-                            .font(.system(size: 10, weight: .semibold))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 30)
-                            .foregroundStyle(isSelected ? Color.primary : Color.secondary)
-                            .background(isSelected ? Theme.accent.opacity(0.18) : Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 7)
-                                    .stroke(isSelected ? Theme.accent.opacity(0.42) : Theme.overlay, lineWidth: isSelected ? 1.5 : 1)
-                            }
-                    }
-                    .help(preset.title)
-                    .accessibilityLabel("Set auto zoom style to \(preset.title)")
-                    .accessibilityAddTraits(isSelected ? .isSelected : [])
+        Picker("Auto zoom style", selection: $selection) {
+            ForEach(TimelineZoomAnimationPreset.allCases) { preset in
+                Text(preset.title)
+                    .tag(preset)
                 }
-            }
         }
+        .pickerStyle(.menu)
+        .foregroundStyle(Theme.fgMuted)
+        .accessibilityHint("Controls the timing and motion used for automatically created zooms")
         .padding(10)
         .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
         .overlay {
@@ -165,16 +137,49 @@ struct SettingsRow: View {
     var value: String
 
     var body: some View {
-        HStack {
-            Text(title)
-                .foregroundStyle(Theme.fgMuted)
-            Spacer()
+        LabeledContent {
             Text(value)
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .foregroundStyle(Theme.fg)
+        } label: {
+            Text(title)
+                .foregroundStyle(Theme.fgMuted)
         }
         .font(.system(size: 13))
+    }
+}
+
+private struct SettingsServiceStatusRow: View {
+    var state: SettingsServicePresentationState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            LabeledContent {
+                HStack(spacing: 7) {
+                    if state.isChecking {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityHidden(true)
+                    }
+                    Text(state.value)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundStyle(Theme.fg)
+                }
+            } label: {
+                Text("Status")
+                    .foregroundStyle(Theme.fgMuted)
+            }
+            if let detail = state.detail {
+                Text(detail)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .font(.system(size: 13))
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -184,24 +189,26 @@ struct FolderRow: View {
     var onOpen: (String) -> Void = { _ in }
 
     var body: some View {
-        HStack {
-            Text(title)
-                .foregroundStyle(Theme.fgMuted)
-            Spacer()
-            Text(path ?? "Unknown")
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .foregroundStyle(Theme.fg)
-            if let path {
-                StudioButton(hitTarget: .rounded(7)) {
+        LabeledContent {
+            HStack(spacing: 8) {
+                Text(path ?? "Not available")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(path == nil ? Color.secondary : Theme.fg)
+                Button {
+                    guard let path else { return }
                     onOpen(path)
                 } label: {
-                    Image(systemName: "folder")
-                        .frame(width: 28, height: 28)
-                        .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
-                        .foregroundStyle(Theme.fgMuted)
+                    Label("Open \(title) Folder", systemImage: "folder")
+                        .labelStyle(.iconOnly)
                 }
+                .buttonStyle(.borderless)
+                .disabled(path == nil)
+                .help(path == nil ? "Folder path is unavailable" : "Open \(title) folder")
             }
+        } label: {
+            Text(title)
+                .foregroundStyle(Theme.fgMuted)
         }
         .font(.system(size: 13))
     }
@@ -212,15 +219,10 @@ struct SettingsToggleRow: View {
     @Binding var isOn: Bool
 
     var body: some View {
-        HStack {
-            Text(title)
-                .foregroundStyle(Theme.fgMuted)
-            Spacer()
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .tint(Theme.accent)
-        }
-        .font(.system(size: 13))
+        Toggle(title, isOn: $isOn)
+            .toggleStyle(.switch)
+            .tint(Theme.accent)
+            .foregroundStyle(Theme.fgMuted)
+            .font(.system(size: 13))
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -238,44 +238,84 @@ struct ResizableStudioSplitPane<Primary: View, Secondary: View>: View {
     }
 
     var body: some View {
-        GeometryReader { proxy in
-            let resolvedSecondarySize = clampedSecondarySize(secondarySize, totalSize: proxy.size.width)
-            let resolvedPrimarySize = max(0, proxy.size.width - resolvedSecondarySize - spacing)
+        HSplitView {
+            primary
+                .frame(minWidth: minPrimarySize, maxWidth: .infinity, maxHeight: .infinity)
 
-            HStack(spacing: 0) {
-                primary
-                    .frame(width: resolvedPrimarySize, height: proxy.size.height)
-                    .clipped()
-
-                SidebarResizeHandle()
-                    .frame(width: spacing, height: proxy.size.height)
-                    .gesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { value in
-                                secondarySize = clampedSecondarySize(
-                                    resolvedSecondarySize - value.translation.width,
-                                    totalSize: proxy.size.width
-                                )
-                            }
-                    )
-
-                secondary
-                    .frame(width: resolvedSecondarySize, height: proxy.size.height)
-                    .zIndex(1)
+            secondary
+                .frame(
+                    minWidth: minSecondarySize,
+                    idealWidth: StudioSplitPaneSizing.normalizedSecondarySize(
+                        secondarySize,
+                        minimum: minSecondarySize,
+                        maximum: maxSecondarySize
+                    ),
+                    maxWidth: maxSecondarySize,
+                    maxHeight: .infinity
+                )
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: StudioSecondaryPaneWidthPreferenceKey.self,
+                            value: proxy.size.width
+                        )
+                    }
+                }
+        }
+        .accessibilityElement(children: .contain)
+        .onAppear(perform: normalizeStoredSecondarySize)
+        .onPreferenceChange(StudioSecondaryPaneWidthPreferenceKey.self) { measuredWidth in
+            let normalized = StudioSplitPaneSizing.normalizedSecondarySize(
+                measuredWidth,
+                minimum: minSecondarySize,
+                maximum: maxSecondarySize
+            )
+            if abs(secondarySize - normalized) > 0.5 {
+                secondarySize = normalized
             }
         }
         .onChange(of: secondarySize) { _, newValue in
-            secondarySize = min(max(newValue, minSecondarySize), maxSecondarySize)
+            let normalized = StudioSplitPaneSizing.normalizedSecondarySize(
+                newValue,
+                minimum: minSecondarySize,
+                maximum: maxSecondarySize
+            )
+            if secondarySize != normalized {
+                secondarySize = normalized
+            }
         }
     }
 
-    private func clampedSecondarySize(_ requestedSize: CGFloat, totalSize: CGFloat) -> CGFloat {
-        let maxAllowedByPrimary = max(0, totalSize - minPrimarySize - spacing)
-        let upperBound = min(maxSecondarySize, maxAllowedByPrimary)
-        guard upperBound >= minSecondarySize else {
-            return max(0, upperBound)
+    private func normalizeStoredSecondarySize() {
+        secondarySize = StudioSplitPaneSizing.normalizedSecondarySize(
+            secondarySize,
+            minimum: minSecondarySize,
+            maximum: maxSecondarySize
+        )
+    }
+}
+
+private struct StudioSecondaryPaneWidthPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let candidate = nextValue()
+        if candidate.isFinite, candidate > 0 {
+            value = candidate
         }
-        return min(max(requestedSize, minSecondarySize), upperBound)
+    }
+}
+
+enum StudioSplitPaneSizing {
+    static func normalizedSecondarySize(
+        _ requestedSize: CGFloat,
+        minimum: CGFloat,
+        maximum: CGFloat
+    ) -> CGFloat {
+        let safeMinimum = minimum.isFinite ? max(0, minimum) : 0
+        let safeMaximum = maximum.isFinite ? max(safeMinimum, maximum) : safeMinimum
+        guard requestedSize.isFinite else { return safeMinimum }
+        return min(max(requestedSize, safeMinimum), safeMaximum)
     }
 }
 
@@ -400,8 +440,8 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
         Coordinator(handler: handler)
     }
 
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
+    func makeNSView(context: Context) -> StudioKeyMonitorAttachmentView {
+        let view = StudioKeyMonitorAttachmentView(frame: .zero)
         context.coordinator.view = view
         context.coordinator.handler = handler
         context.coordinator.isEnabled = isEnabled
@@ -409,19 +449,19 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
         return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {
+    func updateNSView(_ nsView: StudioKeyMonitorAttachmentView, context: Context) {
         context.coordinator.view = nsView
         context.coordinator.handler = handler
         context.coordinator.isEnabled = isEnabled
         context.coordinator.install()
     }
 
-    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    static func dismantleNSView(_ nsView: StudioKeyMonitorAttachmentView, coordinator: Coordinator) {
         coordinator.uninstall()
     }
 
     final class Coordinator {
-        weak var view: NSView?
+        weak var view: StudioKeyMonitorAttachmentView?
         var handler: (NSEvent) -> Bool
         var isEnabled = true
         private var monitor: Any?
@@ -433,7 +473,15 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
         func install() {
             guard monitor == nil else { return }
             monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                guard let self, self.isEnabled else {
+                guard let self,
+                      let view = self.view,
+                      let windowScope = view.windowScope.snapshot(),
+                      StudioKeyEventScope.shouldHandle(
+                          isEnabled: self.isEnabled,
+                          ownerWindowNumber: windowScope.windowNumber,
+                          eventWindowNumber: event.windowNumber,
+                          ownerWindowIsKey: windowScope.isKey
+                      ) else {
                     return event
                 }
                 return self.handler(event) ? nil : event
@@ -446,6 +494,117 @@ struct StudioKeyDownMonitor: NSViewRepresentable {
             }
             monitor = nil
         }
+    }
+}
+
+final class StudioKeyMonitorAttachmentView: NSView {
+    nonisolated let windowScope = StudioKeyWindowScopeCache()
+    private weak var observedWindow: NSWindow?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        stopObservingWindow()
+
+        guard let window else {
+            windowScope.update(windowNumber: nil, isKey: false)
+            return
+        }
+
+        observedWindow = window
+        windowScope.update(windowNumber: window.windowNumber, isKey: window.isKeyWindow)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidBecomeKey(_:)),
+            name: NSWindow.didBecomeKeyNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidResignKey(_:)),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func windowDidBecomeKey(_ notification: Notification) {
+        windowScope.updateIsKey(true)
+    }
+
+    @objc private func windowDidResignKey(_ notification: Notification) {
+        windowScope.updateIsKey(false)
+    }
+
+    private func stopObservingWindow() {
+        guard let observedWindow else { return }
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.didBecomeKeyNotification,
+            object: observedWindow
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.didResignKeyNotification,
+            object: observedWindow
+        )
+        self.observedWindow = nil
+    }
+}
+
+struct StudioKeyWindowScope: Sendable {
+    var windowNumber: Int
+    var isKey: Bool
+}
+
+final class StudioKeyWindowScopeCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var windowNumber: Int?
+    private var isKey = false
+
+    func update(windowNumber: Int?, isKey: Bool) {
+        lock.lock()
+        self.windowNumber = windowNumber
+        self.isKey = isKey
+        lock.unlock()
+    }
+
+    func updateIsKey(_ isKey: Bool) {
+        lock.lock()
+        self.isKey = isKey
+        lock.unlock()
+    }
+
+    func snapshot() -> StudioKeyWindowScope? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let windowNumber else { return nil }
+        return StudioKeyWindowScope(windowNumber: windowNumber, isKey: isKey)
+    }
+}
+
+enum StudioKeyEventScope {
+    static func shouldHandle(
+        isEnabled: Bool,
+        ownerWindowNumber: Int?,
+        eventWindowNumber: Int?,
+        ownerWindowIsKey: Bool
+    ) -> Bool {
+        guard isEnabled,
+              ownerWindowIsKey,
+              let ownerWindowNumber,
+              let eventWindowNumber else {
+            return false
+        }
+        return ownerWindowNumber == eventWindowNumber
+    }
+
+    @MainActor
+    static func isTextInputActive(in window: NSWindow?) -> Bool {
+        guard let responder = window?.firstResponder else { return false }
+        return responder is NSTextView || responder is NSTextField
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/SourceSelectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SourceSelectorViews.swift
@@ -21,8 +21,9 @@ struct SourceSelectorWindowView: View {
                 sourceTab: sourceSelector.sourceTabBinding,
                 visibleTabs: sourceSelector.state.visibleTabs,
                 allSources: model.capture.sources,
-                selectedSourceID: model.selectedSource?.id,
+                selectedSourceID: sourceSelector.state.pendingSourceID,
                 captureMode: model.captureMode,
+                loadPhase: sourceSelector.state.loadPhase,
                 onCancel: {
                     sourceSelector.send(.cancelRequested)
                 },
@@ -30,7 +31,7 @@ struct SourceSelectorWindowView: View {
                     sourceSelector.send(.refreshRequested)
                 },
                 onSelectSource: { source in
-                    model.selectSource(source)
+                    sourceSelector.send(.sourceSelected(source.id))
                 },
                 onShare: {
                     sourceSelector.send(.shareRequested)
@@ -55,15 +56,21 @@ struct SourceSelectorWindowView: View {
         .onAppear {
             sourceSelector.configure(
                 refreshSources: {
-                    model.reloadSourcesForPreview()
+                    await model.refreshSources(requestScreenRecordingPermission: true)
+                    return SourceSelectorRefreshResult(
+                        sourceIDs: model.capture.sources.map(\.id),
+                        errorMessage: model.capture.sourceCatalogState.issueMessage
+                    )
                 },
                 cancel: {
-                    model.cancelCapture()
+                    model.cancelSourceSelection()
+                    dismissWindow(id: "source-selector")
                 },
-                share: {
-                    if let selectedSource = model.selectedSource {
-                        model.selectSource(selectedSource)
+                share: { sourceID in
+                    guard let source = model.capture.sources.first(where: { $0.id == sourceID }) else {
+                        return
                     }
+                    model.selectSource(source)
                     dismissWindow(id: "source-selector")
                 },
                 drawArea: {
@@ -74,8 +81,17 @@ struct SourceSelectorWindowView: View {
                     }
                 }
             )
+            sourceSelector.send(.visibleTabsChanged(visibleTabs))
+            sourceSelector.send(.committedSelectionSynced(model.selectedSource?.id))
+            sourceSelector.send(.sourcesChanged(model.capture.sources.map(\.id)))
             applyPreferredSourceTab()
             sourceSelector.send(.refreshRequested)
+        }
+        .onChange(of: model.selectedSource?.id) { _, sourceID in
+            sourceSelector.send(.committedSelectionSynced(sourceID))
+        }
+        .onChange(of: model.capture.sources.map(\.id)) { _, sourceIDs in
+            sourceSelector.send(.sourcesChanged(sourceIDs))
         }
         .onChange(of: model.preferredSourceSelectorKind) { _, _ in
             applyPreferredSourceTab()
@@ -90,7 +106,7 @@ struct SourceSelectorWindowView: View {
 
 
 
-enum SourceSelectorTab: String, CaseIterable, Identifiable {
+enum SourceSelectorTab: String, CaseIterable, Identifiable, Hashable {
     case screens
     case windows
     case area
@@ -132,6 +148,7 @@ struct SourceSelectorCard: View {
     var allSources: [CaptureSource]
     var selectedSourceID: String?
     var captureMode: CaptureMode
+    var loadPhase: SourceSelectorLoadPhase = .loaded
     var onCancel: (() -> Void)? = nil
     var onRefresh: (() -> Void)? = nil
     var onSelectSource: (CaptureSource) -> Void = { _ in }
@@ -175,9 +192,18 @@ struct SourceSelectorCard: View {
             VStack(spacing: 14) {
                 SourceTabs(sourceTab: $sourceTab, visibleTabs: visibleTabs)
 
-                if sources.isEmpty {
+                if sourceTab == .area && sources.isEmpty {
+                    SourceEmptyState(sourceTab: sourceTab, onDrawArea: onDrawArea)
+                } else if loadPhase == .loading && sources.isEmpty {
+                    SourceLoadingState()
+                } else if case .failed(let message) = loadPhase, sources.isEmpty {
+                    SourceLoadFailureState(message: message, onRetry: onRefresh)
+                } else if sources.isEmpty {
                     SourceEmptyState(sourceTab: sourceTab, onDrawArea: onDrawArea)
                 } else {
+                    if case .failed(let message) = loadPhase {
+                        SourceLoadIssueBanner(message: message)
+                    }
                     SourceGrid(
                         sources: sources,
                         sourceTab: sourceTab,
@@ -194,40 +220,43 @@ struct SourceSelectorCard: View {
                 .frame(height: 1)
 
             HStack {
-                StudioButton(hitTarget: .rounded(8)) {
-                    onCancel?()
-                } label: {
-                    Text("Cancel")
-                        .font(.system(size: 13, weight: .medium))
-                        .frame(height: 34)
-                        .padding(.horizontal, 12)
-                        .background(Color.white.opacity(0.035), in: RoundedRectangle(cornerRadius: 8))
+                if let onCancel {
+                    StudioButton(hitTarget: .rounded(8), action: onCancel) {
+                        Text("Cancel")
+                            .font(.system(size: 13, weight: .medium))
+                            .frame(height: 34)
+                            .padding(.horizontal, 12)
+                            .background(Color.white.opacity(0.035), in: RoundedRectangle(cornerRadius: 8))
+                    }
+                    .foregroundStyle(.secondary)
+                    .keyboardShortcut(.cancelAction)
                 }
-                .foregroundStyle(.secondary)
 
                 StudioButton(hitTarget: .rounded(8)) {
                     onRefresh?()
                 } label: {
-                    Label("Refresh", systemImage: "arrow.clockwise")
+                    Label(loadPhase == .loading ? "Refreshing" : "Refresh", systemImage: "arrow.clockwise")
                         .frame(height: 34)
                         .padding(.horizontal, 12)
                         .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
                 }
                 .foregroundStyle(.secondary)
+                .disabled(onRefresh == nil || loadPhase == .loading)
 
                 Spacer()
 
-                StudioButton(hitTarget: .rounded(8)) {
-                    onShare?()
-                } label: {
-                    Text("Share Source")
-                        .font(.system(size: 13, weight: .semibold))
-                        .frame(height: 34)
-                        .padding(.horizontal, 14)
-                        .background(canShareSource ? Theme.accent : Theme.border, in: RoundedRectangle(cornerRadius: 8))
-                        .foregroundStyle(canShareSource ? Color.white : Color.secondary)
+                if let onShare {
+                    StudioButton(hitTarget: .rounded(8), action: onShare) {
+                        Text("Share Source")
+                            .font(.system(size: 13, weight: .semibold))
+                            .frame(height: 34)
+                            .padding(.horizontal, 14)
+                            .background(canShareSource ? Theme.accent : Theme.border, in: RoundedRectangle(cornerRadius: 8))
+                            .foregroundStyle(canShareSource ? Color.white : Color.secondary)
+                    }
+                    .disabled(!canShareSource)
+                    .keyboardShortcut(.defaultAction)
                 }
-                .disabled(!canShareSource || onShare == nil)
             }
             .padding(16)
         }
@@ -261,40 +290,55 @@ struct SourceTabs: View {
     var visibleTabs: [SourceSelectorTab]
 
     var body: some View {
-        HStack(spacing: 4) {
+        Picker("Source Type", selection: $sourceTab) {
             ForEach(visibleTabs) { tab in
-                StudioSegmentedTabButton(
-                    title: tab.title,
-                    symbolName: tab.symbolName,
-                    isSelected: sourceTab == tab
-                ) {
-                    sourceTab = tab
-                }
+                Label(tab.title, systemImage: tab.symbolName)
+                    .tag(tab)
             }
         }
-        .padding(4)
-        .background(Theme.surfaceControl, in: RoundedRectangle(cornerRadius: 9))
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .accessibilityLabel("Source Type")
     }
 }
 
-struct StudioSegmentedTabButton: View {
-    var title: String
-    var symbolName: String
-    var isSelected: Bool
-    var action: () -> Void
+private struct SourceLoadingState: View {
+    var body: some View {
+        ProgressView("Loading current screens and windows…")
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, minHeight: 210)
+    }
+}
+
+private struct SourceLoadFailureState: View {
+    var message: String
+    var onRetry: (() -> Void)?
 
     var body: some View {
-        StudioButton(hitTarget: .rounded(7), action: action) {
-            HStack(spacing: 6) {
-                Image(systemName: symbolName)
-                Text(title)
+        ContentUnavailableView {
+            Label("Sources Unavailable", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            if let onRetry {
+                Button("Try Again", action: onRetry)
             }
-            .font(.system(size: 12, weight: .semibold))
-            .frame(maxWidth: .infinity)
-            .frame(height: 32)
-            .foregroundStyle(isSelected ? Color.primary : Color.secondary)
-            .background(isSelected ? Theme.border : Color.clear, in: RoundedRectangle(cornerRadius: 7))
         }
+        .frame(maxWidth: .infinity, minHeight: 210)
+    }
+}
+
+private struct SourceLoadIssueBanner: View {
+    var message: String
+
+    var body: some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(10)
+            .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 8))
+            .accessibilityLabel("Source refresh warning: \(message)")
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
@@ -572,19 +572,33 @@ struct StudioTitleBar: View {
             "Settings"
         case .editor:
             if let editorSession {
-                editorTitleWithProjectExtension(editorSession.displayTitle)
+                editorWindowTitle(
+                    displayTitle: editorSession.displayTitle,
+                    projectPath: editorSession.projectPath
+                )
             } else if let currentVideoURL = model.currentVideoURL {
-                editorTitleWithProjectExtension(EditorMediaKind.video.displayTitle(for: currentVideoURL))
+                editorWindowTitle(
+                    displayTitle: EditorMediaKind.video.displayTitle(for: currentVideoURL),
+                    projectPath: matchingLastSessionProjectPath(kind: .video, url: currentVideoURL)
+                )
             } else if let currentScreenshotURL = model.currentScreenshotURL {
-                editorTitleWithProjectExtension(EditorMediaKind.screenshot.displayTitle(for: currentScreenshotURL))
+                editorWindowTitle(
+                    displayTitle: EditorMediaKind.screenshot.displayTitle(for: currentScreenshotURL),
+                    projectPath: matchingLastSessionProjectPath(kind: .screenshot, url: currentScreenshotURL)
+                )
             } else {
                 "Open Recorder Editor"
             }
         }
     }
 
-    private func editorTitleWithProjectExtension(_ title: String) -> String {
-        title.hasSuffix(".openrecorder") ? title : "\(title).openrecorder"
+    private func matchingLastSessionProjectPath(kind: EditorMediaKind, url: URL) -> String? {
+        guard let session = model.lastEditorSession,
+              session.kind == kind,
+              session.url.standardizedFileURL == url.standardizedFileURL else {
+            return nil
+        }
+        return session.projectPath
     }
 
     private var editorMediaKind: EditorMediaKind? {
@@ -613,6 +627,11 @@ struct StudioTitleBar: View {
         }
         return model.currentScreenshotURL
     }
+}
+
+func editorWindowTitle(displayTitle: String, projectPath: String?) -> String {
+    guard projectPath != nil else { return displayTitle }
+    return displayTitle.hasSuffix(".openrecorder") ? displayTitle : "\(displayTitle).openrecorder"
 }
 
 struct EditorShortcutsHelpDialog: View {

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -32,6 +32,7 @@ struct TimelinePanel: View {
     var defaultCameraSettings: FacecamSettings?
     @State private var timelineViewport = TimelineViewport(duration: 0)
     @State private var isDraggingTimelineZoom = false
+    @State private var sourceFramesPerSecond = TimelineSourceFrameRate.fallback
     @FocusState private var isTimelineFocused: Bool
 
     var body: some View {
@@ -132,7 +133,7 @@ struct TimelinePanel: View {
                     .frame(width: 1, height: 22)
                     .padding(.horizontal, 3)
 
-                TimelinePreviewSpeedButton(playback: playback)
+                TimelinePreviewSpeedPicker(playback: playback)
 
                 TimelineZoomSlider(
                     viewport: $timelineViewport,
@@ -142,10 +143,18 @@ struct TimelinePanel: View {
                 )
             }
 
-            TimelineTransportControls(playback: playback)
+            TimelineTransportControls(
+                playback: playback,
+                framesPerSecond: sourceFramesPerSecond
+            )
         }
         .padding(TimelineMetrics.panelPadding)
         .zIndex(1)
+        .task(id: videoURL) {
+            let loadedFrameRate = await TimelineSourceFrameRate.load(from: videoURL)
+            guard !Task.isCancelled else { return }
+            sourceFramesPerSecond = loadedFrameRate
+        }
     }
 
     private func syncTimelineViewportDuration(_ duration: Double) {
@@ -182,6 +191,7 @@ struct TimelineTrackContent: View {
     var defaultCameraSettings: FacecamSettings?
     @Binding var viewport: TimelineViewport
     @State private var timelineSize = CGSize.zero
+    @State private var hoverTime: Double?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -207,25 +217,34 @@ struct TimelineTrackContent: View {
                 edits: edits
             )
         }
-        .overlay(alignment: .topLeading) { TimelinePlayhead(viewport: viewport, currentTime: playback.currentTime) }
+        .overlay(alignment: .topLeading) {
+            ZStack(alignment: .topLeading) {
+                TimelinePlayhead(viewport: viewport, currentTime: playback.currentTime)
+                if let hoverTime {
+                    TimelineHoverIndicator(viewport: viewport, time: hoverTime)
+                }
+            }
+        }
         .readSize { timelineSize = $0 }
         .rectangularHitTarget()
         .onContinuousHover(coordinateSpace: .local) { phase in
             switch phase {
             case .active(let location):
-                hoverSeek(at: location.x)
+                hoverTime = TimelineHoverPreview.time(
+                    videoIsAvailable: videoURL != nil,
+                    playbackIsActive: playback.isPlaying,
+                    x: location.x,
+                    viewport: viewport,
+                    width: timelineSize.width
+                )
             case .ended:
-                break
+                hoverTime = nil
             }
         }
-    }
-
-    private func hoverSeek(at x: CGFloat) {
-        guard videoURL != nil, !playback.isPlaying else { return }
-        guard let time = TimelineSeekMapper.time(forX: x, viewport: viewport, width: timelineSize.width) else { return }
-        playback.seek(to: time)
-        if !viewport.contains(time) {
-            viewport = viewport.keepingVisible(time: time)
+        .onChange(of: playback.isPlaying) { _, isPlaying in
+            if isPlaying {
+                hoverTime = nil
+            }
         }
     }
 }
@@ -233,6 +252,7 @@ struct TimelineTrackContent: View {
 
 private struct TimelineTransportControls: View {
     var playback: VideoPlaybackController
+    var framesPerSecond: Double
 
     var body: some View {
         HStack(spacing: 10) {
@@ -257,8 +277,12 @@ private struct TimelineTransportControls: View {
     }
 
     private func stepFrames(_ frameCount: Int) {
-        let frameDuration = 1.0 / 30.0
-        let target = playback.currentTime + Double(frameCount) * frameDuration
+        let target = TimelineFrameStepper.targetTime(
+            currentTime: playback.currentTime,
+            frameCount: frameCount,
+            framesPerSecond: framesPerSecond,
+            duration: playback.duration
+        )
         playback.seek(to: target)
     }
 }
@@ -355,34 +379,37 @@ private struct TimelineTimeDisplay: View {
     }
 }
 
-private struct TimelinePreviewSpeedButton: View {
+private struct TimelinePreviewSpeedPicker: View {
     var playback: VideoPlaybackController
-    @State private var isHovering = false
 
     var body: some View {
-        StudioButton(hitTarget: .rounded(7), help: "Preview playback speed") {
-            playback.cyclePreviewPlaybackSpeed()
-        } label: {
-            Text(playback.previewPlaybackSpeedLabel())
-                .font(.system(size: 11, weight: .bold, design: .monospaced))
-                .foregroundStyle(Color.white.opacity(isEnabled ? 0.92 : 0.48))
-                .frame(width: 42, height: 28)
-                .background(Color.white.opacity(isHovering && isEnabled ? 0.13 : 0.07), in: RoundedRectangle(cornerRadius: 7))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 7)
-                        .stroke(Color.white.opacity(isHovering && isEnabled ? 0.20 : 0.10), lineWidth: 1)
-                }
+        Picker("Preview speed", selection: speedBinding) {
+            ForEach(VideoPlaybackDriver.previewPlaybackSpeeds, id: \.self) { speed in
+                Text(PreviewPlaybackSpeedSelection.label(for: speed))
+                    .tag(speed)
+            }
         }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .frame(width: 64)
         .disabled(!isEnabled)
         .opacity(isEnabled ? 1 : 0.5)
         .accessibilityLabel("Preview playback speed \(playback.previewPlaybackSpeedLabel())")
-        .onHover { hovering in
-            isHovering = hovering
-        }
+        .help("Preview playback speed")
     }
 
     private var isEnabled: Bool {
         playback.player != nil
+    }
+
+    private var speedBinding: Binding<Double> {
+        Binding(
+            get: { playback.previewPlaybackSpeed },
+            set: { requestedSpeed in
+                PreviewPlaybackSpeedSelection.apply(requestedSpeed, to: playback)
+            }
+        )
     }
 }
 
@@ -656,6 +683,47 @@ struct TimelinePlayhead: View {
     }
 }
 
+struct TimelineHoverIndicator: View {
+    var viewport: TimelineViewport
+    var time: Double
+
+    var body: some View {
+        GeometryReader { proxy in
+            let x = viewport.x(for: time, width: proxy.size.width, clamped: true) ?? 0
+
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.white.opacity(0.38))
+                    .frame(width: 1, height: proxy.size.height)
+                    .offset(x: x - 0.5)
+
+                Text(formatPlaybackTime(time))
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(Theme.fg.opacity(0.92))
+                    .padding(.horizontal, 5)
+                    .frame(height: 18)
+                    .background(Theme.surfaceRaised.opacity(0.94), in: RoundedRectangle(cornerRadius: 4))
+                    .position(x: min(max(x, 28), max(28, proxy.size.width - 28)), y: 9)
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
+enum TimelineHoverPreview {
+    static func time(
+        videoIsAvailable: Bool,
+        playbackIsActive: Bool,
+        x: CGFloat,
+        viewport: TimelineViewport,
+        width: CGFloat
+    ) -> Double? {
+        guard videoIsAvailable, !playbackIsActive else { return nil }
+        return TimelineSeekMapper.time(forX: x, viewport: viewport, width: width)
+    }
+}
+
 enum TimelineSeekMapper {
     static func time(forX x: CGFloat, duration: Double, width: CGFloat) -> Double? {
         guard duration.isFinite, duration > 0, width.isFinite, width > 0, x.isFinite else { return nil }
@@ -668,6 +736,92 @@ enum TimelineSeekMapper {
 
     static func x(forTime time: Double, viewport: TimelineViewport, width: CGFloat, clamped: Bool = false) -> CGFloat? {
         viewport.x(for: time, width: width, clamped: clamped)
+    }
+}
+
+enum TimelineSourceFrameRate {
+    static let fallback = 30.0
+    static let supportedRange = 1.0...240.0
+
+    static func normalized(_ framesPerSecond: Double) -> Double {
+        guard framesPerSecond.isFinite,
+              supportedRange.contains(framesPerSecond) else {
+            return fallback
+        }
+        return framesPerSecond
+    }
+
+    static func load(from videoURL: URL?) async -> Double {
+        guard let videoURL else { return fallback }
+
+        do {
+            let asset = AVURLAsset(url: videoURL)
+            guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+                return fallback
+            }
+            try Task.checkCancellation()
+            let nominalFrameRate = try await videoTrack.load(.nominalFrameRate)
+            return normalized(Double(nominalFrameRate))
+        } catch {
+            return fallback
+        }
+    }
+}
+
+enum TimelineFrameStepper {
+    static func targetTime(
+        currentTime: Double,
+        frameCount: Int,
+        framesPerSecond: Double,
+        duration: Double
+    ) -> Double {
+        let safeFramesPerSecond = TimelineSourceFrameRate.normalized(framesPerSecond)
+        let safeCurrentTime = currentTime.isFinite ? max(0, currentTime) : 0
+        let safeDuration = duration.isFinite ? max(0, duration) : 0
+        let requestedTime = safeCurrentTime + Double(frameCount) / safeFramesPerSecond
+        return min(max(0, requestedTime), safeDuration)
+    }
+}
+
+enum PreviewPlaybackSpeedSelection {
+    static func label(for speed: Double) -> String {
+        guard speed.isFinite, speed > 0 else { return "1x" }
+        if speed.rounded() == speed {
+            return "\(Int(speed))x"
+        }
+        return "\(speed.formatted(.number.precision(.fractionLength(0...2))))x"
+    }
+
+    static func cycleCount(
+        from currentSpeed: Double,
+        to requestedSpeed: Double,
+        availableSpeeds: [Double] = VideoPlaybackDriver.previewPlaybackSpeeds
+    ) -> Int {
+        guard !availableSpeeds.isEmpty,
+              let targetIndex = availableSpeeds.firstIndex(where: { approximatelyEqual($0, requestedSpeed) }) else {
+            return 0
+        }
+
+        let currentIndex = availableSpeeds.enumerated().min { left, right in
+            abs(left.element - currentSpeed) < abs(right.element - currentSpeed)
+        }?.offset ?? 0
+
+        return (targetIndex - currentIndex + availableSpeeds.count) % availableSpeeds.count
+    }
+
+    @MainActor
+    static func apply(_ requestedSpeed: Double, to playback: VideoPlaybackController) {
+        let count = cycleCount(
+            from: playback.previewPlaybackSpeed,
+            to: requestedSpeed
+        )
+        for _ in 0..<count {
+            playback.cyclePreviewPlaybackSpeed()
+        }
+    }
+
+    private static func approximatelyEqual(_ lhs: Double, _ rhs: Double) -> Bool {
+        abs(lhs - rhs) < 0.000_001
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoCropDialog.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoCropDialog.swift
@@ -172,6 +172,7 @@ struct VideoCropDialog: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .stroke(Theme.borderStrong, lineWidth: 1)
         }
+        .interactiveDismissDisabled()
         .overlay(alignment: .topLeading) {
             StudioKeyDownMonitor { event in
                 handleKeyboardAdjustment(event)
@@ -196,7 +197,10 @@ struct VideoCropDialog: View {
 
     private var toolbar: some View {
         HStack(spacing: 14) {
-            trafficLights
+            Label("Crop", systemImage: "crop")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.white.opacity(0.88))
+                .accessibilityAddTraits(.isHeader)
 
             Spacer(minLength: 16)
 
@@ -204,41 +208,31 @@ struct VideoCropDialog: View {
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(Color.white.opacity(0.36))
 
-            CropNumberField(value: widthBinding)
+            CropNumberField(label: "Crop width", value: widthBinding)
             Text("x")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(Theme.fgMuted)
-            CropNumberField(value: heightBinding)
+            CropNumberField(label: "Crop height", value: heightBinding)
 
-            Menu {
+            Picker("Aspect ratio", selection: driver.aspectBinding) {
                 ForEach(VideoCropAspect.allCases) { option in
-                    Button(option.title) {
-                        applyAspect(option)
-                    }
+                    Text(option.title)
+                        .tag(option)
                 }
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: "rectangle.on.rectangle")
-                    Text(driver.state.aspect.title)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
-                }
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(height: 36)
-                .padding(.horizontal, 10)
-                .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
             }
-            .menuStyle(.borderlessButton)
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .controlSize(.small)
             .fixedSize()
+            .help("Crop aspect ratio")
 
             Text("Position")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(Color.white.opacity(0.36))
                 .padding(.leading, 8)
 
-            CropNumberField(value: xBinding)
-            CropNumberField(value: yBinding)
+            CropNumberField(label: "Crop x position", value: xBinding)
+            CropNumberField(label: "Crop y position", value: yBinding)
 
             Button {
                 resetCrop()
@@ -272,15 +266,6 @@ struct VideoCropDialog: View {
         }
     }
 
-    private var trafficLights: some View {
-        HStack(spacing: 9) {
-            Circle().fill(Color(red: 1.0, green: 0.25, blue: 0.27))
-            Circle().fill(Theme.borderStrong)
-            Circle().fill(Theme.borderStrong)
-        }
-        .frame(width: 60, height: 14)
-    }
-
     private var footer: some View {
         HStack(spacing: 10) {
             Button {
@@ -294,8 +279,9 @@ struct VideoCropDialog: View {
                     .foregroundStyle(.white)
             }
             .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
 
-            Button {
+            Button(role: .cancel) {
                 driver.send(.cancelRequested)
             } label: {
                 Text("Discard changes")
@@ -310,16 +296,9 @@ struct VideoCropDialog: View {
                     .foregroundStyle(.white.opacity(0.92))
             }
             .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
         }
         .frame(maxWidth: .infinity)
-    }
-
-    private var effectiveSourceSize: CGSize {
-        driver.state.effectiveSourceSize
-    }
-
-    private var currentPixelRect: CGRect {
-        driver.state.currentPixelRect
     }
 
     private var widthBinding: Binding<Int> {
@@ -339,6 +318,7 @@ struct VideoCropDialog: View {
     }
 
     private func handleKeyboardAdjustment(_ event: NSEvent) -> Bool {
+        guard !StudioKeyEventScope.isTextInputActive(in: event.window) else { return false }
         guard let adjustment = VideoCropKeyboardAdjustment(event: event) else { return false }
         applyKeyboardAdjustment(adjustment)
         return true
@@ -346,10 +326,6 @@ struct VideoCropDialog: View {
 
     private func applyKeyboardAdjustment(_ adjustment: VideoCropKeyboardAdjustment) {
         driver.send(.keyboardAdjusted(adjustment))
-    }
-
-    private func applyAspect(_ option: VideoCropAspect) {
-        driver.send(.aspectSelected(option))
     }
 
     private func resetCrop() {
@@ -615,6 +591,7 @@ private struct VideoCropCanvas: View {
 }
 
 private struct CropNumberField: View {
+    var label: String
     @Binding var value: Int
 
     var body: some View {
@@ -625,6 +602,7 @@ private struct CropNumberField: View {
             .multilineTextAlignment(.center)
             .frame(width: 64, height: 36)
             .background(Theme.overlay, in: RoundedRectangle(cornerRadius: 7))
+            .accessibilityLabel(label)
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import Darwin
 import Observation
 import XCTest
 @testable import OpenRecorderMac
@@ -72,6 +73,51 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
+    func testDeniedScreenPermissionBlocksRecordingBeforePreparingOrHidingCaptureUI() async {
+        let model = AppModel(
+            screenRecordingPermission: makeScreenRecordingPermission(isGranted: false),
+            prepareRecordingFilePath: { _ in
+                XCTFail("File preparation must not run before permission preflight succeeds")
+                return PreparedFile(path: "/tmp/unexpected.mp4")
+            }
+        )
+        let source = makeSource()
+        model.capture.setSourcesForTesting([source])
+        model.setCaptureStateForTesting(.ready(.recording, source))
+
+        model.startRecording()
+        await waitForCondition {
+            !model.isCapturePreflightRunning
+        }
+
+        XCTAssertEqual(model.hudState.phase, .ready(.recording, source))
+        XCTAssertEqual(model.hudState.presentation, .visible)
+        XCTAssertEqual(model.recordingPhase, .idle)
+        XCTAssertEqual(model.statusMessage, CaptureBlocker.screenRecordingPermissionNeedsRestart.message)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+    }
+
+    func testDeniedScreenPermissionBlocksScreenshotBeforeHidingUIOrInvokingCapturer() {
+        var didCapture = false
+        let model = AppModel(
+            screenRecordingPermission: makeScreenRecordingPermission(isGranted: false),
+            screenshotCapture: { _, _ in
+                didCapture = true
+            }
+        )
+        let source = makeSource()
+        model.capture.setSourcesForTesting([source])
+        model.setCaptureStateForTesting(.ready(.screenshot, source))
+
+        model.takeScreenshot()
+
+        XCTAssertFalse(didCapture)
+        XCTAssertEqual(model.hudState.phase, .ready(.screenshot, source))
+        XCTAssertEqual(model.hudState.presentation, .visible)
+        XCTAssertEqual(model.statusMessage, CaptureBlocker.screenRecordingPermissionNeedsRestart.message)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+    }
+
     func testChoosingWindowSourceTypeOpensSourceSelectorOnWindowTab() {
         let model = AppModel()
 
@@ -82,6 +128,31 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.preferredSourceSelectorKind, .window)
         XCTAssertEqual(model.statusMessage, "Choose a window.")
         XCTAssertEqual(model.windowCommand?.action, .showSourceSelector)
+    }
+
+    func testCancelingSourceChangeKeepsPreviouslyCommittedReadySource() {
+        let model = AppModel()
+        let source = makeSource(id: "window:committed", kind: .window)
+        model.setCaptureStateForTesting(.ready(.recording, source))
+        model.requestSourceSelector(kind: .window)
+
+        model.cancelSourceSelection()
+
+        XCTAssertEqual(model.hudState.phase, .ready(.recording, source))
+        XCTAssertEqual(model.selectedSource, source)
+        XCTAssertEqual(model.statusMessage, "Selected \(source.name)")
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+    }
+
+    func testCancelingInitialSourceSelectionStillCancelsCaptureSetup() {
+        let model = AppModel()
+        model.beginCapture(.recording)
+        model.chooseSourceType(.window)
+
+        model.cancelSourceSelection()
+
+        XCTAssertEqual(model.hudState, .choosingMode)
+        XCTAssertEqual(model.windowCommand?.action, .closeCaptureSetup)
     }
 
     func testChoosingAreaSourceTypeOpensSourceSelectorOnAreaTab() {
@@ -263,6 +334,21 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(dottedTitleSession.displayTitle, "Example Recording v1.2")
     }
 
+    func testEditorWindowTitleOnlyShowsProjectExtensionForManagedProjects() {
+        XCTAssertEqual(
+            editorWindowTitle(displayTitle: "Imported Recording", projectPath: nil),
+            "Imported Recording"
+        )
+        XCTAssertEqual(
+            editorWindowTitle(displayTitle: "Managed Recording", projectPath: "/tmp/managed.openrecorder"),
+            "Managed Recording.openrecorder"
+        )
+        XCTAssertEqual(
+            editorWindowTitle(displayTitle: "Already.openrecorder", projectPath: "/tmp/already.openrecorder"),
+            "Already.openrecorder"
+        )
+    }
+
     func testEditorMediaKindTitleIconsMatchEditorType() {
         XCTAssertEqual(EditorMediaKind.video.titleIconSystemName, "video.fill")
         XCTAssertEqual(EditorMediaKind.screenshot.titleIconSystemName, "photo.fill")
@@ -288,6 +374,63 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.hudState, .ready(.recording, source))
         XCTAssertEqual(model.captureFlow, .recordingSetup)
         XCTAssertFalse(model.canStartNewCapture)
+    }
+
+    func testRecordingFilePreparationRunsOffMainActorAfterSuccessfulPreflight() async {
+        var source = makeSource(id: "area:interactive", kind: .area)
+        source.area = CaptureArea(x: 10, y: 20, width: 640, height: 360, displayID: 1)
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preflight-\(UUID().uuidString).mp4")
+        let model = AppModel(
+            screenRecordingPermission: makeScreenRecordingPermission(isGranted: true),
+            runRecordingCountdown: { _ in throw CancellationError() },
+            prepareRecordingFilePath: { _ in
+                guard !Thread.isMainThread else {
+                    throw AppModelTestError.recordingFilePreparationRanOnMainThread
+                }
+                return PreparedFile(path: outputURL.path)
+            }
+        )
+        model.setCaptureStateForTesting(.ready(.recording, source))
+
+        model.startRecording()
+        await waitForCondition { model.statusMessage == "Recording canceled." }
+
+        XCTAssertFalse(model.isCapturePreflightRunning)
+        XCTAssertEqual(model.captureOptions.state.deviceLoadPhase, .idle)
+        XCTAssertEqual(model.hudState.phase, .ready(.recording, source))
+        XCTAssertEqual(model.hudState.presentation, .visible)
+    }
+
+    func testCanceledPermissionPreflightCannotOverwriteANewerCaptureFlow() async {
+        let permissionGate = AsyncPermissionGate()
+        var source = makeSource(id: "area:interactive", kind: .area)
+        source.area = CaptureArea(x: 0, y: 0, width: 800, height: 450, displayID: 1)
+        let model = AppModel(
+            screenRecordingPermission: makeScreenRecordingPermission(isGranted: true),
+            prepareCameraPermission: {
+                await permissionGate.wait()
+                return true
+            }
+        )
+        model.includeCamera = true
+        model.setCaptureStateForTesting(.ready(.recording, source))
+
+        model.startRecording()
+        let permissionCheckStarted = await permissionGate.waitUntilStarted()
+        XCTAssertTrue(permissionCheckStarted)
+        XCTAssertFalse(model.canChangeRecordingOptions)
+        XCTAssertFalse(model.captureOptions.state.canChangeOptions)
+        model.toggleSystemAudio()
+        XCTAssertFalse(model.includeSystemAudio)
+        model.cancelCapture()
+        model.beginCapture(.screenshot)
+        await permissionGate.open()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(model.isCapturePreflightRunning)
+        XCTAssertEqual(model.hudState.phase, .choosingSourceType(.screenshot))
+        XCTAssertEqual(model.statusMessage, "Choose a source type.")
     }
 
     func testChoosingScreenSourceTypePresentsDisplayOverlay() {
@@ -368,11 +511,19 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertTrue(model.canStartNewCapture)
     }
 
-    func testOpenEditorFileRoutesScreenshotImagesToScreenshotEditor() throws {
-        let model = AppModel()
-        let url = URL(fileURLWithPath: "/tmp/example-screenshot.png")
+    func testOpenEditorFileRegistersScreenshotProjectBeforeOpeningEditor() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("example-screenshot.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data("image".utf8)))
+        let project = makeImportedProjectSummary(
+            path: directory.appendingPathComponent("example-screenshot.openrecorder").path,
+            screenshotPath: url.path
+        )
+        let model = AppModel(registerImportedMedia: { _, _ in project })
 
-        model.openEditorFile(at: url)
+        let importTask = try XCTUnwrap(model.openEditorFile(at: url))
+        await importTask.value
 
         let editorSession = try XCTUnwrap(model.windowCommand?.editorSession)
         XCTAssertEqual(model.currentScreenshotURL, url)
@@ -381,7 +532,318 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.windowCommand?.action, .showStudio)
         XCTAssertEqual(editorSession.kind, .screenshot)
         XCTAssertEqual(editorSession.url, url)
+        XCTAssertEqual(editorSession.projectPath, project.path)
+        XCTAssertEqual(model.projects.first, project)
         XCTAssertEqual(model.statusMessage, "Opened example-screenshot.png")
+    }
+
+    func testOpenEditorFileRestoresExistingManagedProjectStateDuringImport() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let mediaURL = directory.appendingPathComponent("existing.png")
+        let projectURL = directory.appendingPathComponent("existing.openrecorder")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mediaURL.path, contents: Data("image".utf8)))
+        let savedState = ScreenshotEditorState(padding: 92, imageRoundness: 24)
+        let document = ProjectDocument(
+            schemaVersion: 2,
+            title: "Existing Project",
+            recordingPath: nil,
+            screenshotPath: mediaURL.path,
+            sourceName: "Imported",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-11T00:00:00Z",
+            editorState: ProjectEditorState(screenshot: savedState),
+            recordingSession: nil
+        )
+        try JSONEncoder().encode(document).write(to: projectURL)
+        let project = makeImportedProjectSummary(path: projectURL.path, screenshotPath: mediaURL.path)
+        let model = AppModel(registerImportedMedia: { _, _ in project })
+
+        let importTask = try XCTUnwrap(model.openEditorFile(at: mediaURL))
+        await importTask.value
+
+        let session = try XCTUnwrap(model.windowCommand?.editorSession)
+        XCTAssertEqual(session.projectPath, projectURL.path)
+        XCTAssertEqual(session.title, "Existing Project")
+        XCTAssertEqual(session.screenshotEditorState, savedState)
+    }
+
+    func testConcurrentRequestsForSameMediaShareOneProjectImport() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let mediaURL = directory.appendingPathComponent("duplicate.png")
+        let mediaAliasURL = directory.appendingPathComponent("duplicate-alias.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mediaURL.path, contents: Data("image".utf8)))
+        try FileManager.default.createSymbolicLink(at: mediaAliasURL, withDestinationURL: mediaURL)
+        let project = makeImportedProjectSummary(
+            path: directory.appendingPathComponent("duplicate.openrecorder").path,
+            screenshotPath: mediaURL.path
+        )
+        let registration = BlockingImportRegistration(summary: project)
+        let model = AppModel(registerImportedMedia: { _, _ in
+            registration.register()
+        })
+
+        let first = try XCTUnwrap(model.openEditorFile(at: mediaURL))
+        let didStartRegistration = await registration.waitForCallCount(1)
+        XCTAssertTrue(didStartRegistration)
+        let second = try XCTUnwrap(model.openEditorFile(at: mediaAliasURL))
+        XCTAssertEqual(registration.callCount, 1)
+
+        registration.release()
+        await first.value
+        await second.value
+
+        XCTAssertEqual(registration.callCount, 1)
+        XCTAssertEqual(model.projects, [project])
+    }
+
+    func testOpenProjectFileLoadsManagedStateAndMediaAsynchronously() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let mediaURL = directory.appendingPathComponent("project-image.png")
+        let projectURL = directory.appendingPathComponent("project.openrecorder")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mediaURL.path, contents: Data("image".utf8)))
+        let savedState = ScreenshotEditorState(padding: 74, backgroundRoundness: 18)
+        let document = ProjectDocument(
+            schemaVersion: 2,
+            title: "Managed Screenshot",
+            recordingPath: nil,
+            screenshotPath: mediaURL.path,
+            sourceName: "Display",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-11T00:00:00Z",
+            editorState: ProjectEditorState(screenshot: savedState),
+            recordingSession: nil
+        )
+        try JSONEncoder().encode(document).write(to: projectURL)
+        let model = AppModel()
+
+        await model.openProjectFile(at: projectURL).value
+
+        let session = try XCTUnwrap(model.windowCommand?.editorSession)
+        XCTAssertEqual(session.url, mediaURL)
+        XCTAssertEqual(session.projectPath, projectURL.path)
+        XCTAssertEqual(session.screenshotEditorState, savedState)
+        XCTAssertEqual(model.statusMessage, "Opened Managed Screenshot")
+    }
+
+    func testOpenProjectFileReportsMissingMediaWithoutOpeningEditor() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let projectURL = directory.appendingPathComponent("missing-media.openrecorder")
+        let missingMediaURL = directory.appendingPathComponent("missing.mp4")
+        let document = ProjectDocument(
+            schemaVersion: 2,
+            title: "Missing Recording",
+            recordingPath: missingMediaURL.path,
+            screenshotPath: nil,
+            sourceName: nil,
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-11T00:00:00Z",
+            editorState: .empty,
+            recordingSession: nil
+        )
+        try JSONEncoder().encode(document).write(to: projectURL)
+        let model = AppModel()
+
+        await model.openProjectFile(at: projectURL).value
+
+        XCTAssertNil(model.windowCommand?.editorSession)
+        XCTAssertNil(model.currentVideoURL)
+        XCTAssertTrue(model.statusMessage.contains("recording file is missing or unreadable"))
+    }
+
+    func testOpenEditorFileFallsBackToDurableLocalVideoProjectWhenRegistrationFails() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("example-recording.mp4")
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data("video".utf8)))
+        let model = AppModel(registerImportedMedia: { _, _ in throw AppModelTestError.importFailed })
+        model.paths = AppPaths(
+            recordingsDir: directory.path,
+            screenshotsDir: directory.path,
+            projectsDir: directory.path,
+            supportDir: directory.path
+        )
+
+        let importTask = try XCTUnwrap(model.openEditorFile(at: url))
+        await importTask.value
+
+        let session = try XCTUnwrap(model.windowCommand?.editorSession)
+        let projectPath = try XCTUnwrap(session.projectPath)
+        XCTAssertEqual(session.kind, .video)
+        XCTAssertEqual(session.url, url)
+        XCTAssertEqual(model.currentVideoURL, url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: projectPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: "\(projectPath).recovery"))
+        XCTAssertEqual(model.statusMessage, "Opened example-recording.mp4")
+
+        let relaunchedModel = AppModel(registerImportedMedia: { _, _ in
+            throw AppModelTestError.importFailed
+        })
+        relaunchedModel.paths = model.paths
+        let reopenedImport = try XCTUnwrap(relaunchedModel.openEditorFile(at: url))
+        await reopenedImport.value
+
+        XCTAssertEqual(relaunchedModel.windowCommand?.editorSession?.projectPath, projectPath)
+        let recoveredProjects = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "openrecorder" }
+        XCTAssertEqual(recoveredProjects.count, 1)
+    }
+
+    func testOpenEditorFileFallsBackToDurableLocalScreenshotProjectWhenRegistrationFails() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("example-screenshot.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data("image".utf8)))
+        let model = AppModel(registerImportedMedia: { _, _ in throw AppModelTestError.importFailed })
+        model.paths = AppPaths(
+            recordingsDir: directory.path,
+            screenshotsDir: directory.path,
+            projectsDir: directory.path,
+            supportDir: directory.path
+        )
+
+        let importTask = try XCTUnwrap(model.openEditorFile(at: url))
+        await importTask.value
+
+        let session = try XCTUnwrap(model.windowCommand?.editorSession)
+        let projectPath = try XCTUnwrap(session.projectPath)
+        XCTAssertEqual(session.kind, .screenshot)
+        XCTAssertEqual(session.url, url)
+        XCTAssertEqual(session.screenshotEditorState, .default)
+        XCTAssertEqual(model.currentScreenshotURL, url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: projectPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: "\(projectPath).recovery"))
+        XCTAssertEqual(model.statusMessage, "Opened example-screenshot.png")
+    }
+
+    func testOpenEditorFileRejectsMissingMediaBeforeCreatingProject() {
+        let url = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString).mp4")
+        let model = AppModel(registerImportedMedia: { _, _ in
+            XCTFail("Registration should not run for a missing file")
+            return makeImportedProjectSummary(path: "/tmp/unexpected.openrecorder", screenshotPath: nil)
+        })
+
+        let task = model.openEditorFile(at: url)
+
+        XCTAssertNil(task)
+        XCTAssertNil(model.windowCommand?.editorSession)
+        XCTAssertTrue(model.statusMessage.contains("missing or unreadable"))
+    }
+
+    func testBackendRefreshRunsServiceWorkOffMainActor() async {
+        let snapshot = BackendSnapshot(
+            health: HealthPayload(service: "open-recorder", version: "1", platform: "macOS"),
+            paths: AppPaths(recordingsDir: "/r", screenshotsDir: "/s", projectsDir: "/p", supportDir: "/support"),
+            projects: []
+        )
+        let model = AppModel(loadBackendSnapshot: {
+            guard pthread_main_np() == 0 else { throw AppModelTestError.backendRanOnMainThread }
+            return snapshot
+        })
+
+        let refresh = model.refreshBackendState()
+        XCTAssertTrue(model.appShell.settings.state.isRefreshingService)
+        let succeeded = await refresh.value
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(model.backendLoadPhase, .loaded)
+        XCTAssertEqual(model.paths, snapshot.paths)
+        XCTAssertEqual(model.serviceHealth, snapshot.health)
+    }
+
+    func testBackendRefreshFailureKeepsPreviouslyLoadedProjects() async {
+        let project = makeImportedProjectSummary(
+            path: "/tmp/existing.openrecorder",
+            screenshotPath: "/tmp/existing.png"
+        )
+        let model = AppModel(loadBackendSnapshot: {
+            throw AppModelTestError.backendUnavailable
+        })
+        model.projects = [project]
+
+        let succeeded = await model.refreshBackendState().value
+
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(model.projects, [project])
+        XCTAssertEqual(model.backendLoadPhase, .failed("Test backend unavailable"))
+    }
+
+    func testNewestBackendRefreshWinsWhenOlderRequestFinishesLast() async {
+        let gate = BackendSnapshotGate()
+        let olderProject = makeImportedProjectSummary(
+            path: "/tmp/older.openrecorder",
+            screenshotPath: "/tmp/older.png"
+        )
+        let newerProject = makeImportedProjectSummary(
+            path: "/tmp/newer.openrecorder",
+            screenshotPath: "/tmp/newer.png"
+        )
+        let model = AppModel(loadBackendSnapshot: {
+            try await gate.load()
+        })
+
+        let olderRefresh = model.refreshBackendState()
+        await waitForBackendCallCount(1, gate: gate)
+        let newerRefresh = model.refreshBackendState()
+        await waitForBackendCallCount(2, gate: gate)
+
+        await gate.resume(call: 2, with: BackendSnapshot(
+            health: HealthPayload(service: "new", version: "2", platform: "macOS"),
+            paths: AppPaths(recordingsDir: "/new/r", screenshotsDir: "/new/s", projectsDir: "/new/p", supportDir: "/new"),
+            projects: [newerProject]
+        ))
+        let newerSucceeded = await newerRefresh.value
+        XCTAssertTrue(newerSucceeded)
+
+        await gate.resume(call: 1, with: BackendSnapshot(
+            health: HealthPayload(service: "old", version: "1", platform: "macOS"),
+            paths: AppPaths(recordingsDir: "/old/r", screenshotsDir: "/old/s", projectsDir: "/old/p", supportDir: "/old"),
+            projects: [olderProject]
+        ))
+        let olderSucceeded = await olderRefresh.value
+        XCTAssertFalse(olderSucceeded)
+
+        XCTAssertEqual(model.projects, [newerProject])
+        XCTAssertEqual(model.serviceHealth?.service, "new")
+        XCTAssertEqual(model.paths?.projectsDir, "/new/p")
+    }
+
+    func testBackendRefreshMergesProjectMutationsThatFinishWhileItIsLoading() async {
+        let gate = BackendSnapshotGate()
+        let deletedProject = makeImportedProjectSummary(
+            path: "/tmp/deleted-during-refresh.openrecorder",
+            screenshotPath: "/tmp/deleted.png"
+        )
+        let importedProject = makeImportedProjectSummary(
+            path: "/tmp/imported-during-refresh.openrecorder",
+            screenshotPath: "/tmp/imported.png"
+        )
+        let remoteProject = makeImportedProjectSummary(
+            path: "/tmp/remote.openrecorder",
+            screenshotPath: "/tmp/remote.png"
+        )
+        let model = AppModel(loadBackendSnapshot: {
+            try await gate.load()
+        })
+        model.projects = [deletedProject]
+
+        let refresh = model.refreshBackendState()
+        await waitForBackendCallCount(1, gate: gate)
+        model.projects = [importedProject]
+        await gate.resume(call: 1, with: BackendSnapshot(
+            health: HealthPayload(service: "open-recorder", version: "1", platform: "macOS"),
+            paths: AppPaths(recordingsDir: "/r", screenshotsDir: "/s", projectsDir: "/p", supportDir: "/support"),
+            projects: [deletedProject, remoteProject]
+        ))
+
+        let refreshSucceeded = await refresh.value
+        XCTAssertTrue(refreshSucceeded)
+        XCTAssertEqual(model.projects, [importedProject, remoteProject])
     }
 
     func testAreaScreenshotCompletionOpensEditorEvenIfScreenshotIndexingFails() async throws {
@@ -412,6 +874,9 @@ final class AppModelStateTests: XCTestCase {
             },
             rememberScreenshot: { _ in
                 throw TestScreenshotError.rememberFailed
+            },
+            registerCapturedMedia: { _, _ in
+                throw AppModelTestError.backendUnavailable
             }
         )
         let area = CaptureArea(x: 24, y: 48, width: 320, height: 180, displayID: 7)
@@ -434,6 +899,14 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.windowCommand?.action, .showStudio)
         XCTAssertEqual(editorSession.kind, .screenshot)
         XCTAssertEqual(editorSession.url, screenshotURL)
+        let projectPath = try XCTUnwrap(editorSession.projectPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: projectPath))
+        let document = try JSONDecoder().decode(
+            ProjectDocument.self,
+            from: Data(contentsOf: URL(fileURLWithPath: projectPath))
+        )
+        XCTAssertEqual(document.screenshotPath, screenshotURL.path)
+        XCTAssertEqual(document.editorState?.screenshot, .default)
         XCTAssertTrue(screenshotURL.path.hasPrefix(screenshotsDir.path))
         XCTAssertEqual(model.statusMessage, "Captured \(screenshotURL.lastPathComponent)")
     }
@@ -612,16 +1085,23 @@ final class AppModelStateTests: XCTestCase {
     }
 
     func testStoppingRecordingWithWrittenFileOpensEditorEvenIfProjectIndexingFails() async throws {
-        let outputURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("finished-recording-\(UUID().uuidString).mp4")
-        defer {
-            try? FileManager.default.removeItem(at: outputURL)
-        }
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let outputURL = directory.appendingPathComponent("finished-recording-\(UUID().uuidString).mp4")
         try Data("mp4".utf8).write(to: outputURL)
         let model = AppModel(
             stopRecording: {
                 outputURL
+            },
+            registerCapturedMedia: { _, _ in
+                throw AppModelTestError.backendUnavailable
             }
+        )
+        model.paths = AppPaths(
+            recordingsDir: directory.path,
+            screenshotsDir: directory.path,
+            projectsDir: directory.path,
+            supportDir: directory.path
         )
         let source = makeSource()
 
@@ -637,6 +1117,14 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.selectedSection, .editor)
         XCTAssertEqual(editorSession.kind, .video)
         XCTAssertEqual(editorSession.url, outputURL)
+        let projectPath = try XCTUnwrap(editorSession.projectPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: projectPath))
+        let document = try JSONDecoder().decode(
+            ProjectDocument.self,
+            from: Data(contentsOf: URL(fileURLWithPath: projectPath))
+        )
+        XCTAssertEqual(document.recordingPath, outputURL.path)
+        XCTAssertEqual(document.recordingSession, editorSession.recordingSession)
         XCTAssertEqual(model.hudState, .choosingMode)
         XCTAssertTrue(model.canStartNewCapture)
     }
@@ -1225,6 +1713,72 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.statusMessage, "Recording will stop after it starts.")
     }
 
+    func testTerminationIsCanceledWhileCaptureWorkIsActive() async {
+        let model = AppModel()
+        let source = makeSource()
+        model.capture.setRecordingForTesting(true)
+        model.setCaptureStateForTesting(.recording(source))
+
+        let canTerminate = await model.prepareForTermination()
+
+        XCTAssertFalse(canTerminate)
+        XCTAssertEqual(model.hudState.phase, .recording(source))
+        XCTAssertEqual(model.statusMessage, "Finish or cancel the current capture before quitting.")
+    }
+
+    func testTerminationGateRejectsNewCaptureAndFileImportWhileAutosaveFinishes() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let mediaURL = directory.appendingPathComponent("late-import.mp4")
+        try Data("video".utf8).write(to: mediaURL)
+        let model = AppModel(registerImportedMedia: { _, _ in
+            throw AppModelTestError.importFailed
+        })
+        let workspace = model.appShell.workspace(for: nil)
+        let saveGate = AppModelAutosaveGate()
+        let saveStarted = expectation(description: "Autosave started before termination gate checks")
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                saveStarted.fulfill()
+                await saveGate.wait()
+                return makeImportedProjectSummary(path: snapshot.projectPath, screenshotPath: nil)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            ProjectAutosaveSnapshot(
+                projectPath: directory.appendingPathComponent("pending.openrecorder").path,
+                title: "Pending",
+                recordingPath: mediaURL.path,
+                screenshotPath: nil,
+                sourceName: nil,
+                editorState: .empty,
+                recordingSession: nil
+            )
+        ))
+
+        let termination = Task { @MainActor in await model.prepareForTermination() }
+        await fulfillment(of: [saveStarted], timeout: 1)
+        let phaseBeforeRejectedCapture = model.captureState.phase
+
+        model.beginCapture(.recording)
+        let importTask = model.openEditorFile(at: mediaURL)
+
+        XCTAssertTrue(model.isTerminationPending)
+        XCTAssertEqual(model.captureState.phase, phaseBeforeRejectedCapture)
+        XCTAssertNil(importTask)
+        XCTAssertEqual(model.statusMessage, "Open Recorder is finishing pending work before quitting.")
+
+        await saveGate.open()
+        let canTerminate = await termination.value
+        XCTAssertTrue(canTerminate)
+        XCTAssertTrue(model.isTerminationPending)
+    }
+
     func testAppWindowActionsOpenEditorCommandUsesEditorWindow() {
         let actions = AppWindowActions()
         let session = EditorSession(
@@ -1492,6 +2046,130 @@ private final class ProjectDeleteSpy: @unchecked Sendable {
     }
 }
 
+private actor AppModelAutosaveGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private final class BlockingImportRegistration: @unchecked Sendable {
+    private let condition = NSCondition()
+    private let summary: ProjectSummary
+    private var isReleased = false
+    private var calls = 0
+
+    init(summary: ProjectSummary) {
+        self.summary = summary
+    }
+
+    var callCount: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return calls
+    }
+
+    func register() -> ProjectSummary {
+        condition.lock()
+        calls += 1
+        condition.broadcast()
+        while !isReleased {
+            condition.wait()
+        }
+        condition.unlock()
+        return summary
+    }
+
+    func waitForCallCount(_ expected: Int) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while callCount < expected {
+            guard clock.now < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
+    }
+
+    func release() {
+        condition.lock()
+        isReleased = true
+        condition.broadcast()
+        condition.unlock()
+    }
+}
+
+private actor BackendSnapshotGate {
+    private var nextCall = 0
+    private var continuations: [Int: CheckedContinuation<BackendSnapshot, Error>] = [:]
+
+    func load() async throws -> BackendSnapshot {
+        nextCall += 1
+        let call = nextCall
+        return try await withCheckedThrowingContinuation { continuation in
+            continuations[call] = continuation
+        }
+    }
+
+    var callCount: Int {
+        nextCall
+    }
+
+    func resume(call: Int, with snapshot: BackendSnapshot) {
+        continuations.removeValue(forKey: call)?.resume(returning: snapshot)
+    }
+}
+
+private actor AsyncPermissionGate {
+    private var started = false
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        started = true
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while !started, clock.now < deadline {
+            try? await clock.sleep(for: .milliseconds(5))
+        }
+        return started
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private func waitForBackendCallCount(_ expectedCount: Int, gate: BackendSnapshotGate) async {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(2))
+    while await gate.callCount < expectedCount, clock.now < deadline {
+        try? await clock.sleep(for: .milliseconds(5))
+    }
+    let actualCount = await gate.callCount
+    XCTAssertGreaterThanOrEqual(actualCount, expectedCount)
+}
+
 private func makeTemporaryDirectory() throws -> URL {
     let url = FileManager.default.temporaryDirectory
         .appendingPathComponent("open-recorder-tests-\(UUID().uuidString)", isDirectory: true)
@@ -1518,6 +2196,37 @@ private func makeDeleteProjectSummary(
         lastOpenedAt: "2026-05-25T00:00:00Z",
         missing: missing
     )
+}
+
+private func makeImportedProjectSummary(path: String, screenshotPath: String?) -> ProjectSummary {
+    ProjectSummary(
+        id: path,
+        title: URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent,
+        path: path,
+        recordingPath: screenshotPath == nil ? "/tmp/imported.mp4" : nil,
+        screenshotPath: screenshotPath,
+        sourceName: "Imported",
+        createdAt: "2026-07-11T00:00:00Z",
+        updatedAt: "2026-07-11T00:00:00Z",
+        lastOpenedAt: "2026-07-11T00:00:00Z",
+        missing: false
+    )
+}
+
+private enum AppModelTestError: LocalizedError {
+    case importFailed
+    case backendRanOnMainThread
+    case backendUnavailable
+    case recordingFilePreparationRanOnMainThread
+
+    var errorDescription: String? {
+        switch self {
+        case .importFailed: "Test import failed"
+        case .backendRanOnMainThread: "Backend work ran on the main thread"
+        case .backendUnavailable: "Test backend unavailable"
+        case .recordingFilePreparationRanOnMainThread: "Recording file preparation ran on the main thread"
+        }
+    }
 }
 
 private enum TestProjectDeleteError: LocalizedError {

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -57,8 +57,41 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(state.paths, paths)
         XCTAssertEqual(state.projects, [project])
         XCTAssertEqual(state.serviceHealth, health)
+        XCTAssertEqual(state.backendLoadPhase, .loaded)
         XCTAssertEqual(state.statusMessage, "Rust service ready")
         XCTAssertEqual(effects, [.setStatusMessage("Rust service ready")])
+    }
+
+    func testShellBackendRefreshPublishesLoadingBeforeResultsArrive() {
+        var state = AppShellState()
+
+        let effects = state.applying(.backendRefreshStarted)
+
+        XCTAssertEqual(state.backendLoadPhase, .loading)
+        XCTAssertEqual(state.statusMessage, "Loading projects…")
+        XCTAssertEqual(effects, [.setStatusMessage("Loading projects…")])
+        XCTAssertEqual(state.applying(.backendRefreshStarted), [])
+    }
+
+    func testShellBackendFailurePreservesLastUsableData() {
+        let paths = AppPaths(recordingsDir: "/r", screenshotsDir: "/s", projectsDir: "/p", supportDir: "/support")
+        let project = makeProjectSummary(path: "/p/demo.openrecorder")
+        let health = HealthPayload(service: "open-recorder", version: "1.0", platform: "macOS")
+        var state = AppShellState(
+            projects: [project],
+            paths: paths,
+            serviceHealth: health,
+            backendLoadPhase: .loaded
+        )
+
+        _ = state.applying(.backendRefreshStarted)
+        let effects = state.applying(.backendRefreshFailed("Service unavailable"))
+
+        XCTAssertEqual(state.projects, [project])
+        XCTAssertEqual(state.paths, paths)
+        XCTAssertEqual(state.serviceHealth, health)
+        XCTAssertEqual(state.backendLoadPhase, .failed("Service unavailable"))
+        XCTAssertEqual(effects, [.setStatusMessage("Service unavailable")])
     }
 
     func testShellRemovesProjectSummaryByPath() {
@@ -191,6 +224,130 @@ final class AppShellStateMachineTests: XCTestCase {
 
         XCTAssertEqual(savedSnapshots, [videoSnapshot, screenshotSnapshot])
         XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 0)
+    }
+
+    func testPreparingForTerminationFlushesAutosavesWithoutEvictingOpenWorkspace() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/quit-save.mp4"))
+        let workspace = shell.workspace(for: session)
+        let snapshot = makeWorkspaceAutosaveSnapshot(path: "/tmp/quit-save.openrecorder", kind: .video)
+        var savedSnapshots: [ProjectAutosaveSnapshot] = []
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                savedSnapshots.append(snapshot)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(snapshot))
+
+        let canTerminate = await shell.prepareForTermination()
+
+        XCTAssertTrue(canTerminate)
+        XCTAssertEqual(savedSnapshots, [snapshot])
+        XCTAssertTrue(shell.workspace(for: session) === workspace)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
+    }
+
+    func testPreparingForTerminationRechecksEarlierAndNewWorkspacesAtAFixedPoint() async {
+        let shell = AppShellDriver()
+        let firstWorkspace = shell.workspace(for: nil)
+        let secondSession = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/quit-second.mp4"))
+        let secondWorkspace = shell.workspace(for: secondSession)
+        let secondSaveGate = WorkspaceAutosaveGate()
+        let secondSaveStarted = expectation(description: "Second workspace save started")
+        var savedPaths: [String] = []
+
+        firstWorkspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                savedPaths.append(snapshot.projectPath)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        secondWorkspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { snapshot in
+                secondSaveStarted.fulfill()
+                await secondSaveGate.wait()
+                savedPaths.append(snapshot.projectPath)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        firstWorkspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: "/tmp/quit-first-1.openrecorder", kind: .video)
+        ))
+        secondWorkspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: "/tmp/quit-second.openrecorder", kind: .video)
+        ))
+
+        let termination = Task { @MainActor in await shell.prepareForTermination() }
+        await fulfillment(of: [secondSaveStarted], timeout: 1)
+
+        firstWorkspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: "/tmp/quit-first-2.openrecorder", kind: .video)
+        ))
+        let thirdSession = EditorSession(kind: .screenshot, url: URL(fileURLWithPath: "/tmp/quit-third.png"))
+        let thirdWorkspace = shell.workspace(for: thirdSession)
+        thirdWorkspace.screenshot.configure(
+            saveHandler: { snapshot in
+                savedPaths.append(snapshot.projectPath)
+                return makeProjectSummary(path: snapshot.projectPath)
+            },
+            statusHandler: { _ in },
+            setWorkspaceStatus: { _ in }
+        )
+        thirdWorkspace.screenshot.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: "/tmp/quit-third.openrecorder", kind: .screenshot)
+        ))
+        await secondSaveGate.open()
+
+        let canTerminate = await termination.value
+        XCTAssertTrue(canTerminate)
+        XCTAssertEqual(Set(savedPaths), Set([
+            "/tmp/quit-first-1.openrecorder",
+            "/tmp/quit-first-2.openrecorder",
+            "/tmp/quit-second.openrecorder",
+            "/tmp/quit-third.openrecorder"
+        ]))
+    }
+
+    func testPreparingForTerminationCancelsQuitAndPresentsRecoveryWhenAutosaveFails() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/quit-failure.mp4"))
+        let workspace = shell.workspace(for: session)
+        workspace.video.configure(
+            applyTimelineSnapshot: { _ in },
+            saveHandler: { _ in throw WorkspaceAutosaveError.failed },
+            statusHandler: { [weak workspace] status in
+                workspace?.handleProjectAutosaveStatus(status, source: .video)
+            },
+            pausePlayback: {},
+            exportVideo: { _, _, _ in },
+            clearVideoExportDialogState: {}
+        )
+        workspace.video.send(.autosaveSnapshotChanged(
+            makeWorkspaceAutosaveSnapshot(path: "/tmp/quit-failure.openrecorder", kind: .video)
+        ))
+
+        let canTerminate = await shell.prepareForTermination()
+
+        XCTAssertFalse(canTerminate)
+        XCTAssertTrue(workspace.state.isAutosaveRecoveryPresented)
+        XCTAssertEqual(workspace.state.statusSeverity, .failure)
+        XCTAssertEqual(shell.sessionWorkspaceCountForTesting, 1)
     }
 
     func testReopeningSessionDuringCloseReusesWorkspaceAndCancelsEviction() async {
@@ -785,9 +942,8 @@ final class AppShellStateMachineTests: XCTestCase {
         XCTAssertEqual(configuredWorkspaces.count, 3)
     }
 
-    func testClosingOneSessionClearsOnlyItsActiveExport() async {
+    func testClosingSessionDoesNotSilentlyCancelAnActiveExport() async {
         let shell = AppShellDriver()
-        var temporaryURLs: [ObjectIdentifier: URL] = [:]
         var cancellationTokens: [ObjectIdentifier: VideoExportCancellationToken] = [:]
         var deletedURLs: [URL] = []
         let rendersStarted = expectation(description: "Both workspace exports started")
@@ -795,7 +951,6 @@ final class AppShellStateMachineTests: XCTestCase {
         shell.configure(configureWorkspace: { workspace in
             let workspaceID = ObjectIdentifier(workspace)
             let temporaryURL = URL(fileURLWithPath: "/tmp/\(UUID().uuidString).mov")
-            temporaryURLs[workspaceID] = temporaryURL
             workspace.videoExport.configure(
                 renderVideo: { _, _, _, token, _, _ in
                     cancellationTokens[workspaceID] = token
@@ -824,15 +979,55 @@ final class AppShellStateMachineTests: XCTestCase {
         secondWorkspace.videoExport.export(sourceURL: secondSession.url, options: .default, edits: .empty)
         await fulfillment(of: [rendersStarted], timeout: 1)
 
-        await shell.closeWorkspace(for: firstSession)
+        let closeOutcome = await shell.closeWorkspace(for: firstSession)
+        let didDiscardActiveExport = shell.discardWorkspace(for: firstSession)
 
-        XCTAssertEqual(firstWorkspace.videoExport.state.phase, .idle)
-        XCTAssertTrue(cancellationTokens[firstID]?.isCancelled == true)
-        XCTAssertEqual(deletedURLs, temporaryURLs[firstID].map { [$0] } ?? [])
+        XCTAssertEqual(closeOutcome, .canceled)
+        XCTAssertFalse(didDiscardActiveExport)
+        XCTAssertEqual(firstWorkspace.videoExport.state.phase, .exporting)
+        XCTAssertFalse(cancellationTokens[firstID]?.isCancelled ?? true)
+        XCTAssertEqual(deletedURLs, [])
         XCTAssertEqual(secondWorkspace.videoExport.state.phase, .exporting)
         XCTAssertFalse(cancellationTokens[secondID]?.isCancelled ?? true)
 
+        firstWorkspace.videoExport.cancelExport()
+        secondWorkspace.videoExport.cancelExport()
         await shell.closeWorkspace(for: secondSession)
+    }
+
+    func testCloseAndQuitPreserveFinishedExportUntilUserSavesOrCancelsIt() async {
+        let shell = AppShellDriver()
+        let session = EditorSession(kind: .video, url: URL(fileURLWithPath: "/tmp/save-pending.mp4"))
+        let workspace = shell.workspace(for: session)
+        let temporaryURL = URL(fileURLWithPath: "/tmp/save-pending-export.mov")
+        var deletedURLs: [URL] = []
+        workspace.videoExport.configure(
+            renderVideo: { _, _, _, _, _, _ in },
+            temporaryURL: { _ in temporaryURL },
+            saveDestination: { _, _ in nil },
+            copyFile: { _, _ in },
+            deleteFile: { deletedURLs.append($0) },
+            revealFile: { _ in },
+            setStatusMessage: { _ in }
+        )
+
+        workspace.videoExport.export(sourceURL: session.url, options: .default, edits: .empty)
+        await waitForCondition { workspace.videoExport.state.phase == .savePending }
+
+        let closeWhilePending = await shell.closeWorkspace(for: session)
+        let canTerminateWhilePending = await shell.prepareForTermination()
+        let didDiscardFinishedExport = shell.discardWorkspace(for: session)
+        XCTAssertEqual(closeWhilePending, .canceled)
+        XCTAssertFalse(canTerminateWhilePending)
+        XCTAssertFalse(didDiscardFinishedExport)
+        XCTAssertEqual(workspace.videoExport.state.pendingTempURL, temporaryURL)
+        XCTAssertEqual(deletedURLs, [])
+        XCTAssertEqual(workspace.state.statusSeverity, .failure)
+
+        workspace.videoExport.clear()
+        XCTAssertEqual(deletedURLs, [temporaryURL])
+        let closeAfterCancel = await shell.closeWorkspace(for: session)
+        XCTAssertEqual(closeAfterCancel, .closed)
     }
 
     func testAppModelFacadeMirrorsShellRouting() {
@@ -1033,6 +1228,101 @@ final class CaptureOptionsStateMachineTests: XCTestCase {
         XCTAssertEqual(state.statusMessage, "System audio is on for this recording.")
         XCTAssertEqual(effects, [.setStatusMessage("System audio is on for this recording.")])
     }
+
+    func testLockedCaptureOptionsRejectEveryUserMutationButAllowRuntimeCameraFallback() {
+        var state = CaptureOptionsState(
+            includeMicrophone: true,
+            includeSystemAudio: true,
+            includeCamera: true,
+            showCursor: true,
+            showClicks: false,
+            selectedMicrophoneDeviceID: "mic-original",
+            selectedCameraDeviceID: "cam-original",
+            canChangeOptions: false
+        )
+        let lockedEvents: [CaptureOptionsEvent] = [
+            .microphoneEnabledChanged(false),
+            .systemAudioChanged(false),
+            .cameraEnabledChanged(false),
+            .microphoneSelectionRequested,
+            .cameraSelectionRequested,
+            .microphoneSelected("mic-new"),
+            .cameraSelected("cam-new"),
+            .microphoneDisabled,
+            .cameraDisabled,
+            .cursorVisibilityChanged(false),
+            .clickVisibilityChanged(true)
+        ]
+
+        for event in lockedEvents {
+            let effects = state.applying(event)
+            XCTAssertEqual(effects, [.setStatusMessage("Recording options are locked while capture is starting.")])
+        }
+        XCTAssertTrue(state.includeMicrophone)
+        XCTAssertTrue(state.includeSystemAudio)
+        XCTAssertTrue(state.includeCamera)
+        XCTAssertTrue(state.showCursor)
+        XCTAssertFalse(state.showClicks)
+        XCTAssertEqual(state.selectedMicrophoneDeviceID, "mic-original")
+        XCTAssertEqual(state.selectedCameraDeviceID, "cam-original")
+
+        XCTAssertEqual(state.applying(.cameraDisabledForCaptureFailure), [])
+        XCTAssertFalse(state.includeCamera)
+    }
+
+    func testDeviceRefreshPreservesExplicitUnavailableSelections() {
+        var state = CaptureOptionsState(
+            includeMicrophone: true,
+            includeCamera: true,
+            microphoneDevices: [CaptureDeviceInfo(id: "mic-old", name: "Old Mic", isDefault: true)],
+            cameraDevices: [CaptureDeviceInfo(id: "cam-old", name: "Old Camera", isDefault: true)],
+            selectedMicrophoneDeviceID: "mic-old",
+            selectedCameraDeviceID: "cam-old"
+        )
+
+        XCTAssertEqual(state.applying(.devicesRefreshed(
+            microphones: [CaptureDeviceInfo(id: "mic-new", name: "New Mic", isDefault: true)],
+            cameras: []
+        )), [])
+
+        XCTAssertEqual(state.selectedMicrophoneDeviceID, "mic-old")
+        XCTAssertEqual(state.selectedCameraDeviceID, "cam-old")
+        XCTAssertEqual(state.selectedMicrophoneDeviceName, "Previously Selected (Unavailable)")
+        XCTAssertEqual(state.selectedCameraDeviceName, "Previously Selected (Unavailable)")
+        XCTAssertFalse(state.hasAvailableMicrophoneSelection)
+        XCTAssertFalse(state.hasAvailableCameraSelection)
+        XCTAssertEqual(state.deviceLoadPhase, .loaded)
+    }
+
+    func testDeviceLoadPhaseAndSystemDefaultsRequireARealDevice() {
+        var state = CaptureOptionsState()
+
+        XCTAssertEqual(state.applying(.deviceRefreshStarted), [])
+        XCTAssertEqual(state.deviceLoadPhase, .loading)
+        XCTAssertEqual(state.applying(.deviceRefreshFailed("Device service unavailable")), [])
+        XCTAssertEqual(state.deviceLoadPhase, .failed("Device service unavailable"))
+        XCTAssertFalse(state.hasAvailableMicrophoneSelection)
+        XCTAssertFalse(state.hasAvailableCameraSelection)
+
+        _ = state.applying(.devicesRefreshed(
+            microphones: [CaptureDeviceInfo(id: "mic-1", name: "Mic", isDefault: true)],
+            cameras: [CaptureDeviceInfo(id: "cam-1", name: "Camera", isDefault: true)]
+        ))
+        XCTAssertTrue(state.hasAvailableMicrophoneSelection)
+        XCTAssertTrue(state.hasAvailableCameraSelection)
+    }
+
+    func testOpeningDeviceSelectorsDoesNotEnumerateDevicesTwice() {
+        var state = CaptureOptionsState(
+            microphoneDevices: [CaptureDeviceInfo(id: "mic-1", name: "Mic", isDefault: true)],
+            cameraDevices: [CaptureDeviceInfo(id: "cam-1", name: "Camera", isDefault: true)],
+            deviceLoadPhase: .loaded
+        )
+
+        XCTAssertEqual(state.applying(.microphoneSelectionRequested), [.showMicrophoneSelector])
+        XCTAssertEqual(state.applying(.cameraSelectionRequested), [.showCameraSelector])
+        XCTAssertEqual(state.deviceLoadPhase, .loaded)
+    }
 }
 
 @MainActor
@@ -1051,7 +1341,10 @@ final class SourceSelectorStateMachineTests: XCTestCase {
         XCTAssertEqual(state.preferredHeight, 532)
 
         XCTAssertEqual(state.applying(.refreshRequested), [.refreshSources])
-        XCTAssertEqual(state.applying(.shareRequested), [.share])
+        XCTAssertEqual(state.loadPhase, .loading)
+        XCTAssertEqual(state.applying(.sourcesChanged(["window-1"])), [])
+        XCTAssertEqual(state.applying(.sourceSelected("window-1")), [])
+        XCTAssertEqual(state.applying(.shareRequested), [.share("window-1")])
         XCTAssertEqual(state.applying(.drawAreaRequested), [.drawArea])
     }
 
@@ -1061,6 +1354,90 @@ final class SourceSelectorStateMachineTests: XCTestCase {
         XCTAssertEqual(state.applying(.preferredSourceKindSynced(.display)), [])
 
         XCTAssertEqual(state.sourceTab, .windows)
+    }
+
+    func testFloatingSelectionRemainsPendingUntilExplicitShare() {
+        var state = SourceSelectorState(sourceTab: .windows, visibleTabs: [.windows, .area])
+        _ = state.applying(.sourcesChanged(["window-1", "window-2"]))
+        _ = state.applying(.committedSelectionSynced("window-1"))
+
+        XCTAssertEqual(state.applying(.sourceSelected("window-2")), [])
+        XCTAssertEqual(state.committedSourceID, "window-1")
+        XCTAssertEqual(state.pendingSourceID, "window-2")
+
+        XCTAssertEqual(state.applying(.cancelRequested), [.cancel])
+        XCTAssertEqual(state.pendingSourceID, "window-1")
+
+        _ = state.applying(.sourceSelected("window-2"))
+        XCTAssertEqual(state.applying(.shareRequested), [.share("window-2")])
+        XCTAssertEqual(state.committedSourceID, "window-2")
+    }
+
+    func testSourceRefreshClearsUnavailablePendingChoiceAndReportsFailures() {
+        var state = SourceSelectorState(sourceTab: .windows, visibleTabs: [.windows])
+        _ = state.applying(.sourcesChanged(["window-1"]))
+        _ = state.applying(.sourceSelected("window-1"))
+
+        let effects = state.applying(.refreshCompleted(SourceSelectorRefreshResult(
+            sourceIDs: [],
+            errorMessage: "Screen Recording permission is required."
+        )))
+
+        XCTAssertEqual(effects, [])
+        XCTAssertNil(state.pendingSourceID)
+        XCTAssertFalse(state.canSharePendingSource)
+        XCTAssertEqual(state.loadPhase, .failed("Screen Recording permission is required."))
+        XCTAssertEqual(state.applying(.shareRequested), [])
+    }
+
+    func testDriverPublishesAsyncRefreshBeforeSharingExactPendingSource() async {
+        let driver = SourceSelectorDriver(sourceTab: .windows, visibleTabs: [.windows])
+        var sharedSourceID: String?
+        driver.configure(
+            refreshSources: {
+                .loaded(sourceIDs: ["window-1"])
+            },
+            share: { sourceID in
+                sharedSourceID = sourceID
+            }
+        )
+
+        driver.send(.refreshRequested)
+        XCTAssertEqual(driver.state.loadPhase, .loading)
+        await waitForCondition {
+            driver.state.loadPhase == .loaded
+        }
+
+        driver.send(.sourceSelected("window-1"))
+        driver.send(.shareRequested)
+
+        XCTAssertEqual(sharedSourceID, "window-1")
+        XCTAssertEqual(driver.state.committedSourceID, "window-1")
+    }
+
+    func testDriverIgnoresCanceledRefreshResultWhenANewerRequestWins() async {
+        let driver = SourceSelectorDriver(sourceTab: .windows, visibleTabs: [.windows])
+        var refreshCount = 0
+        driver.configure(refreshSources: {
+            refreshCount += 1
+            let currentRefresh = refreshCount
+            if currentRefresh == 1 {
+                try? await Task.sleep(for: .milliseconds(200))
+                return .loaded(sourceIDs: ["stale-window"])
+            }
+            return .loaded(sourceIDs: ["fresh-window"])
+        })
+
+        driver.send(.refreshRequested)
+        await waitForCondition { refreshCount == 1 }
+        driver.send(.refreshRequested)
+        await waitForCondition {
+            driver.state.loadPhase == .loaded &&
+                driver.state.availableSourceIDs == ["fresh-window"]
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertEqual(driver.state.availableSourceIDs, ["fresh-window"])
     }
 }
 
@@ -1096,6 +1473,8 @@ final class OnboardingAndSettingsStateMachineTests: XCTestCase {
         XCTAssertEqual(state.autoZoomAnimationPreset, .guided)
         XCTAssertEqual(state.applying(.folderOpenRequested("/tmp")), [.openFolder("/tmp")])
 
+        XCTAssertEqual(state.applying(.serviceRefreshStarted), [])
+        XCTAssertTrue(state.isRefreshingService)
         XCTAssertEqual(state.applying(.serviceRefreshSucceeded), [])
         XCTAssertFalse(state.isRefreshingService)
     }

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
@@ -190,11 +190,212 @@ final class CaptureStateReducerTests: XCTestCase {
 
         let recording = CaptureState.areaSelecting(.recording).applying(.completeInteractiveAreaSelection(source))
         XCTAssertEqual(recording.state.phase, .ready(.recording, source))
-        XCTAssertEqual(recording.effects, [.prepareRecordingFile(source)])
+        XCTAssertEqual(recording.effects, [.showHUD])
 
         let screenshot = CaptureState.areaSelecting(.screenshot).applying(.completeInteractiveAreaSelection(source))
         XCTAssertEqual(screenshot.state.phase, .capturingScreenshot(source))
         XCTAssertEqual(screenshot.effects, [.dismissScreenSelection, .hideAppWindowsForCapture, .runScreenshotCapture(source)])
+    }
+
+    func testCaptureReadinessReportsTypedBlockersBeforeRuntimeWorkBegins() {
+        let selected = makeSource(id: "window:chosen", kind: .window)
+        let missingMicrophoneID = "mic:missing"
+        let state = CaptureState.ready(.recording, selected)
+        let options = CaptureOptionsState(
+            includeMicrophone: true,
+            includeCamera: true,
+            microphoneDevices: [CaptureDeviceInfo(id: "mic:other", name: "Other Mic", isDefault: true)],
+            cameraDevices: [],
+            selectedMicrophoneDeviceID: missingMicrophoneID
+        )
+
+        let readiness = state.readiness(
+            availableSources: [],
+            screenRecordingPermissionState: .requestAlreadyShown,
+            options: options,
+            runtimeIsRecording: false
+        )
+
+        XCTAssertFalse(readiness.canCapture)
+        XCTAssertEqual(readiness.source, selected)
+        XCTAssertEqual(readiness.blockers, [
+            .screenRecordingPermissionNeedsRestart,
+            .sourceUnavailable(name: selected.name),
+            .microphoneUnavailable(deviceID: missingMicrophoneID),
+            .cameraUnavailable(deviceID: nil)
+        ])
+        XCTAssertEqual(readiness.primaryBlocker?.recoveryAction, .openScreenRecordingSettings)
+    }
+
+    func testCaptureReadinessSucceedsOnlyAfterSourcePermissionAndDevicesAreAvailable() {
+        let selected = makeSource(id: "window:chosen", kind: .window)
+        let options = CaptureOptionsState(
+            includeMicrophone: true,
+            includeCamera: true,
+            microphoneDevices: [CaptureDeviceInfo(id: "mic:1", name: "Mic", isDefault: true)],
+            cameraDevices: [CaptureDeviceInfo(id: "cam:1", name: "Camera", isDefault: true)],
+            selectedMicrophoneDeviceID: "mic:1",
+            selectedCameraDeviceID: "cam:1"
+        )
+
+        let ready = CaptureState.ready(.recording, selected).readiness(
+            availableSources: [selected],
+            screenRecordingPermissionState: .granted,
+            options: options,
+            runtimeIsRecording: false
+        )
+        let checking = CaptureState.ready(.recording, selected).readiness(
+            availableSources: [selected],
+            screenRecordingPermissionState: .granted,
+            options: options,
+            runtimeIsRecording: false,
+            isChecking: true
+        )
+
+        XCTAssertTrue(ready.canCapture)
+        XCTAssertEqual(ready.blockers, [])
+        XCTAssertFalse(checking.canCapture)
+        XCTAssertEqual(checking.blockers, [])
+    }
+
+    func testCaptureReadinessReportsDeniedMediaPermissionsBeforeDeviceAvailability() {
+        let selected = makeSource()
+        let options = CaptureOptionsState(
+            includeMicrophone: true,
+            includeCamera: true,
+            microphoneDevices: [],
+            cameraDevices: []
+        )
+
+        let readiness = CaptureState.ready(.recording, selected).readiness(
+            availableSources: [selected],
+            screenRecordingPermissionState: .granted,
+            options: options,
+            runtimeIsRecording: false,
+            microphoneAuthorization: .denied,
+            cameraAuthorization: .denied
+        )
+
+        XCTAssertEqual(readiness.blockers, [
+            .microphonePermissionDenied,
+            .cameraPermissionDenied
+        ])
+        XCTAssertEqual(readiness.blockers.map(\.recoveryAction), [
+            .openMicrophoneSettings,
+            .openCameraSettings
+        ])
+    }
+
+    func testScreenshotReadinessIgnoresRecordingOnlyDeviceChoices() {
+        let selected = makeSource()
+        let options = CaptureOptionsState(
+            includeMicrophone: true,
+            includeCamera: true,
+            microphoneDevices: [],
+            cameraDevices: []
+        )
+
+        let readiness = CaptureState.ready(.screenshot, selected).readiness(
+            availableSources: [selected],
+            screenRecordingPermissionState: .granted,
+            options: options,
+            runtimeIsRecording: false
+        )
+
+        XCTAssertTrue(readiness.canCapture)
+    }
+
+    func testAreaReadinessRequiresCompletedGeometryButNotCatalogMembership() {
+        let placeholder = makeSource(id: "area:interactive", kind: .area)
+        var completed = placeholder
+        completed.area = CaptureArea(x: 10, y: 20, width: 640, height: 360, displayID: 1)
+        let options = CaptureOptionsState()
+
+        let placeholderReadiness = CaptureState.ready(.recording, placeholder).readiness(
+            availableSources: [],
+            screenRecordingPermissionState: .granted,
+            options: options,
+            runtimeIsRecording: false
+        )
+        let completedReadiness = CaptureState.ready(.recording, completed).readiness(
+            availableSources: [],
+            screenRecordingPermissionState: .granted,
+            options: options,
+            runtimeIsRecording: false
+        )
+
+        XCTAssertEqual(placeholderReadiness.blockers, [.areaSelectionRequired])
+        XCTAssertTrue(completedReadiness.canCapture)
+    }
+
+    func testCatalogRefreshNeverChoosesOrSilentlyReplacesASource() {
+        let previous = makeSource(id: "display:2", kind: .display)
+        let unrelated = makeSource(id: "display:1", kind: .display)
+
+        let withoutSelection = CaptureState.selectingSource(.recording)
+            .applying(.refreshSelectedSource(unrelated))
+        XCTAssertNil(withoutSelection.state.selectedSource)
+        XCTAssertEqual(withoutSelection.state.phase, .selectingSource(.recording))
+
+        let missing = CaptureState.ready(.recording, previous)
+            .applying(.refreshSelectedSource(unrelated))
+        XCTAssertNil(missing.state.selectedSource)
+        XCTAssertEqual(missing.state.phase, .selectingSource(.recording))
+        XCTAssertEqual(missing.state.preferredSourceKind, .display)
+        XCTAssertEqual(missing.statusMessage, "Display 1 is no longer available. Choose another source.")
+    }
+
+    func testCatalogRefreshUpdatesMatchingSourceMetadataAndPreservesInteractiveArea() {
+        var previous = makeSource(id: "window:old", kind: .window)
+        previous.ownerBundleID = "com.example.app"
+        previous.windowID = 42
+        var refreshed = previous
+        refreshed.id = "window:new"
+        refreshed.subtitle = "Updated"
+
+        let updated = CaptureState.ready(.recording, previous)
+            .applying(.refreshSelectedSource(refreshed))
+        XCTAssertEqual(updated.state.phase, .ready(.recording, refreshed))
+
+        var area = makeSource(id: "area:interactive", kind: .area)
+        area.area = CaptureArea(x: 0, y: 0, width: 100, height: 100)
+        let preserved = CaptureState.ready(.recording, area)
+            .applying(.refreshSelectedSource(nil))
+        XCTAssertEqual(preserved.state, CaptureState.ready(.recording, area))
+    }
+
+    func testCatalogRefreshDoesNotRetargetToSameTitleWindowWithDifferentWindowID() {
+        var selected = makeSource(id: "window:selected", kind: .window)
+        selected.name = "Document"
+        selected.ownerBundleID = "com.example.editor"
+        selected.windowID = 41
+        var differentWindow = selected
+        differentWindow.id = "window:different"
+        differentWindow.windowID = 42
+
+        let refreshed = CaptureState.ready(.recording, selected)
+            .applying(.refreshSelectedSource(differentWindow))
+
+        XCTAssertNil(refreshed.state.selectedSource)
+        XCTAssertEqual(refreshed.state.phase, .selectingSource(.recording))
+        XCTAssertEqual(refreshed.statusMessage, "Document is no longer available. Choose another source.")
+    }
+
+    func testCatalogRefreshCannotRewriteSourceDuringRuntimeCapture() {
+        let source = makeSource()
+        let states: [CaptureState] = [
+            .countingDownRecording(source),
+            .startingRecording(source),
+            .recording(source),
+            .stoppingRecording(source),
+            .capturingScreenshot(source)
+        ]
+
+        for state in states {
+            let transition = state.applying(.refreshSelectedSource(nil))
+            XCTAssertEqual(transition.state, state)
+            XCTAssertNil(transition.statusMessage)
+        }
     }
 
     private func makeSource(

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorInteractionSemanticsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorInteractionSemanticsTests.swift
@@ -1,0 +1,260 @@
+import CoreGraphics
+import SwiftUI
+import XCTest
+@testable import OpenRecorderMac
+
+final class StudioKeyEventScopeTests: XCTestCase {
+    func testHandlesOnlyEnabledEventsFromOwningKeyWindow() {
+        XCTAssertTrue(StudioKeyEventScope.shouldHandle(
+            isEnabled: true,
+            ownerWindowNumber: 42,
+            eventWindowNumber: 42,
+            ownerWindowIsKey: true
+        ))
+
+        XCTAssertFalse(StudioKeyEventScope.shouldHandle(
+            isEnabled: false,
+            ownerWindowNumber: 42,
+            eventWindowNumber: 42,
+            ownerWindowIsKey: true
+        ))
+        XCTAssertFalse(StudioKeyEventScope.shouldHandle(
+            isEnabled: true,
+            ownerWindowNumber: 42,
+            eventWindowNumber: 7,
+            ownerWindowIsKey: true
+        ))
+        XCTAssertFalse(StudioKeyEventScope.shouldHandle(
+            isEnabled: true,
+            ownerWindowNumber: 42,
+            eventWindowNumber: 42,
+            ownerWindowIsKey: false
+        ))
+    }
+
+    func testRejectsEventsWithoutAResolvedWindow() {
+        XCTAssertFalse(StudioKeyEventScope.shouldHandle(
+            isEnabled: true,
+            ownerWindowNumber: nil,
+            eventWindowNumber: 42,
+            ownerWindowIsKey: true
+        ))
+        XCTAssertFalse(StudioKeyEventScope.shouldHandle(
+            isEnabled: true,
+            ownerWindowNumber: 42,
+            eventWindowNumber: nil,
+            ownerWindowIsKey: true
+        ))
+    }
+
+    func testWindowScopeCacheUpdatesAndClearsAtomically() {
+        let cache = StudioKeyWindowScopeCache()
+        XCTAssertNil(cache.snapshot())
+
+        cache.update(windowNumber: 9, isKey: false)
+        XCTAssertEqual(cache.snapshot()?.windowNumber, 9)
+        XCTAssertEqual(cache.snapshot()?.isKey, false)
+
+        cache.updateIsKey(true)
+        XCTAssertEqual(cache.snapshot()?.isKey, true)
+
+        cache.update(windowNumber: nil, isKey: false)
+        XCTAssertNil(cache.snapshot())
+    }
+}
+
+final class StudioSplitPaneSizingTests: XCTestCase {
+    func testClampsStoredWidthToConfiguredBounds() {
+        XCTAssertEqual(
+            StudioSplitPaneSizing.normalizedSecondarySize(200, minimum: 280, maximum: 440),
+            280
+        )
+        XCTAssertEqual(
+            StudioSplitPaneSizing.normalizedSecondarySize(320, minimum: 280, maximum: 440),
+            320
+        )
+        XCTAssertEqual(
+            StudioSplitPaneSizing.normalizedSecondarySize(500, minimum: 280, maximum: 440),
+            440
+        )
+    }
+
+    func testSanitizesInvalidBoundsAndWidths() {
+        XCTAssertEqual(
+            StudioSplitPaneSizing.normalizedSecondarySize(.nan, minimum: 280, maximum: 440),
+            280
+        )
+        XCTAssertEqual(
+            StudioSplitPaneSizing.normalizedSecondarySize(100, minimum: -20, maximum: .infinity),
+            0
+        )
+        XCTAssertEqual(
+            StudioSplitPaneSizing.normalizedSecondarySize(300, minimum: 440, maximum: 280),
+            440
+        )
+    }
+}
+
+final class TimelineHoverPreviewTests: XCTestCase {
+    private let viewport = TimelineViewport(duration: 100, visibleStart: 20, visibleDuration: 10)
+
+    func testMapsHoverToPreviewTimeWithoutPlaybackState() {
+        XCTAssertEqual(
+            TimelineHoverPreview.time(
+                videoIsAvailable: true,
+                playbackIsActive: false,
+                x: 50,
+                viewport: viewport,
+                width: 100
+            ) ?? -1,
+            25,
+            accuracy: 0.001
+        )
+    }
+
+    func testSuppressesHoverPreviewWithoutVideoOrDuringPlayback() {
+        XCTAssertNil(TimelineHoverPreview.time(
+            videoIsAvailable: false,
+            playbackIsActive: false,
+            x: 50,
+            viewport: viewport,
+            width: 100
+        ))
+        XCTAssertNil(TimelineHoverPreview.time(
+            videoIsAvailable: true,
+            playbackIsActive: true,
+            x: 50,
+            viewport: viewport,
+            width: 100
+        ))
+    }
+
+    func testRejectsInvalidTimelineGeometry() {
+        XCTAssertNil(TimelineHoverPreview.time(
+            videoIsAvailable: true,
+            playbackIsActive: false,
+            x: .nan,
+            viewport: viewport,
+            width: 100
+        ))
+        XCTAssertNil(TimelineHoverPreview.time(
+            videoIsAvailable: true,
+            playbackIsActive: false,
+            x: 50,
+            viewport: viewport,
+            width: 0
+        ))
+    }
+}
+
+final class TimelineFrameStepperTests: XCTestCase {
+    func testUsesSourceFrameRate() {
+        XCTAssertEqual(
+            TimelineFrameStepper.targetTime(
+                currentTime: 1,
+                frameCount: 10,
+                framesPerSecond: 60,
+                duration: 10
+            ),
+            1 + 10.0 / 60.0,
+            accuracy: 0.000_001
+        )
+    }
+
+    func testClampsFrameStepsToMediaBounds() {
+        XCTAssertEqual(
+            TimelineFrameStepper.targetTime(
+                currentTime: 0.1,
+                frameCount: -10,
+                framesPerSecond: 30,
+                duration: 10
+            ),
+            0
+        )
+        XCTAssertEqual(
+            TimelineFrameStepper.targetTime(
+                currentTime: 9.9,
+                frameCount: 10,
+                framesPerSecond: 30,
+                duration: 10
+            ),
+            10
+        )
+    }
+
+    func testFallsBackForInvalidFrameRateAndTimes() {
+        XCTAssertEqual(TimelineSourceFrameRate.normalized(.nan), 30)
+        XCTAssertEqual(TimelineSourceFrameRate.normalized(0), 30)
+        XCTAssertEqual(TimelineSourceFrameRate.normalized(241), 30)
+        XCTAssertEqual(TimelineSourceFrameRate.normalized(59.94), 59.94, accuracy: 0.001)
+
+        XCTAssertEqual(
+            TimelineFrameStepper.targetTime(
+                currentTime: .nan,
+                frameCount: 10,
+                framesPerSecond: .infinity,
+                duration: .infinity
+            ),
+            0
+        )
+    }
+}
+
+final class PreviewPlaybackSpeedSelectionTests: XCTestCase {
+    func testCalculatesForwardCycleCountForExplicitSelection() {
+        let speeds = [1.0, 2.0, 4.0, 8.0]
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.cycleCount(from: 1, to: 4, availableSpeeds: speeds), 2)
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.cycleCount(from: 8, to: 2, availableSpeeds: speeds), 2)
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.cycleCount(from: 2, to: 2, availableSpeeds: speeds), 0)
+    }
+
+    func testRejectsUnsupportedSelectionAndFormatsLabels() {
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.cycleCount(from: 1, to: 3, availableSpeeds: [1, 2, 4]), 0)
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.label(for: 2), "2x")
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.label(for: 1.25), "1.25x")
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.label(for: .infinity), "1x")
+        XCTAssertEqual(PreviewPlaybackSpeedSelection.label(for: .nan), "1x")
+    }
+}
+
+final class InspectorAvailabilityTests: XCTestCase {
+    func testHidesInertAudioTabWithoutRemovingCompatibilityCase() {
+        XCTAssertFalse(InspectorTab.availableCases.contains(.audio))
+        XCTAssertEqual(InspectorTab.availableCases, [.appearance, .cursor, .camera])
+        XCTAssertTrue(InspectorTab.allCases.contains(.audio))
+    }
+}
+
+final class EditorControlCompatibilityTests: XCTestCase {
+    @MainActor
+    func testResizableSplitPaneLegacyInitializerRemainsAvailable() {
+        let split = ResizableStudioSplitPane(
+            secondarySize: .constant(320),
+            minPrimarySize: 520,
+            minSecondarySize: 280,
+            maxSecondarySize: 440,
+            spacing: 12
+        ) {
+            EmptyView()
+        } secondary: {
+            EmptyView()
+        }
+
+        _ = split.body
+    }
+
+    @MainActor
+    func testScreenshotSettingsLegacyExportInitializerRemainsAvailable() {
+        let panel = ScreenshotSettingsPanel(
+            background: .constant(.transparent),
+            padding: .constant(18),
+            backgroundRoundness: .constant(12),
+            backgroundShadow: .constant(0.35),
+            imageRoundness: .constant(0),
+            imageShadow: .constant(0),
+            onExport: {}
+        )
+
+        _ = panel.body
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectLibraryAndSettingsViewStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectLibraryAndSettingsViewStateTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import XCTest
+@testable import OpenRecorderMac
+
+final class ProjectLibraryViewStateTests: XCTestCase {
+    func testProjectQueryFiltersBySelectedMediaKind() {
+        let recording = makeProject(id: "recording", title: "Demo", recordingPath: "/media/demo.mov")
+        let screenshot = makeProject(id: "screenshot", title: "Still", screenshotPath: "/media/still.png")
+
+        XCTAssertEqual(
+            ProjectLibraryQuery.projects(
+                from: [screenshot, recording],
+                tab: .screenRecordings,
+                searchText: "",
+                sortOrder: []
+            ).map(\.id),
+            ["recording"]
+        )
+        XCTAssertEqual(
+            ProjectLibraryQuery.projects(
+                from: [recording, screenshot],
+                tab: .screenshots,
+                searchText: "",
+                sortOrder: []
+            ).map(\.id),
+            ["screenshot"]
+        )
+    }
+
+    func testProjectQueryMatchesAllNormalizedTermsAcrossMetadata() {
+        let matching = makeProject(
+            id: "matching",
+            title: "Café walkthrough",
+            sourceName: "Design Review",
+            recordingPath: "/media/walkthrough.mov"
+        )
+        let other = makeProject(
+            id: "other",
+            title: "Café walkthrough",
+            sourceName: "Engineering",
+            recordingPath: "/media/engineering.mov"
+        )
+
+        let result = ProjectLibraryQuery.projects(
+            from: [other, matching],
+            tab: .screenRecordings,
+            searchText: "  CAFE   review ",
+            sortOrder: []
+        )
+
+        XCTAssertEqual(result.map(\.id), ["matching"])
+    }
+
+    func testProjectQueryUsesMediaFileNameWhenSourceNameIsAbsent() {
+        let project = makeProject(
+            id: "recording",
+            title: "Untitled",
+            recordingPath: "/media/Quarterly-Demo.mov"
+        )
+
+        let result = ProjectLibraryQuery.projects(
+            from: [project],
+            tab: .screenRecordings,
+            searchText: "quarterly",
+            sortOrder: []
+        )
+
+        XCTAssertEqual(result.map(\.id), ["recording"])
+        XCTAssertEqual(projectSourceDisplayName(project), "Quarterly-Demo.mov")
+
+        var blankSource = project
+        blankSource.sourceName = "  \n"
+        XCTAssertEqual(projectSourceDisplayName(blankSource), "Quarterly-Demo.mov")
+    }
+
+    func testDefaultProjectSortUsesActualDatesAcrossStoredFormats() {
+        let january = makeProject(id: "january", title: "January", lastOpenedAt: "1767225600")
+        let february = makeProject(id: "february", title: "February", lastOpenedAt: "2026-02-01T00:00:00Z")
+        let unknown = makeProject(id: "unknown", title: "Unknown", lastOpenedAt: "not-a-date")
+
+        let result = ProjectLibraryQuery.projects(
+            from: [unknown, january, february],
+            tab: .screenRecordings,
+            searchText: "",
+            sortOrder: []
+        )
+
+        XCTAssertEqual(result.map(\.id), ["february", "january", "unknown"])
+    }
+
+    func testProjectSortSupportsNativeTableColumns() {
+        let alpha = makeProject(id: "alpha", title: "Alpha", sourceName: "Window B")
+        let beta = makeProject(id: "beta", title: "Beta", sourceName: "Window A")
+
+        let titleAscending = ProjectLibraryQuery.projects(
+            from: [beta, alpha],
+            tab: .screenRecordings,
+            searchText: "",
+            sortOrder: [ProjectLibraryComparator(field: .title)]
+        )
+        let sourceDescending = ProjectLibraryQuery.projects(
+            from: [alpha, beta],
+            tab: .screenRecordings,
+            searchText: "",
+            sortOrder: [ProjectLibraryComparator(field: .source, order: .reverse)]
+        )
+
+        XCTAssertEqual(titleAscending.map(\.id), ["alpha", "beta"])
+        XCTAssertEqual(sourceDescending.map(\.id), ["alpha", "beta"])
+    }
+
+    func testInvalidProjectDateFormatsAsUnknownInsteadOfCurrentTime() {
+        XCTAssertNil(projectDate("not-a-date"))
+        XCTAssertEqual(formattedProjectDate("not-a-date"), "Unknown")
+    }
+
+    func testProjectAvailabilityControlsOpenBehaviorAndSpecificStatus() {
+        var missingMedia = makeProject(id: "missing-media", title: "Missing media")
+        missingMedia.availability = .missingMedia
+
+        XCTAssertFalse(missingMedia.isOpenableFromLibrary)
+        XCTAssertEqual(missingMedia.libraryAvailabilityLabel, "Media missing")
+
+        var legacyMissing = makeProject(id: "legacy-missing", title: "Legacy missing")
+        legacyMissing.missing = true
+        legacyMissing.availability = .available
+
+        XCTAssertFalse(legacyMissing.isOpenableFromLibrary)
+        XCTAssertEqual(legacyMissing.libraryAvailabilityLabel, "Unavailable")
+    }
+}
+
+final class SettingsViewPresentationStateTests: XCTestCase {
+    func testServiceStartsAsNotCheckedInsteadOfClaimingFailure() {
+        let state = settingsServicePresentationState(
+            health: nil,
+            isRefreshing: false,
+            statusMessage: ""
+        )
+
+        XCTAssertEqual(state, .notChecked)
+        XCTAssertEqual(state.value, "Not checked")
+        XCTAssertFalse(state.isChecking)
+    }
+
+    func testRefreshingServiceKeepsTheLastKnownValueVisible() {
+        let health = HealthPayload(service: "open-recorder", version: "1.2.3", platform: "macOS")
+
+        let state = settingsServicePresentationState(
+            health: health,
+            isRefreshing: true,
+            statusMessage: "Checking service..."
+        )
+
+        XCTAssertEqual(state, .checking(previousValue: "open-recorder 1.2.3"))
+        XCTAssertEqual(state.value, "open-recorder 1.2.3")
+        XCTAssertTrue(state.isChecking)
+    }
+
+    func testAvailableServiceUsesTheSuccessfulMachineStatus() {
+        let health = HealthPayload(service: "open-recorder", version: "2.0", platform: "macOS")
+
+        XCTAssertEqual(
+            settingsServicePresentationState(
+                health: health,
+                isRefreshing: false,
+                statusMessage: "Rust service ready"
+            ),
+            .available("open-recorder 2.0")
+        )
+    }
+
+    func testFailedRefreshDoesNotHideBehindStaleHealth() {
+        let health = HealthPayload(service: "open-recorder", version: "2.0", platform: "macOS")
+
+        XCTAssertEqual(
+            settingsServicePresentationState(
+                health: health,
+                isRefreshing: false,
+                statusMessage: "Service stopped responding."
+            ),
+            .unavailable("Service stopped responding.")
+        )
+    }
+
+    func testUnavailableServicePreservesAUsefulTrimmedFailure() {
+        let state = settingsServicePresentationState(
+            health: nil,
+            isRefreshing: false,
+            statusMessage: "  Service executable was not found.\n"
+        )
+
+        XCTAssertEqual(state, .unavailable("Service executable was not found."))
+        XCTAssertEqual(state.value, "Unavailable")
+        XCTAssertEqual(state.detail, "Service executable was not found.")
+    }
+}
+
+private func makeProject(
+    id: String,
+    title: String,
+    sourceName: String? = nil,
+    recordingPath: String? = "/media/demo.mov",
+    screenshotPath: String? = nil,
+    lastOpenedAt: String = "1767225600"
+) -> ProjectSummary {
+    ProjectSummary(
+        id: id,
+        title: title,
+        path: "/projects/\(id).openrecorder",
+        recordingPath: recordingPath,
+        screenshotPath: screenshotPath,
+        sourceName: sourceName,
+        createdAt: "1767225600",
+        updatedAt: lastOpenedAt,
+        lastOpenedAt: lastOpenedAt,
+        missing: false
+    )
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ProjectSummaryTests.swift
@@ -44,6 +44,61 @@ final class ProjectSummaryTests: XCTestCase {
         XCTAssertNil(summary.screenshotPath)
         XCTAssertEqual(summary.mediaKind, .video)
         XCTAssertEqual(summary.mediaPath, "/tmp/recording.mp4")
+        XCTAssertEqual(summary.availability, .available)
+    }
+
+    func testLegacyMissingSummaryDecodesAsUnavailable() throws {
+        let json = """
+        {
+            "id": "project-1",
+            "title": "Project",
+            "path": "/tmp/project.openrecorder",
+            "recordingPath": "/tmp/recording.mp4",
+            "createdAt": "2026-06-26T00:00:00Z",
+            "updatedAt": "2026-06-26T00:00:00Z",
+            "lastOpenedAt": "2026-06-26T00:00:00Z",
+            "missing": true
+        }
+        """
+
+        let summary = try JSONDecoder().decode(ProjectSummary.self, from: Data(json.utf8))
+
+        XCTAssertTrue(summary.missing)
+        XCTAssertEqual(summary.availability, .unavailable)
+    }
+
+    func testDetailedAvailabilityDecodesWithoutChangingLegacyMissingFlag() throws {
+        let json = """
+        {
+            "id": "project-1",
+            "title": "Project",
+            "path": "/tmp/project.openrecorder",
+            "recordingPath": "/tmp/recording.mp4",
+            "createdAt": "2026-06-26T00:00:00Z",
+            "updatedAt": "2026-06-26T00:00:00Z",
+            "lastOpenedAt": "2026-06-26T00:00:00Z",
+            "missing": true,
+            "availability": "missingMedia"
+        }
+        """
+
+        let summary = try JSONDecoder().decode(ProjectSummary.self, from: Data(json.utf8))
+
+        XCTAssertTrue(summary.missing)
+        XCTAssertEqual(summary.availability, .missingMedia)
+    }
+
+    func testEncodingPreservesLegacyAndDetailedAvailabilityFields() throws {
+        var summary = makeProjectSummary(recordingPath: "/tmp/recording.mp4", screenshotPath: nil)
+        summary.missing = true
+        summary.availability = .missingProject
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(summary)) as? [String: Any]
+        )
+
+        XCTAssertEqual(object["missing"] as? Bool, true)
+        XCTAssertEqual(object["availability"] as? String, "missingProject")
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/ScreenRecordingPermissionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/ScreenRecordingPermissionTests.swift
@@ -17,6 +17,7 @@ final class ScreenRecordingPermissionTests: XCTestCase {
         ))
         let controller = CaptureController(screenRecordingPermission: permission)
 
+        XCTAssertEqual(controller.screenRecordingPermissionState, .granted)
         try controller.ensureScreenRecordingPermissionForTesting()
 
         XCTAssertEqual(requestCount, 0)
@@ -123,5 +124,57 @@ final class ScreenRecordingPermissionTests: XCTestCase {
 
         XCTAssertEqual(requestCount, 0)
         XCTAssertFalse(controller.sources.isEmpty)
+        XCTAssertEqual(controller.sourceCatalogState, .permissionRequired)
+        XCTAssertEqual(
+            controller.sourceCatalogState.issueMessage,
+            "Screen Recording permission is required to list current screens and windows."
+        )
+    }
+
+    func testPreviewRefreshReportsDeniedPermissionInsteadOfPresentingFallbackAsFresh() async {
+        var requestCount = 0
+        var promptRequested = false
+        let permission = ScreenRecordingPermission(client: ScreenRecordingPermissionClient(
+            preflight: { false },
+            request: {
+                requestCount += 1
+                return false
+            },
+            hasRequestedPrompt: { promptRequested },
+            setRequestedPrompt: { promptRequested = $0 }
+        ))
+        let controller = CaptureController(screenRecordingPermission: permission)
+
+        await controller.reloadSources(requestScreenRecordingPermission: true)
+
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertEqual(controller.screenRecordingPermissionState, .requestAlreadyShown)
+        XCTAssertEqual(controller.sourceCatalogState, .permissionRequired)
+    }
+
+    func testInjectedSourcesMarkCatalogAsLoadedForDeterministicConsumers() {
+        let permission = ScreenRecordingPermission(client: ScreenRecordingPermissionClient(
+            preflight: { false },
+            request: { false },
+            hasRequestedPrompt: { false },
+            setRequestedPrompt: { _ in }
+        ))
+        let controller = CaptureController(screenRecordingPermission: permission)
+        let source = CaptureSource(
+            id: "display:1",
+            kind: .display,
+            name: "Display 1",
+            subtitle: "Built-in",
+            displayIndex: 1,
+            displayID: 1,
+            windowID: nil,
+            area: nil,
+            thumbnailData: nil
+        )
+
+        controller.setSourcesForTesting([source])
+
+        XCTAssertEqual(controller.sources, [source])
+        XCTAssertEqual(controller.sourceCatalogState, .loaded)
     }
 }


### PR DESCRIPTION
## Description

Improves the macOS app's recording, project-library, editor, and shutdown workflows by using native semantic controls and explicit state handling while retaining the existing visual system.

### Capture correctness

- Adds typed capture readiness and recovery actions, strict source identity, pending source selection, permission and device preflight, and immutable recording-option snapshots.
- Preserves a committed source when a source-change sheet is canceled and prevents capture setup, countdown, or screenshot cancellation races.
- Skips camera and microphone discovery for screen-only recordings.

### Projects and settings

- Uses native searchable and sortable single-selection tables, segmented pickers, toggles, control groups, default and cancel actions, and accurate loading, stale, failure, and empty states.
- Keeps legacy project-summary decoding compatible while distinguishing missing, unavailable, and corrupt project data.
- Coalesces same-media imports and provides durable local recovery when the Rust service is unavailable.

### Editor and lifecycle

- Uses a native split view, source-FPS-aware frame stepping, non-mutating timeline hover previews, window-scoped key monitors, and semantic export controls.
- Waits for autosaves, imports, and exports before close or quit; active capture and save-pending work now block termination safely.

Preferred rollout: merge the backward-compatible service durability companion, #993, first. This PR remains compatible with the service currently on `main`.

## Motivation

Several workflows looked complete but had ambiguous state transitions, silent fallback behavior, non-semantic controls, and shutdown or service-outage paths that could surprise users. This change tightens those behaviors without a styling redesign or a data-format break.

## Type of Change

- [x] New Feature
- [x] Bug Fix
- [x] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Companion service durability PR: #993.

## Screenshots / Video

Not included. The existing visual system is intentionally retained; this PR changes control semantics, state behavior, accessibility, and recovery paths rather than restyling the interface.

## Testing Guide

From `apps/macos`:

```bash
swift test --scratch-path /tmp/open-recorder-swift-build
```

Expected: 560 Swift tests pass.

Suggested behavior checks:

1. Start a window recording, change the selected source, cancel the chooser, and verify the prior ready source remains selected.
2. Deny camera or microphone access and verify the preflight provides a recovery action before hiding windows or starting a countdown.
3. Open raw media while the service is unavailable, relaunch, and verify the same durable local project is rediscovered without duplication.
4. Start an export or autosave, request close or quit, and verify termination waits or focuses the blocking editor instead of silently canceling work.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos. (Not applicable; no visual redesign.)
- [x] I have linked related issue(s) and updated the changelog if applicable. (Companion linked; no release bump in a feature PR.)
