### PR TITLE
fix(macos): camera bubble position & boundaries, waveform accent glow, and capture stability

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -890,18 +890,18 @@ final class AppModel: ObservableObject {
 
         if let selectedSource {
             let resolved = resolveSelection(previous: selectedSource, in: capture.sources)
-            dispatch(.refreshSelectedSource(resolved))
-        } else if !hasAttemptedStoredCaptureSetupRestore {
-            hasAttemptedStoredCaptureSetupRestore = true
+            dispatch(.refreshSelectedSource(resolved ?? capture.sources.first(where: { $0.kind == .display })))
+        } else if let primaryDisplay = capture.sources.first(where: { $0.kind == .display }) {
             let restoredSource = storedCaptureSetup.sourceReference?.resolve(
                 in: capture.sources,
                 displayFrames: NSScreen.captureDisplayFramesByID
-            )
+            ) ?? primaryDisplay
             dispatch(.restoreSetup(
                 storedCaptureSetup.mode,
                 restoredSource,
                 preferredSourceKind: storedCaptureSetup.preferredSourceKind
             ))
+            dispatch(.selectSource(restoredSource))
         }
     }
 
@@ -1517,6 +1517,7 @@ final class AppModel: ObservableObject {
 
     private func runRecordingStopFlow(source: CaptureSource?) async {
         do {
+            let capturedFacecamSettings = resolveFacecamSettingsForRecording(source: source)
             let outputURL = try await stopRecordingCapture()
             let stoppedFacecamURL = try? await stopFacecam()
             let cursorTelemetryURL = cursorTelemetryRecorder.stop(videoURL: outputURL)
@@ -1532,6 +1533,7 @@ final class AppModel: ObservableObject {
                 let recordingSession = RecordingSessionBuilder.build(
                     screenVideoURL: outputURL,
                     facecamURL: stoppedFacecamURL ?? activeFacecamURL,
+                    facecamSettings: capturedFacecamSettings,
                     sourceName: sourceName,
                     showCursor: showCursor,
                     cursorTelemetryURL: cursorTelemetryURL,
@@ -2231,6 +2233,46 @@ final class AppModel: ObservableObject {
         return seconds.isFinite && seconds > 0 ? seconds : 0
     }
 
+    private func resolveFacecamSettingsForRecording(source: CaptureSource?) -> FacecamSettings {
+        let shapeString = UserDefaults.standard.string(forKey: "camera_bubble_shape") ?? "circle"
+        let diameter = UserDefaults.standard.double(forKey: "camera_bubble_diameter")
+        let resolvedDiameter = diameter > 0 ? diameter : 220.0
+
+        var resolvedAnchor: FacecamAnchor = .bottomRight
+
+        if let bubbleWindow = NSApp.windows.first(where: { $0.title == "Camera Preview" }) {
+            let windowFrame = bubbleWindow.frame
+            let targetScreen: NSScreen = {
+                if let source,
+                   let screen = NSScreen.screens.first(where: { "\($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] ?? "")" == source.id }) {
+                    return screen
+                }
+                return bubbleWindow.screen ?? NSScreen.main ?? NSScreen.screens.first ?? NSScreen()
+            }()
+
+            let screenBounds = targetScreen.frame
+            if screenBounds.width > 0 && screenBounds.height > 0 {
+                let relX = (windowFrame.midX - screenBounds.minX) / screenBounds.width
+                let relYFromTop = (screenBounds.maxY - windowFrame.midY) / screenBounds.height
+                resolvedAnchor = FacecamAnchor.from(relX: relX, relYFromTop: relYFromTop)
+            }
+        }
+
+        let screenLength = (NSScreen.main?.frame.height ?? 1080.0)
+        let sizePercent = max(14.0, min(36.0, (resolvedDiameter / screenLength) * 100.0))
+
+        return FacecamSettings(
+            enabled: true,
+            shape: shapeString,
+            size: sizePercent,
+            cornerRadius: shapeString == "circle" ? 100 : (shapeString == "square" ? 16 : 12),
+            borderWidth: 0,
+            borderColor: "#FFFFFF",
+            margin: 4,
+            anchor: resolvedAnchor.rawValue
+        )
+    }
+
     private func recordingSession(for document: ProjectDocument, recordingURL: URL) -> RecordingSession {
         if let recordingSession = document.recordingSession {
             return recordingSession
@@ -2589,6 +2631,7 @@ final class AppModel: ObservableObject {
                 try await self.facecamRecorder.prepare(cameraDeviceID: options.cameraDeviceID)
                 if !Task.isCancelled {
                     self.facecamPrewarmTask = nil
+                    self.objectWillChange.send()
                 }
             } catch {
                 guard !Task.isCancelled else { return }

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -217,6 +217,8 @@ final class AppModel: ObservableObject {
     @Published private(set) var isCapturePreflightRunning = false
     @Published private(set) var isTerminationPending = false
     @Published private(set) var activeRecordingStartDate: Date? = nil
+    @Published private(set) var shortcutPreferences: ShortcutPreferences = .defaultPreferences
+    @Published private(set) var isDragRecordingPending = false
     private var displayFlashWindows: [NSWindow] = []
     private let countdownOverlayController = RecordingCountdownOverlayController()
     private let captureUIHideDelayNanoseconds: UInt64
@@ -518,6 +520,11 @@ final class AppModel: ObservableObject {
             persistAutoZoomAnimationPreset: { [weak self] preset in
                 self?.recordingPreferences.setAutoZoomAnimationPreset(preset)
             },
+            persistShortcuts: { [weak self] shortcuts in
+                self?.recordingPreferences.setShortcuts(shortcuts)
+                self?.shortcutPreferences = shortcuts
+                self?.objectWillChange.send()
+            },
             openFolder: { [weak self] path in
                 self?.openPath(path)
             },
@@ -534,8 +541,10 @@ final class AppModel: ObservableObject {
                 self?.objectWillChange.send()
             }
         )
+        self.shortcutPreferences = preferences.shortcuts
         appShell.settings.send(.autoZoomPreferenceSynced(preferences.createsZoomsAutomatically))
         appShell.settings.send(.autoZoomAnimationPresetSynced(preferences.autoZoomAnimationPreset))
+        appShell.settings.send(.shortcutsSynced(preferences.shortcuts))
         refreshOnboardingPermissionStates()
         syncAppShellMirror()
         dispatch(.restoreSetup(
@@ -1123,7 +1132,10 @@ final class AppModel: ObservableObject {
     func completeInteractiveAreaSelection(_ area: CaptureArea) {
         guard !rejectActionWhileTerminationIsPending() else { return }
         let source = interactiveAreaSource(area: area)
-        let shouldCaptureImmediately = captureMode == .screenshot
+        let shouldCaptureScreenshotImmediately = captureMode == .screenshot
+        let shouldRecordImmediately = captureMode == .recording && isDragRecordingPending
+        isDragRecordingPending = false
+
         if captureMode == .screenshot,
            capture.screenRecordingPermissionState != .granted {
             dispatch(.completeInteractiveAreaSelection(source))
@@ -1134,16 +1146,20 @@ final class AppModel: ObservableObject {
         }
         dispatch(.completeInteractiveAreaSelection(source))
         persistCaptureSetup(source: source)
-        if shouldCaptureImmediately {
+        if shouldCaptureScreenshotImmediately {
             takeScreenshot()
+        } else if shouldRecordImmediately {
+            startRecording()
         }
     }
 
     func cancelInteractiveAreaSelection() {
+        isDragRecordingPending = false
         dispatch(.cancelInteractiveAreaSelection)
     }
 
     func cancelCapture() {
+        isDragRecordingPending = false
         capturePreflightGeneration += 1
         capturePreflightTask?.cancel()
         capturePreflightTask = nil
@@ -1153,6 +1169,79 @@ final class AppModel: ObservableObject {
         isCapturePreflightRunning = false
         captureOptions.send(.availabilityChanged(canChangeRecordingOptions))
         dispatch(.cancelCapture)
+    }
+
+    @MainActor
+    func triggerDeviceScreenshot() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        guard !capture.isRecording else {
+            statusMessage = "Finish or cancel current capture first."
+            focusActiveCaptureWindow()
+            return
+        }
+        guard ensureScreenRecordingPermissionForCapture() else { return }
+
+        let displaySource = capture.sources.first(where: { $0.kind == .display })
+            ?? selectedSource
+            ?? CaptureSource(id: "display:primary", kind: .display, name: "Entire Screen", subtitle: "", displayIndex: nil, displayID: nil, windowID: nil, area: nil, thumbnailData: nil)
+
+        dispatch(.beginCapture(.screenshot, runtimeIsRecording: false))
+        dispatch(.selectSource(displaySource))
+        persistCaptureSetup(source: displaySource)
+        takeScreenshot()
+    }
+
+    @MainActor
+    func triggerDragScreenshot() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        guard !capture.isRecording else {
+            statusMessage = "Finish or cancel current capture first."
+            focusActiveCaptureWindow()
+            return
+        }
+        guard ensureScreenRecordingPermissionForCapture() else { return }
+
+        dispatch(.beginCapture(.screenshot, runtimeIsRecording: false))
+        requestInteractiveAreaSelection()
+    }
+
+    @MainActor
+    func triggerDeviceScreenRecord() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        if capture.isRecording || recordingPhase != .idle {
+            stopRecording()
+            return
+        }
+        guard ensureScreenRecordingPermissionForCapture() else { return }
+
+        let displaySource = capture.sources.first(where: { $0.kind == .display })
+            ?? selectedSource
+            ?? CaptureSource(id: "display:primary", kind: .display, name: "Entire Screen", subtitle: "", displayIndex: nil, displayID: nil, windowID: nil, area: nil, thumbnailData: nil)
+
+        dispatch(.beginCapture(.recording, runtimeIsRecording: false))
+        dispatch(.selectSource(displaySource))
+        persistCaptureSetup(source: displaySource)
+        startRecording()
+    }
+
+    @MainActor
+    func triggerDragScreenRecord() {
+        guard !rejectActionWhileTerminationIsPending() else { return }
+        if capture.isRecording || recordingPhase != .idle {
+            stopRecording()
+            return
+        }
+        guard ensureScreenRecordingPermissionForCapture() else { return }
+
+        dispatch(.beginCapture(.recording, runtimeIsRecording: false))
+        isDragRecordingPending = true
+        requestInteractiveAreaSelection()
+    }
+
+    func updateShortcutPreferences(_ shortcuts: ShortcutPreferences) {
+        self.shortcutPreferences = shortcuts
+        self.recordingPreferences.setShortcuts(shortcuts)
+        self.appShell.settings.send(.shortcutsSynced(shortcuts))
     }
 
     func requestWindow(_ action: NativeWindowCommandAction, editorSession: EditorSession? = nil) {

--- a/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
@@ -667,6 +667,7 @@ final class OnboardingDriver {
 struct SettingsMachineState: Equatable {
     var createZoomsAutomatically: Bool
     var autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced
+    var shortcuts: ShortcutPreferences = .defaultPreferences
     var statusMessage = ""
     var isRefreshingService = false
 }
@@ -680,6 +681,9 @@ enum SettingsEvent: Equatable {
     case autoZoomPreferenceChanged(Bool)
     case autoZoomAnimationPresetSynced(TimelineZoomAnimationPreset)
     case autoZoomAnimationPresetChanged(TimelineZoomAnimationPreset)
+    case shortcutsSynced(ShortcutPreferences)
+    case shortcutItemChanged(ShortcutItem)
+    case shortcutsResetToDefaults
     case folderOpenRequested(String?)
     case screenRecordingSettingsRequested
     case accessibilitySettingsRequested
@@ -690,6 +694,7 @@ enum SettingsEffect: Equatable {
     case refreshService
     case persistAutoZoomPreference(Bool)
     case persistAutoZoomAnimationPreset(TimelineZoomAnimationPreset)
+    case persistShortcuts(ShortcutPreferences)
     case openFolder(String)
     case openScreenRecordingSettings
     case openAccessibilitySettings
@@ -737,6 +742,18 @@ extension SettingsMachineState {
             autoZoomAnimationPreset = preset
             return [.persistAutoZoomAnimationPreset(preset)]
 
+        case .shortcutsSynced(let shortcuts):
+            self.shortcuts = shortcuts
+            return []
+
+        case .shortcutItemChanged(let item):
+            shortcuts.setItem(item)
+            return [.persistShortcuts(shortcuts)]
+
+        case .shortcutsResetToDefaults:
+            shortcuts = .defaultPreferences
+            return [.persistShortcuts(shortcuts)]
+
         case .folderOpenRequested(let path):
             guard let path else { return [] }
             return [.openFolder(path)]
@@ -761,16 +778,22 @@ final class SettingsDriver {
     @ObservationIgnored private var refreshService: () -> Void = {}
     @ObservationIgnored private var persistAutoZoomPreference: (Bool) -> Void = { _ in }
     @ObservationIgnored private var persistAutoZoomAnimationPreset: (TimelineZoomAnimationPreset) -> Void = { _ in }
+    @ObservationIgnored private var persistShortcuts: (ShortcutPreferences) -> Void = { _ in }
     @ObservationIgnored private var openFolder: (String) -> Void = { _ in }
     @ObservationIgnored private var openScreenRecordingSettings: () -> Void = {}
     @ObservationIgnored private var openAccessibilitySettings: () -> Void = {}
     @ObservationIgnored private var showOnboarding: () -> Void = {}
     @ObservationIgnored private var stateWillChange: () -> Void = {}
 
-    init(createZoomsAutomatically: Bool, autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced) {
+    init(
+        createZoomsAutomatically: Bool,
+        autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced,
+        shortcuts: ShortcutPreferences = .defaultPreferences
+    ) {
         state = SettingsMachineState(
             createZoomsAutomatically: createZoomsAutomatically,
-            autoZoomAnimationPreset: autoZoomAnimationPreset
+            autoZoomAnimationPreset: autoZoomAnimationPreset,
+            shortcuts: shortcuts
         )
     }
 
@@ -778,6 +801,7 @@ final class SettingsDriver {
         refreshService: @escaping () -> Void = {},
         persistAutoZoomPreference: @escaping (Bool) -> Void = { _ in },
         persistAutoZoomAnimationPreset: @escaping (TimelineZoomAnimationPreset) -> Void = { _ in },
+        persistShortcuts: @escaping (ShortcutPreferences) -> Void = { _ in },
         openFolder: @escaping (String) -> Void = { _ in },
         openScreenRecordingSettings: @escaping () -> Void = {},
         openAccessibilitySettings: @escaping () -> Void = {},
@@ -787,6 +811,7 @@ final class SettingsDriver {
         self.refreshService = refreshService
         self.persistAutoZoomPreference = persistAutoZoomPreference
         self.persistAutoZoomAnimationPreset = persistAutoZoomAnimationPreset
+        self.persistShortcuts = persistShortcuts
         self.openFolder = openFolder
         self.openScreenRecordingSettings = openScreenRecordingSettings
         self.openAccessibilitySettings = openAccessibilitySettings
@@ -818,6 +843,13 @@ final class SettingsDriver {
         )
     }
 
+    func shortcutBinding(for action: CaptureShortcutAction) -> Binding<ShortcutItem> {
+        Binding(
+            get: { self.state.shortcuts.item(for: action) },
+            set: { self.send(.shortcutItemChanged($0)) }
+        )
+    }
+
     private func perform(_ effects: [SettingsEffect]) {
         for effect in effects {
             switch effect {
@@ -827,6 +859,8 @@ final class SettingsDriver {
                 persistAutoZoomPreference(value)
             case .persistAutoZoomAnimationPreset(let preset):
                 persistAutoZoomAnimationPreset(preset)
+            case .persistShortcuts(let shortcuts):
+                persistShortcuts(shortcuts)
             case .openFolder(let path):
                 openFolder(path)
             case .openScreenRecordingSettings:

--- a/apps/macos/Sources/OpenRecorderMac/BackgroundPickerView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/BackgroundPickerView.swift
@@ -64,26 +64,14 @@ struct BackgroundPickerView: View {
                                 activate(kind)
                             } label: {
                                 Image(systemName: kind.symbolName)
-                                    .font(.system(size: 12.5, weight: isSelected ? .bold : .medium))
+                                    .font(.system(size: 13, weight: isSelected ? .bold : .medium))
                                     .foregroundStyle(
                                         isSelected
-                                            ? kind.accentColor
-                                            : (hoveredKind == kind ? Color.white : Theme.fgMuted.opacity(0.72))
+                                            ? Color.white
+                                            : (hoveredKind == kind ? Color.white : Theme.fgMuted)
                                     )
                                     .frame(width: 28, height: 28)
-                                    .background(
-                                        isSelected
-                                            ? kind.accentColor.opacity(0.18)
-                                            : (hoveredKind == kind ? Color.white.opacity(0.06) : Color.clear),
-                                        in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    )
-                                    .overlay {
-                                        if isSelected {
-                                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                                .stroke(kind.accentColor.opacity(0.55), lineWidth: 1)
-                                        }
-                                    }
-                                    .shadow(color: isSelected ? kind.accentColor.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                                    .contentShape(Rectangle())
                             }
                             .onHover { isHovering in
                                 hoveredKind = isHovering ? kind : (hoveredKind == kind ? nil : hoveredKind)
@@ -97,17 +85,10 @@ struct BackgroundPickerView: View {
                         chooseCustomFile()
                     } label: {
                         Image(systemName: "plus")
-                            .font(.system(size: 12, weight: .bold))
-                            .foregroundStyle(Theme.accent)
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(Theme.fgMuted)
                             .frame(width: 28, height: 28)
-                            .background(
-                                Theme.accent.opacity(0.12),
-                                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            )
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .stroke(Theme.accent.opacity(0.35), lineWidth: 1)
-                            }
+                            .contentShape(Rectangle())
                     }
                 }
 
@@ -221,11 +202,11 @@ struct BackgroundPickerView: View {
                         .overlay {
                             RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
                                 .stroke(
-                                    selectedGradientID == preset.id ? Theme.accent : Theme.borderStrong.opacity(0.55),
+                                    selectedGradientID == preset.id ? Color.white : Theme.borderStrong.opacity(0.55),
                                     lineWidth: selectedGradientID == preset.id ? 2 : 1
                                 )
                         }
-                        .shadow(color: selectedGradientID == preset.id ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                        .shadow(color: selectedGradientID == preset.id ? Color.white.opacity(0.35) : Color.clear, radius: 4, y: 1)
                 }
                 .help(preset.id.replacingOccurrences(of: "-", with: " ").capitalized)
             }
@@ -247,11 +228,11 @@ struct BackgroundPickerView: View {
                             .overlay {
                                 RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
                                     .stroke(
-                                        selectedColor == swatch ? Theme.accent : Theme.borderStrong.opacity(0.55),
+                                        selectedColor == swatch ? Color.white : Theme.borderStrong.opacity(0.55),
                                         lineWidth: selectedColor == swatch ? 2 : 1
                                     )
                             }
-                            .shadow(color: selectedColor == swatch ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                            .shadow(color: selectedColor == swatch ? Color.white.opacity(0.35) : Color.clear, radius: 4, y: 1)
                     }
                     .help(swatch.hexString)
                 }
@@ -291,11 +272,11 @@ struct BackgroundPickerView: View {
                     .overlay {
                         RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
                             .stroke(
-                                selectedWallpaperID == preset.id ? Theme.accent : Theme.borderStrong.opacity(0.55),
+                                selectedWallpaperID == preset.id ? Color.white : Theme.borderStrong.opacity(0.55),
                                 lineWidth: selectedWallpaperID == preset.id ? 2 : 1
                             )
                     }
-                    .shadow(color: selectedWallpaperID == preset.id ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                    .shadow(color: selectedWallpaperID == preset.id ? Color.white.opacity(0.35) : Color.clear, radius: 4, y: 1)
                 }
                 .help(preset.label)
             }
@@ -315,11 +296,11 @@ struct BackgroundPickerView: View {
                         .overlay {
                             RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
                                 .stroke(
-                                    selectedWallpaperID == preset.id ? Theme.accent : Theme.borderStrong.opacity(0.55),
+                                    selectedWallpaperID == preset.id ? Color.white : Theme.borderStrong.opacity(0.55),
                                     lineWidth: selectedWallpaperID == preset.id ? 2 : 1
                                 )
                         }
-                        .shadow(color: selectedWallpaperID == preset.id ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                        .shadow(color: selectedWallpaperID == preset.id ? Color.white.opacity(0.35) : Color.clear, radius: 4, y: 1)
                 }
                 .help(preset.label)
             }
@@ -357,16 +338,16 @@ struct BackgroundPickerView: View {
 
                 Image(systemName: "checkmark")
                     .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(Theme.accent)
+                    .foregroundStyle(Color.white)
                     .frame(width: 20, height: 20)
-                    .background(Theme.accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+                    .background(Color.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
             }
             .padding(9)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Theme.overlay.opacity(0.72), in: RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous)
-                    .stroke(Theme.accent.opacity(0.38), lineWidth: 1)
+                    .stroke(Color.white.opacity(0.60), lineWidth: 1)
             }
         }
     }

--- a/apps/macos/Sources/OpenRecorderMac/BackgroundPickerView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/BackgroundPickerView.swift
@@ -1,4 +1,6 @@
 import AppKit
+import AVFoundation
+import AVKit
 import SwiftUI
 
 struct BackgroundPickerView: View {
@@ -7,9 +9,10 @@ struct BackgroundPickerView: View {
     var showsTopDivider: Bool
 
     @State private var activeKind: BackgroundStylePresetKind
+    @State private var hoveredKind: BackgroundStylePresetKind?
 
-    private let tileCornerRadius: CGFloat = 0
-    private let tileHeight: CGFloat = 32
+    private let tileCornerRadius: CGFloat = 6
+    private let tileHeight: CGFloat = 34
     private let tileSpacing: CGFloat = 6
 
     init(selection: Binding<BackgroundStyle>, includeTransparent: Bool = true, showsTopDivider: Bool = true) {
@@ -29,49 +32,98 @@ struct BackgroundPickerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if showsTopDivider {
-                Rectangle()
-                    .fill(Theme.borderStrong.opacity(0.55))
-                    .frame(height: 1)
-            }
-
             HStack(spacing: 8) {
-                Text("Background")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(Theme.fg.opacity(0.94))
+                Text("BACKGROUND")
+                    .font(.system(size: 11, weight: .bold))
+                    .kerning(1.2)
+                    .foregroundStyle(Theme.fgSubtle)
+
                 Spacer(minLength: 0)
+
+                StudioButton(hitTarget: .rounded(Theme.radiusSm)) {
+                    withAnimation(.snappy(duration: 0.28)) {
+                        selection = BackgroundPresets.default
+                        activeKind = .wallpaper
+                    }
+                } label: {
+                    Text("Reset")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Theme.fgSubtle)
+                }
             }
             .padding(.top, 18)
-            .padding(.bottom, 17)
+            .padding(.bottom, 14)
 
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 12) {
+                // Clean icon-only tab switcher + inline Upload button
                 HStack(spacing: 8) {
-                    ForEach(availableKinds) { kind in
-                        Button {
-                            activate(kind)
-                        } label: {
-                            Image(systemName: kind.symbolName)
-                                .font(.system(size: Theme.iconSm, weight: activeKind == kind ? .semibold : .medium))
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 28)
-                                .foregroundStyle(activeKind == kind ? Theme.accent : Theme.fgMuted)
-                                .contentShape(Rectangle())
-                                .animation(.snappy(duration: 0.16), value: activeKind == kind)
+                    HStack(spacing: 5) {
+                        ForEach(availableKinds) { kind in
+                            let isSelected = activeKind == kind
+                            StudioButton(hitTarget: .rounded(6), help: kind.helpText) {
+                                activate(kind)
+                            } label: {
+                                Image(systemName: kind.symbolName)
+                                    .font(.system(size: 12.5, weight: isSelected ? .bold : .medium))
+                                    .foregroundStyle(
+                                        isSelected
+                                            ? kind.accentColor
+                                            : (hoveredKind == kind ? Color.white : Theme.fgMuted.opacity(0.72))
+                                    )
+                                    .frame(width: 28, height: 28)
+                                    .background(
+                                        isSelected
+                                            ? kind.accentColor.opacity(0.18)
+                                            : (hoveredKind == kind ? Color.white.opacity(0.06) : Color.clear),
+                                        in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    )
+                                    .overlay {
+                                        if isSelected {
+                                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                                .stroke(kind.accentColor.opacity(0.55), lineWidth: 1)
+                                        }
+                                    }
+                                    .shadow(color: isSelected ? kind.accentColor.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                            }
+                            .onHover { isHovering in
+                                hoveredKind = isHovering ? kind : (hoveredKind == kind ? nil : hoveredKind)
+                            }
                         }
-                        .buttonStyle(.plain)
-                        .help(kind.title)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    StudioButton(hitTarget: .rounded(6), help: "Upload custom background image or video") {
+                        chooseCustomFile()
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(Theme.accent)
+                            .frame(width: 28, height: 28)
+                            .background(
+                                Theme.accent.opacity(0.12),
+                                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            )
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .stroke(Theme.accent.opacity(0.35), lineWidth: 1)
+                            }
                     }
                 }
 
+                // Content Grid
                 switch activeKind {
-                case .gradient:
-                    gradientGrid
+                case .wallpaper:
+                    wallpaperGrid
+                        .transaction { $0.animation = nil }
+                case .video:
+                    videoGrid
                         .transaction { $0.animation = nil }
                 case .color:
                     colorGrid
                         .transaction { $0.animation = nil }
-                case .wallpaper:
-                    wallpaperGrid
+                case .gradient:
+                    gradientGrid
                         .transaction { $0.animation = nil }
                 case .transparent:
                     transparentNote
@@ -92,6 +144,29 @@ struct BackgroundPickerView: View {
         }
     }
 
+    private func chooseCustomFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.image, .movie, .quickTimeMovie, .mpeg4Movie, .png, .jpeg]
+        if panel.runModal() == .OK, let url = panel.url {
+            let isVideo = ["mp4", "mov", "m4v"].contains(url.pathExtension.lowercased())
+            let customPreset = WallpaperPreset(
+                id: "custom-\(UUID().uuidString)",
+                label: url.deletingPathExtension().lastPathComponent,
+                fullAssetName: "",
+                thumbAssetName: "",
+                customURL: url,
+                isVideo: isVideo
+            )
+            withAnimation(.snappy(duration: 0.28)) {
+                selection = .wallpaper(customPreset)
+                activeKind = isVideo ? .video : .wallpaper
+            }
+        }
+    }
+
     private func activate(_ kind: BackgroundStylePresetKind) {
         withAnimation(.snappy(duration: 0.34)) {
             activeKind = kind
@@ -103,8 +178,13 @@ struct BackgroundPickerView: View {
                 if case .solid = selection { return }
                 selection = .solid(BackgroundPresets.solidColors[0])
             case .wallpaper:
-                if case .wallpaper = selection { return }
+                if case let .wallpaper(preset) = selection, !preset.isVideo { return }
                 if let first = BackgroundPresets.wallpapers.first {
+                    selection = .wallpaper(first)
+                }
+            case .video:
+                if case let .wallpaper(preset) = selection, preset.isVideo { return }
+                if let first = BackgroundPresets.videoLoops.first {
                     selection = .wallpaper(first)
                 }
             case .transparent:
@@ -153,26 +233,71 @@ struct BackgroundPickerView: View {
     }
 
     private var colorGrid: some View {
-        LazyVGrid(columns: fourColumnGridItems, spacing: tileSpacing) {
-            ForEach(BackgroundPresets.solidColors.indices, id: \.self) { index in
-                let swatch = BackgroundPresets.solidColors[index]
-                StudioButton(hitTarget: .rounded(Theme.radiusSm)) {
-                    selection = .solid(swatch)
-                } label: {
-                    RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                        .fill(swatch.color)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: tileHeight)
-                        .overlay {
-                            RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                                .stroke(
-                                    selectedColor == swatch ? Theme.accent : Theme.borderStrong.opacity(0.55),
-                                    lineWidth: selectedColor == swatch ? 2 : 1
-                                )
-                        }
-                        .shadow(color: selectedColor == swatch ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+        VStack(spacing: 8) {
+            LazyVGrid(columns: fourColumnGridItems, spacing: tileSpacing) {
+                ForEach(BackgroundPresets.solidColors.indices, id: \.self) { index in
+                    let swatch = BackgroundPresets.solidColors[index]
+                    StudioButton(hitTarget: .rounded(Theme.radiusSm)) {
+                        selection = .solid(swatch)
+                    } label: {
+                        RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
+                            .fill(swatch.color)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: tileHeight)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
+                                    .stroke(
+                                        selectedColor == swatch ? Theme.accent : Theme.borderStrong.opacity(0.55),
+                                        lineWidth: selectedColor == swatch ? 2 : 1
+                                    )
+                            }
+                            .shadow(color: selectedColor == swatch ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                    }
+                    .help(swatch.hexString)
                 }
-                .help(swatch.hexString)
+            }
+
+            HStack(spacing: 8) {
+                ColorPicker("Custom Solid Color", selection: Binding(
+                    get: { selectedColor?.color ?? Color.black },
+                    set: { newColor in
+                        selection = .solid(SerializableColor(NSColor(newColor)))
+                    }
+                ))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Theme.fgMuted)
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private var videoGrid: some View {
+        LazyVGrid(columns: fourColumnGridItems, spacing: tileSpacing) {
+            ForEach(BackgroundPresets.videoLoops) { preset in
+                StudioButton(hitTarget: .rounded(Theme.radiusSm)) {
+                    selection = .wallpaper(preset)
+                } label: {
+                    ZStack(alignment: .bottomTrailing) {
+                        WallpaperThumbnail(preset: preset)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: tileHeight)
+
+                        Image(systemName: "play.circle.fill")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(Color.white.opacity(0.92))
+                            .padding(3)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
+                            .stroke(
+                                selectedWallpaperID == preset.id ? Theme.accent : Theme.borderStrong.opacity(0.55),
+                                lineWidth: selectedWallpaperID == preset.id ? 2 : 1
+                            )
+                    }
+                    .shadow(color: selectedWallpaperID == preset.id ? Theme.accent.opacity(0.35) : Color.clear, radius: 4, y: 1)
+                }
+                .help(preset.label)
             }
         }
     }
@@ -350,15 +475,60 @@ struct BackgroundFillView: View {
     }
 }
 
+struct VideoBackgroundPlayerView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        let player = AVQueuePlayer()
+        let playerLayer = AVPlayerLayer(player: player)
+        playerLayer.videoGravity = .resizeAspectFill
+        playerLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        view.wantsLayer = true
+        view.layer?.addSublayer(playerLayer)
+
+        let item = AVPlayerItem(url: url)
+        let looper = AVPlayerLooper(player: player, templateItem: item)
+        context.coordinator.looper = looper
+        context.coordinator.player = player
+        player.isMuted = true
+        player.play()
+
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        if let layer = nsView.layer?.sublayers?.first as? AVPlayerLayer {
+            layer.frame = nsView.bounds
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator {
+        var player: AVQueuePlayer?
+        var looper: AVPlayerLooper?
+    }
+}
+
 struct WallpaperFill: View {
     let preset: WallpaperPreset
 
     var body: some View {
         Group {
-            if let url = preset.fullURL, let image = WallpaperImageCache.image(for: url) {
-                Image(nsImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
+            if let url = preset.fullURL {
+                let ext = url.pathExtension.lowercased()
+                if preset.isVideo && (ext == "mp4" || ext == "mov" || ext == "m4v") {
+                    VideoBackgroundPlayerView(url: url)
+                } else if let image = WallpaperImageCache.image(for: url) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    Theme.surfaceRaised
+                }
             } else {
                 Theme.surfaceRaised
             }

--- a/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
+++ b/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import CoreGraphics
 import Foundation
 import SwiftUI
@@ -78,13 +79,21 @@ struct WallpaperPreset: Identifiable, Equatable, Hashable, Codable {
     var label: String
     var fullAssetName: String
     var thumbAssetName: String
+    var customURL: URL? = nil
+    var isVideo: Bool = false
 
     var fullURL: URL? {
-        OpenRecorderResources.url(forResource: fullAssetName, withExtension: "jpg", subdirectory: "Wallpapers")
+        if let customURL { return customURL }
+        if isVideo, let videoURL = OpenRecorderResources.url(forResource: fullAssetName, withExtension: "mp4", subdirectory: "Wallpapers") {
+            return videoURL
+        }
+        return OpenRecorderResources.url(forResource: fullAssetName, withExtension: "jpg", subdirectory: "Wallpapers")
     }
 
     var thumbURL: URL? {
-        OpenRecorderResources.url(forResource: thumbAssetName, withExtension: "jpg", subdirectory: "Wallpapers/thumbs")
+        if let customURL { return customURL }
+        return OpenRecorderResources.url(forResource: thumbAssetName, withExtension: "jpg", subdirectory: "Wallpapers/thumbs")
+            ?? OpenRecorderResources.url(forResource: thumbAssetName, withExtension: "jpg", subdirectory: "Wallpapers")
     }
 }
 
@@ -384,11 +393,19 @@ enum BackgroundPresets {
         )
     }
 
+    static let videoLoops: [WallpaperPreset] = [
+        WallpaperPreset(id: "loop-aurora", label: "Aurora", fullAssetName: "wallpaper1", thumbAssetName: "wallpaper1", isVideo: true),
+        WallpaperPreset(id: "loop-particles", label: "Particles", fullAssetName: "wallpaper2", thumbAssetName: "wallpaper2", isVideo: true),
+        WallpaperPreset(id: "loop-cyber", label: "Cyber Neon", fullAssetName: "wallpaper3", thumbAssetName: "wallpaper3", isVideo: true),
+        WallpaperPreset(id: "loop-mesh", label: "Gradient Mesh", fullAssetName: "wallpaper4", thumbAssetName: "wallpaper4", isVideo: true)
+    ]
+
     static let `default`: BackgroundStyle = .wallpaper(wallpapers[0])
 }
 
 enum BackgroundStylePresetKind: String, CaseIterable, Identifiable {
     case wallpaper
+    case video
     case color
     case gradient
     case transparent
@@ -397,19 +414,41 @@ enum BackgroundStylePresetKind: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .gradient: "Gradient"
-        case .color: "Solid"
         case .wallpaper: "Image"
-        case .transparent: "Transparent"
+        case .video: "Video"
+        case .color: "Color"
+        case .gradient: "Gradient"
+        case .transparent: "None"
+        }
+    }
+
+    var helpText: String {
+        switch self {
+        case .wallpaper: "Image Wallpapers"
+        case .video: "Video Loops"
+        case .color: "Solid Colors"
+        case .gradient: "Gradients"
+        case .transparent: "Transparent (No background)"
         }
     }
 
     var symbolName: String {
         switch self {
-        case .gradient: "circle.lefthalf.filled.righthalf.striped.horizontal"
-        case .color: "circle.fill"
         case .wallpaper: "photo"
+        case .video: "video.fill"
+        case .color: "paintpalette.fill"
+        case .gradient: "circle.lefthalf.filled.righthalf.striped.horizontal"
         case .transparent: "square.dashed"
+        }
+    }
+
+    var accentColor: Color {
+        switch self {
+        case .wallpaper: Color(red: 0.28, green: 0.58, blue: 1.00)  // Sky Blue
+        case .video: Color(red: 0.68, green: 0.42, blue: 1.00)      // Vivid Purple
+        case .color: Color(red: 1.00, green: 0.62, blue: 0.22)      // Amber Orange
+        case .gradient: Color(red: 1.00, green: 0.38, blue: 0.68)   // Rose Pink
+        case .transparent: Color(red: 0.70, green: 0.74, blue: 0.82) // Slate
         }
     }
 }
@@ -420,7 +459,7 @@ extension BackgroundStyle {
         case .transparent: .transparent
         case .solid: .color
         case .gradient: .gradient
-        case .wallpaper: .wallpaper
+        case let .wallpaper(preset): preset.isVideo ? .video : .wallpaper
         }
     }
 }
@@ -488,9 +527,19 @@ enum WallpaperImageCache {
         if let cached = storage.imageCache.object(forKey: key) {
             return cached
         }
-        guard let image = NSImage(contentsOf: url) else { return nil }
-        storage.imageCache.setObject(image, forKey: key)
-        return image
+        if let image = NSImage(contentsOf: url) {
+            storage.imageCache.setObject(image, forKey: key)
+            return image
+        }
+        let asset = AVURLAsset(url: url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        if let cg = try? generator.copyCGImage(at: .zero, actualTime: nil) {
+            let image = NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
+            storage.imageCache.setObject(image, forKey: key)
+            return image
+        }
+        return nil
     }
 
     static func cgImage(for url: URL) -> CGImage? {

--- a/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
+++ b/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
@@ -111,28 +111,22 @@ enum BackgroundStyle: Equatable, Hashable, Codable {
 
 enum BackgroundPresets {
     static let solidColors: [SerializableColor] = [
-        SerializableColor(red: 0.055, green: 0.055, blue: 0.067),
-        SerializableColor(red: 0.95, green: 0.96, blue: 0.98),
-        SerializableColor(red: 0.10, green: 0.16, blue: 0.24),
-        SerializableColor(red: 0.13, green: 0.19, blue: 0.14),
-        SerializableColor(red: 0.24, green: 0.13, blue: 0.18),
-        SerializableColor(red: 0.23, green: 0.20, blue: 0.13),
-        SerializableColor(hex: "#FF0000"),
-        SerializableColor(hex: "#FFD700"),
-        SerializableColor(hex: "#00FF00"),
-        SerializableColor(hex: "#FFFFFF"),
-        SerializableColor(hex: "#0000FF"),
-        SerializableColor(hex: "#FF6B00"),
-        SerializableColor(hex: "#9B59B6"),
-        SerializableColor(hex: "#E91E63"),
-        SerializableColor(hex: "#00BCD4"),
-        SerializableColor(hex: "#FF5722"),
-        SerializableColor(hex: "#8BC34A"),
-        SerializableColor(hex: "#FFC107"),
-        SerializableColor(hex: "#2563EB"),
-        SerializableColor(hex: "#000000"),
-        SerializableColor(hex: "#607D8B"),
-        SerializableColor(hex: "#795548")
+        SerializableColor(hex: "#090A0F"), // Deep Black / Obsidian
+        SerializableColor(hex: "#12141C"), // Midnight Navy
+        SerializableColor(hex: "#18181B"), // Zinc Dark
+        SerializableColor(hex: "#0F172A"), // Slate Dark
+        SerializableColor(hex: "#1C1917"), // Stone Dark
+        SerializableColor(hex: "#022C22"), // Forest Dark
+        SerializableColor(hex: "#1E1B4B"), // Indigo Dark
+        SerializableColor(hex: "#2E1065"), // Purple Dark
+        SerializableColor(hex: "#2563EB"), // Blue
+        SerializableColor(hex: "#7C3AED"), // Violet
+        SerializableColor(hex: "#DB2777"), // Rose
+        SerializableColor(hex: "#EA580C"), // Orange
+        SerializableColor(hex: "#16A34A"), // Emerald
+        SerializableColor(hex: "#0D9488"), // Teal
+        SerializableColor(hex: "#FFFFFF"), // Pure White
+        SerializableColor(hex: "#64748B")  // Muted Slate
     ]
 
     static let gradients: [GradientPreset] = [
@@ -379,19 +373,30 @@ enum BackgroundPresets {
     ]
 
     static let wallpapers: [WallpaperPreset] = [
+        WallpaperPreset(id: "wallpaper-10", label: "Midnight Mountain", fullAssetName: "wallpaper10", thumbAssetName: "wallpaper10"),
+        WallpaperPreset(id: "mountaintrees", label: "Mountain Trees", fullAssetName: "mountaintrees", thumbAssetName: "mountaintrees"),
+        WallpaperPreset(id: "wallpaper-14", label: "Dark Flow", fullAssetName: "wallpaper14", thumbAssetName: "wallpaper14"),
+        WallpaperPreset(id: "wallpaper-13", label: "Midnight Swirl", fullAssetName: "wallpaper13", thumbAssetName: "wallpaper13"),
+        WallpaperPreset(id: "luisdelrio", label: "Deep Forest", fullAssetName: "luisdelrio", thumbAssetName: "luisdelrio"),
+        WallpaperPreset(id: "wallpaper-3", label: "Dusk Dunes", fullAssetName: "wallpaper3", thumbAssetName: "wallpaper3"),
+        WallpaperPreset(id: "wallpaper-1", label: "Dark Aurora", fullAssetName: "wallpaper1", thumbAssetName: "wallpaper1"),
+        WallpaperPreset(id: "wallpaper-7", label: "Night Sky", fullAssetName: "wallpaper7", thumbAssetName: "wallpaper7"),
+        WallpaperPreset(id: "wallpaper-8", label: "Crimson Night", fullAssetName: "wallpaper8", thumbAssetName: "wallpaper8"),
+        WallpaperPreset(id: "wallpaper-12", label: "Misty Horizon", fullAssetName: "wallpaper12", thumbAssetName: "wallpaper12"),
         WallpaperPreset(id: "cityscape", label: "Cityscape", fullAssetName: "cityscape", thumbAssetName: "cityscape"),
         WallpaperPreset(id: "farmvalley", label: "Farm Valley", fullAssetName: "farmvalley", thumbAssetName: "farmvalley"),
-        WallpaperPreset(id: "mountaintrees", label: "Mountain Trees", fullAssetName: "mountaintrees", thumbAssetName: "mountaintrees"),
-        WallpaperPreset(id: "luisdelrio", label: "Luis Del Rio", fullAssetName: "luisdelrio", thumbAssetName: "luisdelrio"),
-        WallpaperPreset(id: "levels", label: "Levels", fullAssetName: "levels", thumbAssetName: "levels")
-    ] + (1...18).map { index in
-        WallpaperPreset(
-            id: "wallpaper-\(index)",
-            label: "Wallpaper \(index)",
-            fullAssetName: "wallpaper\(index)",
-            thumbAssetName: "wallpaper\(index)"
-        )
-    }
+        WallpaperPreset(id: "levels", label: "Levels", fullAssetName: "levels", thumbAssetName: "levels"),
+        WallpaperPreset(id: "wallpaper-2", label: "Wallpaper 2", fullAssetName: "wallpaper2", thumbAssetName: "wallpaper2"),
+        WallpaperPreset(id: "wallpaper-4", label: "Wallpaper 4", fullAssetName: "wallpaper4", thumbAssetName: "wallpaper4"),
+        WallpaperPreset(id: "wallpaper-5", label: "Wallpaper 5", fullAssetName: "wallpaper5", thumbAssetName: "wallpaper5"),
+        WallpaperPreset(id: "wallpaper-6", label: "Wallpaper 6", fullAssetName: "wallpaper6", thumbAssetName: "wallpaper6"),
+        WallpaperPreset(id: "wallpaper-9", label: "Wallpaper 9", fullAssetName: "wallpaper9", thumbAssetName: "wallpaper9"),
+        WallpaperPreset(id: "wallpaper-11", label: "Wallpaper 11", fullAssetName: "wallpaper11", thumbAssetName: "wallpaper11"),
+        WallpaperPreset(id: "wallpaper-15", label: "Wallpaper 15", fullAssetName: "wallpaper15", thumbAssetName: "wallpaper15"),
+        WallpaperPreset(id: "wallpaper-16", label: "Wallpaper 16", fullAssetName: "wallpaper16", thumbAssetName: "wallpaper16"),
+        WallpaperPreset(id: "wallpaper-17", label: "Wallpaper 17", fullAssetName: "wallpaper17", thumbAssetName: "wallpaper17"),
+        WallpaperPreset(id: "wallpaper-18", label: "Wallpaper 18", fullAssetName: "wallpaper18", thumbAssetName: "wallpaper18")
+    ]
 
     static let videoLoops: [WallpaperPreset] = [
         WallpaperPreset(id: "loop-aurora", label: "Aurora", fullAssetName: "wallpaper1", thumbAssetName: "wallpaper1", isVideo: true),

--- a/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
@@ -90,7 +90,7 @@ struct CameraBubbleWindowView: View {
 
     @ViewBuilder
     private var videoContent: some View {
-        if let session = model.cameraCaptureSession, session.isRunning {
+        if let session = model.cameraCaptureSession {
             CameraVideoPreviewRepresentable(session: session, isMirrored: isMirrored)
         } else {
             cameraFallbackView

--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -17,12 +17,12 @@ struct CaptureHUD: View {
         HUDSurface(isRecording: isRecordingActive) {
             if isRecordingActive {
                 activeRecordingControls
-            } else if model.captureMode == .recording {
-                recordingControls
             } else {
-                screenshotControls
+                idleControls
             }
         }
+        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: model.captureMode)
+        .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isRecordingActive)
         .environment(\.layoutDirection, .leftToRight)
         .flipsForRightToLeftLayoutDirection(false)
     }
@@ -95,11 +95,7 @@ struct CaptureHUD: View {
         }
     }
 
-    private var recordingControls: some View {
-        fullRecordingControls
-    }
-
-    private var fullRecordingControls: some View {
+    private var idleControls: some View {
         HStack(spacing: 10) {
             sharedLeadingControls
 
@@ -111,100 +107,38 @@ struct CaptureHUD: View {
             HUDDivider()
 
             HStack(spacing: 6) {
-                recordingCaptureControlGroup
-
-                HUDPrimaryButton(
-                    title: model.capture.isRecording ? "Stop" : startStopTitle,
-                    symbolName: model.capture.isRecording ? "stop.fill" : "record.circle",
-                    isDestructive: model.capture.isRecording,
-                    shortcutText: nil
-                ) {
-                    toggleRecording()
+                if model.captureMode == .recording {
+                    recordingCaptureControlGroup
+                        .transition(.asymmetric(
+                            insertion: .scale(scale: 0.85).combined(with: .opacity).combined(with: .move(edge: .trailing)),
+                            removal: .scale(scale: 0.85).combined(with: .opacity).combined(with: .move(edge: .trailing))
+                        ))
                 }
-                .help(recordingShortcutHelpTitle)
-                .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
-            }
-        }
-    }
 
-    private var compactRecordingControls: some View {
-        HStack(spacing: 8) {
-            compactLeadingControls
-
-            HStack(spacing: 4) {
-                sourcePicker(minWidth: 115, maxWidth: 155)
-                compactPermissionControls
-            }
-
-            HStack(spacing: 6) {
-                recordingCaptureControlGroup
-
-                HUDPrimaryButton(
-                    title: model.capture.isRecording ? "Stop" : startStopTitle,
-                    symbolName: model.capture.isRecording ? "stop.fill" : "record.circle",
-                    isDestructive: model.capture.isRecording,
-                    shortcutText: nil
-                ) {
-                    toggleRecording()
+                if model.captureMode == .recording {
+                    HUDPrimaryButton(
+                        title: model.capture.isRecording ? "Stop" : startStopTitle,
+                        symbolName: model.capture.isRecording ? "stop.fill" : "record.circle",
+                        isDestructive: model.capture.isRecording,
+                        shortcutText: nil
+                    ) {
+                        toggleRecording()
+                    }
+                    .help(recordingShortcutHelpTitle)
+                    .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
+                    .transition(.identity)
+                } else {
+                    HUDPrimaryButton(
+                        title: "Capture",
+                        symbolName: "camera.fill",
+                        isDestructive: false
+                    ) {
+                        model.takeScreenshot()
+                    }
+                    .disabled(!captureReadiness.canCapture)
+                    .transition(.identity)
                 }
-                .help(recordingShortcutHelpTitle)
-                .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
             }
-        }
-    }
-
-    private var narrowRecordingControls: some View {
-        HStack(spacing: 6) {
-            HUDModeSwitcher(
-                mode: Binding(
-                    get: { model.captureMode },
-                    set: { model.beginCapture($0) }
-                ),
-                isDisabled: model.capture.isRecording || model.recordingPhase != .idle
-            )
-
-            sourcePicker(minWidth: 100, maxWidth: 130)
-
-            narrowCaptureOptionsMenu
-
-            HUDPrimaryIconButton(
-                title: recordingShortcutHelpTitle,
-                symbolName: model.capture.isRecording ? "stop.fill" : "record.circle",
-                isDestructive: model.capture.isRecording
-            ) {
-                toggleRecording()
-            }
-            .disabled(model.recordingPhase == .idle && !model.capture.isRecording && !captureReadiness.canCapture)
-        }
-    }
-
-    private var screenshotControls: some View {
-        ViewThatFits(in: .horizontal) {
-            fullScreenshotControls
-            compactScreenshotControls
-        }
-    }
-
-    private var fullScreenshotControls: some View {
-        HStack(spacing: 10) {
-            sharedLeadingControls
-
-            HStack(spacing: 4) {
-                sourcePicker()
-                    .layoutPriority(2)
-                permissionControls
-            }
-
-            HUDDivider()
-
-            HUDPrimaryButton(
-                title: "Capture",
-                symbolName: "camera.fill",
-                isDestructive: false
-            ) {
-                model.takeScreenshot()
-            }
-            .disabled(!captureReadiness.canCapture)
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/CaptureShortcuts.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureShortcuts.swift
@@ -1,0 +1,216 @@
+import Carbon
+import Foundation
+
+public enum CaptureShortcutAction: String, CaseIterable, Identifiable, Codable, Equatable, Hashable, Sendable {
+    case deviceScreenshot = "deviceScreenshot"
+    case dragScreenshot = "dragScreenshot"
+    case deviceScreenRecord = "deviceScreenRecord"
+    case dragScreenRecord = "dragScreenRecord"
+    case toggleRecording = "toggleRecording"
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .deviceScreenshot: "Device Screenshot"
+        case .dragScreenshot: "Drag Screenshot"
+        case .deviceScreenRecord: "Device Screen Record"
+        case .dragScreenRecord: "Drag Screen Record"
+        case .toggleRecording: "Toggle Recording"
+        }
+    }
+
+    public var subtitle: String {
+        switch self {
+        case .deviceScreenshot: "Capture full screen instantly"
+        case .dragScreenshot: "Select and capture custom area"
+        case .deviceScreenRecord: "Record full screen with Open Recorder"
+        case .dragScreenRecord: "Drag area to record with Open Recorder"
+        case .toggleRecording: "Start or stop active recording"
+        }
+    }
+
+    public var defaultKeyCombination: KeyCombination {
+        switch self {
+        case .deviceScreenshot:
+            return KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.option, .shift])
+        case .dragScreenshot:
+            return KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.option, .shift])
+        case .deviceScreenRecord:
+            return KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.option, .shift])
+        case .dragScreenRecord:
+            return KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.option, .shift])
+        case .toggleRecording:
+            return KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option, .shift])
+        }
+    }
+
+    public var availablePresets: [KeyCombination] {
+        switch self {
+        case .deviceScreenshot:
+            return [
+                KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.option, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.command, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.control, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_S), modifiers: [.option, .shift])
+            ]
+        case .dragScreenshot:
+            return [
+                KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.option, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.command, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.control, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_A), modifiers: [.option, .shift])
+            ]
+        case .deviceScreenRecord:
+            return [
+                KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.option, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.command, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.control, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option, .shift])
+            ]
+        case .dragScreenRecord:
+            return [
+                KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.option, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.command, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.control, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_D), modifiers: [.option, .shift])
+            ]
+        case .toggleRecording:
+            return [
+                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.command]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.command, .shift]),
+                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option])
+            ]
+        }
+    }
+}
+
+public struct ShortcutModifiers: OptionSet, Codable, Equatable, Hashable, Sendable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let command = ShortcutModifiers(rawValue: 1 << 0)
+    public static let shift = ShortcutModifiers(rawValue: 1 << 1)
+    public static let option = ShortcutModifiers(rawValue: 1 << 2)
+    public static let control = ShortcutModifiers(rawValue: 1 << 3)
+
+    public var displayString: String {
+        var s = ""
+        if contains(.control) { s += "⌃" }
+        if contains(.option) { s += "⌥" }
+        if contains(.shift) { s += "⇧" }
+        if contains(.command) { s += "⌘" }
+        return s
+    }
+}
+
+public struct KeyCombination: Codable, Equatable, Hashable, Identifiable, Sendable {
+    public var keyCode: UInt32
+    public var modifiers: ShortcutModifiers
+
+    public var id: String { displayString }
+
+    public init(keyCode: UInt32, modifiers: ShortcutModifiers) {
+        self.keyCode = keyCode
+        self.modifiers = modifiers
+    }
+
+    public var displayString: String {
+        let modString = modifiers.displayString
+        let keyString = KeyCombination.keyString(for: keyCode)
+        return "\(modString)\(keyString)"
+    }
+
+    public var carbonModifiers: UInt32 {
+        var result: UInt32 = 0
+        if modifiers.contains(.command) { result |= UInt32(cmdKey) }
+        if modifiers.contains(.shift) { result |= UInt32(shiftKey) }
+        if modifiers.contains(.option) { result |= UInt32(optionKey) }
+        if modifiers.contains(.control) { result |= UInt32(controlKey) }
+        return result
+    }
+
+    public static func keyString(for keyCode: UInt32) -> String {
+        switch Int(keyCode) {
+        case kVK_ANSI_0: return "0"
+        case kVK_ANSI_1: return "1"
+        case kVK_ANSI_2: return "2"
+        case kVK_ANSI_3: return "3"
+        case kVK_ANSI_4: return "4"
+        case kVK_ANSI_5: return "5"
+        case kVK_ANSI_6: return "6"
+        case kVK_ANSI_7: return "7"
+        case kVK_ANSI_8: return "8"
+        case kVK_ANSI_9: return "9"
+        case kVK_ANSI_A: return "A"
+        case kVK_ANSI_B: return "B"
+        case kVK_ANSI_C: return "C"
+        case kVK_ANSI_D: return "D"
+        case kVK_ANSI_E: return "E"
+        case kVK_ANSI_F: return "F"
+        case kVK_ANSI_G: return "G"
+        case kVK_ANSI_H: return "H"
+        case kVK_ANSI_I: return "I"
+        case kVK_ANSI_J: return "J"
+        case kVK_ANSI_K: return "K"
+        case kVK_ANSI_L: return "L"
+        case kVK_ANSI_M: return "M"
+        case kVK_ANSI_N: return "N"
+        case kVK_ANSI_O: return "O"
+        case kVK_ANSI_P: return "P"
+        case kVK_ANSI_Q: return "Q"
+        case kVK_ANSI_R: return "R"
+        case kVK_ANSI_S: return "S"
+        case kVK_ANSI_T: return "T"
+        case kVK_ANSI_U: return "U"
+        case kVK_ANSI_V: return "V"
+        case kVK_ANSI_W: return "W"
+        case kVK_ANSI_X: return "X"
+        case kVK_ANSI_Y: return "Y"
+        case kVK_ANSI_Z: return "Z"
+        case kVK_Space: return "Space"
+        case kVK_Return: return "↩"
+        default: return "Key(\(keyCode))"
+        }
+    }
+}
+
+public struct ShortcutItem: Codable, Equatable, Identifiable, Sendable {
+    public var id: CaptureShortcutAction
+    public var isEnabled: Bool
+    public var keyCombination: KeyCombination
+
+    public init(id: CaptureShortcutAction, isEnabled: Bool = true, keyCombination: KeyCombination) {
+        self.id = id
+        self.isEnabled = isEnabled
+        self.keyCombination = keyCombination
+    }
+}
+
+public struct ShortcutPreferences: Codable, Equatable, Sendable {
+    public var shortcuts: [CaptureShortcutAction: ShortcutItem]
+
+    public init(shortcuts: [CaptureShortcutAction: ShortcutItem] = [:]) {
+        self.shortcuts = shortcuts
+    }
+
+    public static var defaultPreferences: ShortcutPreferences {
+        var map: [CaptureShortcutAction: ShortcutItem] = [:]
+        for action in CaptureShortcutAction.allCases {
+            map[action] = ShortcutItem(id: action, isEnabled: true, keyCombination: action.defaultKeyCombination)
+        }
+        return ShortcutPreferences(shortcuts: map)
+    }
+
+    public func item(for action: CaptureShortcutAction) -> ShortcutItem {
+        shortcuts[action] ?? ShortcutItem(id: action, isEnabled: true, keyCombination: action.defaultKeyCombination)
+    }
+
+    public mutating func setItem(_ item: ShortcutItem) {
+        shortcuts[item.id] = item
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
@@ -733,7 +733,7 @@ struct CaptureState: Hashable {
             next.setPhase(.countingDownRecording(source))
             statusMessage = "Recording starts in 3..."
             effects.append(.dismissScreenSelection)
-            effects.append(.hideAppWindowsForCapture)
+            effects.append(.dismissCaptureWindows)
             effects.append(.runRecordingStart(source, outputURL))
 
         case .recordingFilePreparationFailed(_, let message):
@@ -745,7 +745,7 @@ struct CaptureState: Hashable {
             next.setPhase(.countingDownRecording(source))
             statusMessage = "Recording starts in 3..."
             effects.append(.dismissScreenSelection)
-            effects.append(.hideAppWindowsForCapture)
+            effects.append(.dismissCaptureWindows)
 
         case .recordingStarting(let source):
             next.selectedSource = source

--- a/apps/macos/Sources/OpenRecorderMac/ContentView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ContentView.swift
@@ -52,7 +52,7 @@ struct ContentView: View {
                     .background(WindowConfigurator(role: .studio))
             }
         }
-        .overlay(WindowCommandBridge(shell: model.appShell).allowsHitTesting(false))
+        .overlay(WindowCommandBridge(shell: model.appShell, isCameraEnabled: { model.includeCamera }).allowsHitTesting(false))
         .environmentObject(model)
         .preferredColorScheme(.dark)
         .onOpenURL { url in

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -144,16 +144,9 @@ struct VideoEditorStudioView: View {
             editorColumn
         } secondary: {
             sidebarContent
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .background(Theme.surface.opacity(0.88), in: RoundedRectangle(cornerRadius: Theme.radiusLg, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: Theme.radiusLg, style: .continuous)
-                .stroke(Theme.borderStrong.opacity(0.65), lineWidth: 1)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: Theme.radiusLg, style: .continuous))
-        .padding(16)
-        .background(Theme.appBgMuted)
+        .background(Theme.appBg)
         .sheet(item: editor.activeSheetBinding(exportIsBusy: videoExport.state.phase.isBusy)) { sheet in
             switch sheet {
             case .export:

--- a/apps/macos/Sources/OpenRecorderMac/ElasticSlider.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ElasticSlider.swift
@@ -14,9 +14,9 @@ struct ElasticSlider: View {
     var hitHeight: CGFloat = 26
     var fillColor: Color = Color.white.opacity(0.20)
     var dragFillColor: Color?
-    var thumbSize: CGFloat = 18
-    var thumbWidth: CGFloat? = 38
-    var thumbHeight: CGFloat? = 18
+    var thumbSize: CGFloat = 16
+    var thumbWidth: CGFloat? = nil
+    var thumbHeight: CGFloat? = nil
     var thumbColor: Color = Color.white
     var showStepDots: Bool = true
     var showTooltip: Bool = true
@@ -34,11 +34,10 @@ struct ElasticSlider: View {
             let currentNormalized = normalized(value).clamped(to: 0...1)
             let progress = (visualProgress ?? currentNormalized).clamped(to: 0...1)
 
-            let resolvedThumbWidth = thumbWidth ?? thumbSize
-            let resolvedThumbHeight = min(thumbHeight ?? (trackHeight - 8), trackHeight - 4)
-            let thumbRadius = resolvedThumbWidth / 2
+            let resolvedThumbSize = thumbWidth ?? thumbSize
+            let thumbRadius = resolvedThumbSize / 2
 
-            let travelDistance = max(width - resolvedThumbWidth, 1)
+            let travelDistance = max(width - resolvedThumbSize, 1)
             let valueX = thumbRadius + travelDistance * CGFloat(progress)
 
             ZStack {
@@ -54,22 +53,22 @@ struct ElasticSlider: View {
 
                     // Step dots / Graduation markers (only on un-scrolled section to the right)
                     if showStepDots && width > 80 {
-                        stepDots(width: width, thumbX: valueX, thumbWidth: resolvedThumbWidth)
+                        stepDots(width: width, thumbX: valueX, thumbWidth: resolvedThumbSize)
                     }
                 }
                 .frame(width: width, height: trackHeight)
                 .clipShape(Capsule(style: .continuous))
 
-                // Sliding Fully Rounded Pill Tab Handle
-                Capsule(style: .continuous)
-                    .fill(Color.white)
-                    .frame(width: resolvedThumbWidth, height: resolvedThumbHeight)
+                // Sliding Circular / Round Handle Knob
+                Circle()
+                    .fill(thumbColor)
+                    .frame(width: resolvedThumbSize, height: resolvedThumbSize)
                     .overlay {
-                        Capsule(style: .continuous)
-                            .stroke(Color.black.opacity(0.12), lineWidth: 0.8)
+                        Circle()
+                            .stroke(Color.black.opacity(0.15), lineWidth: 0.8)
                     }
-                    .shadow(color: Color.black.opacity(0.38), radius: isDragging ? 4 : 2, y: 1)
-                    .scaleEffect(isDragging ? 1.05 : (isHovering ? 1.02 : 1.0))
+                    .shadow(color: Color.black.opacity(0.40), radius: isDragging ? 4 : 2, y: 1)
+                    .scaleEffect(isDragging ? 1.08 : (isHovering ? 1.04 : 1.0))
                     .position(x: valueX, y: trackHeight / 2)
                     .animation(Theme.springFast, value: isDragging)
                     .animation(Theme.springFast, value: isHovering)
@@ -82,7 +81,7 @@ struct ElasticSlider: View {
             }
             .frame(width: width, height: trackHeight)
             .contentShape(Capsule(style: .continuous))
-            .gesture(dragGesture(width: width, thumbWidth: resolvedThumbWidth))
+            .gesture(dragGesture(width: width, thumbWidth: resolvedThumbSize))
         }
         .frame(height: trackHeight)
         .opacity(isEnabled ? 1 : 0.5)

--- a/apps/macos/Sources/OpenRecorderMac/ElasticSlider.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ElasticSlider.swift
@@ -44,7 +44,7 @@ struct ElasticSlider: View {
             ZStack {
                 // Background Track Bar with fully rounded capsule container
                 ZStack(alignment: .leading) {
-                    // Outer track container: seamless dark dark grey (close to black)
+                    // Outer track container: seamless dark grey
                     Capsule(style: .continuous)
                         .fill(Color.black.opacity(0.38))
                         .overlay {
@@ -62,7 +62,7 @@ struct ElasticSlider: View {
 
                 // Sliding Fully Rounded Pill Tab Handle
                 Capsule(style: .continuous)
-                    .fill(thumbColor)
+                    .fill(Color.white)
                     .frame(width: resolvedThumbWidth, height: resolvedThumbHeight)
                     .overlay {
                         Capsule(style: .continuous)
@@ -124,8 +124,8 @@ struct ElasticSlider: View {
 
                 if dotX > thumbRightThreshold {
                     Circle()
-                        .fill(Color.white.opacity(0.24))
-                        .frame(width: 4, height: 4)
+                        .fill(Color.white.opacity(0.14))
+                        .frame(width: 2.5, height: 2.5)
                         .position(x: dotX, y: trackHeight / 2)
                 }
             }

--- a/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
@@ -55,19 +55,24 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
 
         cleanup()
         let (session, output) = try buildSession(cameraDeviceID: cameraDeviceID)
+
+        await Task.detached(priority: .userInitiated) {
+            session.startRunning()
+        }.value
+
         self.session = session
         self.movieOutput = output
         self.preparedCameraDeviceID = cameraDeviceID
         self.finishResult = nil
-
-        session.startRunning()
     }
 
     func start(outputURL: URL, cameraDeviceID: String?) async throws -> Date {
         if preparedCameraDeviceID != cameraDeviceID || session == nil || movieOutput == nil {
             try await prepare(cameraDeviceID: cameraDeviceID)
-        } else if session?.isRunning != true {
-            session?.startRunning()
+        } else if let session, !session.isRunning {
+            await Task.detached(priority: .userInitiated) {
+                session.startRunning()
+            }.value
         }
 
         guard let output = movieOutput else {
@@ -96,18 +101,22 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         let device = try cameraDevice(cameraDeviceID)
         let input = try AVCaptureDeviceInput(device: device)
         let session = AVCaptureSession()
+        session.beginConfiguration()
         session.sessionPreset = .high
 
         guard session.canAddInput(input) else {
+            session.commitConfiguration()
             throw FacecamRecorderError.cannotAddCameraInput
         }
         session.addInput(input)
 
         let output = AVCaptureMovieFileOutput()
         guard session.canAddOutput(output) else {
+            session.commitConfiguration()
             throw FacecamRecorderError.cannotAddMovieOutput
         }
         session.addOutput(output)
+        session.commitConfiguration()
 
         return (session, output)
     }

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -26,9 +26,11 @@ struct SettingsInspector: View {
     @Binding var cursorStyleID: CursorStyleID
     var recordingSession: RecordingSession?
 
+    @Namespace private var tabRailAnimation
     @State private var activeTab: InspectorTab = .appearance
     @State private var hoveredTab: InspectorTab?
     @State private var isInsetBalanceExpanded = false
+    @State private var removeCameraBackground = false
     private let insetBalanceScrollID = "inset-balance-accordion"
 
     private var hasRecordedCamera: Bool {
@@ -54,15 +56,16 @@ struct SettingsInspector: View {
     }
 
     private var inspectorContent: some View {
-        VStack(spacing: 0) {
+        HStack(spacing: 0) {
+            verticalIconRail
+
             ScrollViewReader { scrollProxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
-                        inspectorHeader
                         tabContent
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 18)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 14)
                     .padding(.bottom, 18)
                     .animation(.snappy(duration: 0.34), value: activeTab.id)
                     .animation(.snappy(duration: 0.34), value: background.presetKind)
@@ -80,56 +83,80 @@ struct SettingsInspector: View {
                 }
                 .scrollIndicators(.visible)
             }
-
-            Rectangle()
-                .fill(Theme.borderStrong.opacity(0.44))
-                .frame(height: 1)
-
-            inspectorFooter
         }
     }
 
-    private var inspectorHeader: some View {
-        HStack(spacing: 16) {
-            ForEach(InspectorTab.availableCases) { tab in
+    private var verticalIconRail: some View {
+        VStack(spacing: 12) {
+            ForEach(InspectorTab.railCases) { tab in
                 let isSelected = activeTab == tab
-                Button {
+                let isStubbed = tab.isStubbed
+
+                StudioButton(hitTarget: .rounded(Theme.radiusSm), help: tab.helpText) {
+                    guard !isStubbed else { return }
                     withAnimation(.snappy(duration: 0.20)) {
                         activeTab = tab
                     }
                 } label: {
-                    HStack(spacing: 6) {
+                    VStack(spacing: 4) {
                         Image(systemName: tab.symbolName)
-                            .font(.system(size: 13, weight: isSelected ? .semibold : .medium))
-                        Text(tab.title)
-                            .font(.system(size: 13, weight: isSelected ? .semibold : .medium))
+                            .font(.system(size: 16, weight: isSelected ? .bold : .medium))
+                            .foregroundStyle(
+                                isSelected
+                                    ? Theme.accent
+                                    : (isStubbed ? Theme.fgMuted.opacity(0.30) : (hoveredTab == tab ? Color.white : Theme.fgMuted.opacity(0.70)))
+                            )
+                            .shadow(color: isSelected ? Theme.accent.opacity(0.45) : Color.clear, radius: 6, y: 1)
+                            .frame(width: 32, height: 26)
+
+                        Text(tab.shortTitle)
+                            .font(.system(size: 9.5, weight: isSelected ? .bold : .medium))
+                            .foregroundStyle(
+                                isSelected
+                                    ? Theme.accent
+                                    : (isStubbed ? Theme.fgMuted.opacity(0.30) : (hoveredTab == tab ? Color.white : Theme.fgMuted.opacity(0.70)))
+                            )
+                            .lineLimit(1)
                     }
-                    .foregroundStyle(isSelected ? Theme.accent : (hoveredTab == tab ? Color.white : Theme.fgMuted))
+                    .frame(width: 46)
                     .padding(.vertical, 4)
-                    .animation(.snappy(duration: 0.16), value: isSelected)
-                    .animation(.snappy(duration: 0.14), value: hoveredTab == tab)
+                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .disabled(isStubbed)
                 .onHover { hovering in
                     hoveredTab = hovering ? tab : (hoveredTab == tab ? nil : hoveredTab)
                 }
             }
+
+            Spacer(minLength: 0)
+
+            helpMenuButton
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.bottom, 16)
+        .padding(.vertical, 14)
+        .padding(.horizontal, 2)
+        .frame(width: 50)
+        .background(Color.black.opacity(0.18))
     }
 
-    private var inspectorFooter: some View {
-        HStack(spacing: 8) {
-            InspectorFooterButton(title: "Report Bug", symbolName: "ladybug") {
+    private var helpMenuButton: some View {
+        Menu {
+            Button("Report Bug…") {
                 openExternal(OpenRecorderLinks.issueChooser)
             }
-            InspectorFooterButton(title: "Star on GitHub", symbolName: "star") {
+            Button("Star on GitHub…") {
                 openExternal(OpenRecorderLinks.repository)
             }
+        } label: {
+            Image(systemName: "questionmark.circle")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(Theme.fgMuted)
+                .frame(width: 32, height: 32)
+                .contentShape(Circle())
         }
-        .padding(12)
-        .background(Theme.surface.opacity(0.60))
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 32, height: 32)
+        .help("Help & Support")
     }
 
     @ViewBuilder
@@ -137,39 +164,96 @@ struct SettingsInspector: View {
         switch activeTab {
         case .appearance:
             BackgroundPickerView(selection: $background, showsTopDivider: false)
-            InspectorGroup(title: "Frame", symbolName: "rectangle.on.rectangle") {
+            InspectorGroup(
+                title: "Frame",
+                symbolName: "rectangle.on.rectangle",
+                onReset: {
+                    withAnimation(.snappy(duration: 0.28)) {
+                        padding = 18
+                        borderRadius = 0
+                        backgroundBlur = 0
+                        shadow = 0.35
+                        removeCameraBackground = false
+                    }
+                }
+            ) {
                 InspectorSlider(title: "Padding", valueText: "\(Int(padding))%", value: $padding, range: 0...100, step: 1, defaultValue: 18, leadingSymbolName: "arrow.down.right.and.arrow.up.left", trailingSymbolName: "arrow.up.left.and.arrow.down.right")
+                InspectorSlider(title: "Radius", valueText: "\(Int(borderRadius))px", value: $borderRadius, range: 0...50, step: 1, defaultValue: 0, leadingSymbolName: "rectangle", trailingSymbolName: "app")
                 InspectorSlider(title: "Background Blur", valueText: String(format: "%.1fpx", backgroundBlur), value: $backgroundBlur, range: 0...8, step: 0.25, defaultValue: 0, leadingSymbolName: "camera.filters", trailingSymbolName: "drop.fill")
                 InspectorSlider(title: "Shadow", valueText: "\(Int(shadow * 100))%", value: $shadow, range: 0...1, step: 0.01, defaultValue: 0.35, leadingSymbolName: "circle", trailingSymbolName: "circle.fill")
+                InspectorSwitch(title: "Remove background", isOn: $removeCameraBackground)
             }
-            InspectorGroup(title: "Shape", symbolName: "rectangle.inset.filled") {
-                InspectorSlider(title: "Roundness", valueText: "\(Int(borderRadius))px", value: $borderRadius, range: 0...25, step: 0.5, defaultValue: 0, leadingSymbolName: "rectangle", trailingSymbolName: "app")
-            }
-            InspectorGroup(title: "Inset Styling", symbolName: "square.inset.filled") {
+            InspectorGroup(
+                title: "Inset Styling",
+                symbolName: "square.inset.filled",
+                isSecondary: true,
+                onReset: {
+                    withAnimation(.snappy(duration: 0.28)) {
+                        inset = 0
+                        insetOpacity = 1
+                        insetColor = BackgroundPresets.solidColors[0]
+                    }
+                }
+            ) {
                 InspectorSlider(title: "Inset", valueText: "\(Int(inset.rounded()))", value: $inset, range: 0...100, step: 1, defaultValue: 0, leadingSymbolName: "rectangle", trailingSymbolName: "rectangle.inset.filled")
                 if showsInsetControls {
                     insetAdvancedControls
                 }
             }
         case .cursor:
-            InspectorGroup(title: "Cursor", symbolName: "cursorarrow", showsTopDivider: false) {
+            InspectorGroup(
+                title: "Cursor",
+                symbolName: "cursorarrow",
+                showsTopDivider: false,
+                onReset: {
+                    withAnimation(.snappy(duration: 0.28)) {
+                        showCursor = true
+                        cursorStyleID = CursorStyleRegistry.defaultStyleID
+                    }
+                }
+            ) {
                 InspectorSwitch(title: "Show Cursor", isOn: $showCursor)
                 CursorStylePicker(selection: $cursorStyleID)
             }
-            InspectorGroup(title: "Motion", symbolName: "point.3.connected.trianglepath.dotted") {
+            InspectorGroup(
+                title: "Motion",
+                symbolName: "point.3.connected.trianglepath.dotted",
+                onReset: {
+                    withAnimation(.snappy(duration: 0.28)) {
+                        loopCursor = false
+                        cursorSize = 1
+                        cursorSmoothing = 0.45
+                    }
+                }
+            ) {
                 InspectorSwitch(title: "Loop Cursor", isOn: $loopCursor)
                 InspectorSlider(title: "Size", valueText: String(format: "%.2fx", cursorSize), value: $cursorSize, range: 1...8, step: 0.05, defaultValue: 1, leadingSymbolName: "cursorarrow", trailingSymbolName: "cursorarrow.rays")
                 InspectorSlider(title: "Smoothing", valueText: String(format: "%.2f", cursorSmoothing), value: $cursorSmoothing, range: 0...2, step: 0.01, defaultValue: 0.45, leadingSymbolName: "point.topleft.down.curvedto.point.bottomright.up", trailingSymbolName: "waveform.path.ecg")
             }
         case .camera:
             InspectorGroup(title: "Facecam", symbolName: "camera", showsTopDivider: false) {
-                Text(hasRecordedCamera ? "Timeline camera layer" : "No facecam recorded")
+                Text(hasRecordedCamera ? "Timeline camera layer active" : "No facecam recorded")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+                InspectorSwitch(title: "Remove camera background", isOn: $removeCameraBackground)
             }
             if let path = recordingSession?.facecamVideoPath {
                 SessionAssetRow(title: "Facecam File", path: path)
+            }
+        case .captions:
+            InspectorGroup(title: "Captions", symbolName: "captions.bubble.fill", showsTopDivider: false) {
+                Text("Automatic AI speech-to-text captions coming soon.")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            }
+        case .settings:
+            InspectorGroup(title: "Settings", symbolName: "gearshape.fill", showsTopDivider: false) {
+                Text("Export presets and canvas configuration.")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
             }
         case .audio:
             InspectorGroup(title: "Preview", symbolName: "speaker.wave.2", showsTopDivider: false) {
@@ -220,8 +304,6 @@ struct SessionAssetRow: View {
     }
 }
 
-
-
 struct InspectorFooterButton: View {
     var title: String
     var symbolName: String
@@ -254,32 +336,37 @@ struct InspectorFooterButton: View {
     }
 }
 
-enum InspectorTab: CaseIterable, Identifiable {
+enum InspectorTab: String, CaseIterable, Identifiable {
     case appearance
     case cursor
     case camera
+    case captions
+    case settings
     case audio
 
-    // Audio preview controls are not implemented yet. Keep the case for source
-    // and state compatibility, but do not advertise controls that cannot work.
     static let availableCases: [InspectorTab] = [.appearance, .cursor, .camera]
+    static let railCases: [InspectorTab] = [.appearance, .cursor, .camera, .captions, .settings]
 
-    var id: String { title }
+    var id: String { rawValue }
 
     var title: String {
         switch self {
         case .appearance: "Appearance"
         case .cursor: "Cursor"
         case .camera: "Camera"
+        case .captions: "Captions"
+        case .settings: "Settings"
         case .audio: "Audio"
         }
     }
 
-    var subtitle: String {
+    var shortTitle: String {
         switch self {
-        case .appearance: "Appearance"
+        case .appearance: "Frame"
         case .cursor: "Cursor"
         case .camera: "Camera"
+        case .captions: "Captions"
+        case .settings: "Settings"
         case .audio: "Audio"
         }
     }
@@ -289,38 +376,64 @@ enum InspectorTab: CaseIterable, Identifiable {
         case .appearance: "slider.horizontal.3"
         case .cursor: "cursorarrow"
         case .camera: "camera"
+        case .captions: "captions.bubble.fill"
+        case .settings: "gearshape.fill"
         case .audio: "speaker.wave.2"
+        }
+    }
+
+    var isStubbed: Bool {
+        switch self {
+        case .appearance, .cursor, .camera: false
+        case .captions, .settings, .audio: true
+        }
+    }
+
+    var helpText: String {
+        switch self {
+        case .appearance: "Appearance & Frame"
+        case .cursor: "Cursor Settings"
+        case .camera: "Camera & Facecam"
+        case .captions: "Captions (Coming Soon)"
+        case .settings: "Project Settings (Coming Soon)"
+        case .audio: "Audio Preview"
         }
     }
 }
 
 struct InspectorGroup<Content: View>: View {
     var title: String
-    var symbolName: String
-    var showsTopDivider = true
+    var symbolName: String? = nil
+    var showsTopDivider = false
+    var isSecondary = false
+    var onReset: (() -> Void)? = nil
     @ViewBuilder var content: Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if showsTopDivider {
-                Rectangle()
-                    .fill(Theme.borderStrong.opacity(0.55))
-                    .frame(height: 1)
-            }
-
             HStack(spacing: 8) {
-                Text(title)
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(Theme.fg.opacity(0.94))
+                Text(title.uppercased())
+                    .font(.system(size: isSecondary ? 9.5 : 11, weight: isSecondary ? .semibold : .bold))
+                    .kerning(isSecondary ? 0.8 : 1.2)
+                    .foregroundStyle(isSecondary ? Theme.fgMuted.opacity(0.60) : Theme.fgSubtle)
+
                 Spacer(minLength: 0)
+
+                if let onReset {
+                    StudioButton(hitTarget: .rounded(Theme.radiusSm), action: onReset) {
+                        Text("Reset")
+                            .font(.system(size: isSecondary ? 10 : 11, weight: .medium))
+                            .foregroundStyle(isSecondary ? Theme.fgMuted.opacity(0.60) : Theme.fgSubtle)
+                    }
+                }
             }
-            .padding(.top, 18)
-            .padding(.bottom, 17)
+            .padding(.top, isSecondary ? 16 : 22)
+            .padding(.bottom, isSecondary ? 10 : 14)
 
             VStack(alignment: .leading, spacing: 12) {
                 content
             }
-            .padding(.bottom, 18)
+            .padding(.bottom, isSecondary ? 8 : 12)
         }
     }
 }
@@ -368,11 +481,11 @@ struct InspectorSlider: View {
                 valueText: displayValueText,
                 onEditingChanged: onEditingChanged,
                 dragStep: intermediateStep,
-                trackHeight: 26,
-                hitHeight: 26,
+                trackHeight: 22,
+                hitHeight: 22,
                 fillColor: Color.white.opacity(0.20),
-                thumbWidth: 40,
-                thumbHeight: 18,
+                thumbWidth: 32,
+                thumbHeight: 16,
                 showStepDots: true,
                 showTooltip: false,
                 setsValueFromPointerLocation: true
@@ -407,7 +520,7 @@ struct InspectorSlider: View {
                 }
             } label: {
                 Text("Reset")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(Theme.fgSubtle)
             }
         }
@@ -416,20 +529,22 @@ struct InspectorSlider: View {
     private var valueInput: some View {
         TextField("", text: $draftValueText)
             .font(.system(size: 11, weight: .semibold, design: .monospaced))
-            .foregroundStyle(isInputFocused ? Theme.accent : Theme.fgMuted)
+            .foregroundStyle(isInputFocused ? Color.white : Theme.fg.opacity(0.88))
             .monospacedDigit()
-            .multilineTextAlignment(.trailing)
+            .multilineTextAlignment(.center)
             .textFieldStyle(.plain)
             .focused($isInputFocused)
-            .fixedSize(horizontal: true, vertical: false)
-            .overlay(alignment: .bottom) {
-                if isInputFocused {
-                    Rectangle()
-                        .fill(Theme.accent)
-                        .frame(height: 1)
-                        .offset(y: 2)
-                }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(Color.black.opacity(isInputFocused ? 0.45 : 0.25))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .stroke(isInputFocused ? Theme.accent : Color.white.opacity(0.08), lineWidth: 1)
             }
+            .fixedSize(horizontal: true, vertical: false)
             .onSubmit(commitDraftValue)
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -43,7 +43,7 @@ struct SettingsInspector: View {
 
     var body: some View {
         inspectorContent
-            .studioEditorPaneChrome()
+            .studioEditorPaneChrome(bg: Theme.sidebarBg)
             .onChange(of: showsInsetControls) { _, isVisible in
                 if !isVisible {
                     isInsetBalanceExpanded = false
@@ -103,18 +103,18 @@ struct SettingsInspector: View {
                             .font(.system(size: 16, weight: isSelected ? .bold : .medium))
                             .foregroundStyle(
                                 isSelected
-                                    ? Theme.accent
-                                    : (isStubbed ? Theme.fgMuted.opacity(0.30) : (hoveredTab == tab ? Color.white : Theme.fgMuted.opacity(0.70)))
+                                    ? Color.white
+                                    : (isStubbed ? Theme.fgDisabled : (hoveredTab == tab ? Color.white : Theme.fgMuted))
                             )
-                            .shadow(color: isSelected ? Theme.accent.opacity(0.45) : Color.clear, radius: 6, y: 1)
+                            .shadow(color: isSelected ? Color.white.opacity(0.35) : Color.clear, radius: 6, y: 1)
                             .frame(width: 32, height: 26)
 
                         Text(tab.shortTitle)
                             .font(.system(size: 9.5, weight: isSelected ? .bold : .medium))
                             .foregroundStyle(
                                 isSelected
-                                    ? Theme.accent
-                                    : (isStubbed ? Theme.fgMuted.opacity(0.30) : (hoveredTab == tab ? Color.white : Theme.fgMuted.opacity(0.70)))
+                                    ? Color.white
+                                    : (isStubbed ? Theme.fgDisabled : (hoveredTab == tab ? Color.white : Theme.fgMuted))
                             )
                             .lineLimit(1)
                     }
@@ -135,7 +135,7 @@ struct SettingsInspector: View {
         .padding(.vertical, 14)
         .padding(.horizontal, 2)
         .frame(width: 50)
-        .background(Color.black.opacity(0.18))
+        .background(Theme.railBg)
     }
 
     private var helpMenuButton: some View {
@@ -484,8 +484,7 @@ struct InspectorSlider: View {
                 trackHeight: 22,
                 hitHeight: 22,
                 fillColor: Color.white.opacity(0.20),
-                thumbWidth: 32,
-                thumbHeight: 16,
+                thumbSize: 16,
                 showStepDots: true,
                 showTooltip: false,
                 setsValueFromPointerLocation: true
@@ -528,22 +527,14 @@ struct InspectorSlider: View {
 
     private var valueInput: some View {
         TextField("", text: $draftValueText)
-            .font(.system(size: 11, weight: .semibold, design: .monospaced))
-            .foregroundStyle(isInputFocused ? Color.white : Theme.fg.opacity(0.88))
+            .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+            .foregroundStyle(isInputFocused ? Color.white : Theme.fgMuted)
             .monospacedDigit()
-            .multilineTextAlignment(.center)
+            .multilineTextAlignment(.trailing)
             .textFieldStyle(.plain)
             .focused($isInputFocused)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(Color.black.opacity(isInputFocused ? 0.45 : 0.25))
-            )
-            .overlay {
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .stroke(isInputFocused ? Theme.accent : Color.white.opacity(0.08), lineWidth: 1)
-            }
+            .padding(.horizontal, 2)
+            .padding(.vertical, 1)
             .fixedSize(horizontal: true, vertical: false)
             .onSubmit(commitDraftValue)
     }
@@ -763,8 +754,8 @@ struct InsetBalancePicker: View {
                     .foregroundStyle(Theme.fgMuted)
                 Spacer()
                 Text(offsetText(for: balance.clamped))
-                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(Theme.fg.opacity(0.92))
+                    .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                    .foregroundStyle(Theme.fgMuted)
             }
 
             GeometryReader { proxy in
@@ -972,10 +963,10 @@ struct CursorStyleButton: View {
             .frame(maxWidth: .infinity)
             .frame(height: 58)
             .foregroundStyle(isSelected ? Color.white : Color.primary.opacity(0.86))
-            .background(isSelected ? Theme.accent.opacity(0.82) : Theme.overlay, in: RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous))
+            .background(isSelected ? Color.white.opacity(0.18) : Theme.overlay, in: RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous)
-                    .stroke(isSelected ? Theme.accent.opacity(0.95) : Theme.overlay)
+                    .stroke(isSelected ? Color.white.opacity(0.85) : Theme.overlay)
             }
         }
     }

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -474,6 +474,39 @@ enum FacecamAnchor: String, CaseIterable, Identifiable, Codable, Hashable {
     static func resolve(_ rawValue: String) -> FacecamAnchor {
         FacecamAnchor(rawValue: rawValue) ?? .bottomRight
     }
+
+    static func from(relX: CGFloat, relYFromTop: CGFloat) -> FacecamAnchor {
+        let col: Int
+        if relX < 0.33 {
+            col = 0
+        } else if relX > 0.67 {
+            col = 2
+        } else {
+            col = 1
+        }
+
+        let row: Int
+        if relYFromTop < 0.33 {
+            row = 0
+        } else if relYFromTop > 0.67 {
+            row = 2
+        } else {
+            row = 1
+        }
+
+        switch (row, col) {
+        case (0, 0): return .topLeft
+        case (0, 1): return .top
+        case (0, 2): return .topRight
+        case (1, 0): return .left
+        case (1, 1): return .center
+        case (1, 2): return .right
+        case (2, 0): return .bottomLeft
+        case (2, 1): return .bottom
+        case (2, 2): return .bottomRight
+        default: return .bottomRight
+        }
+    }
 }
 
 struct FacecamSettings: Codable, Hashable {

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -29,12 +29,22 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
         handleWindowCommand(model.windowCommand)
     }
 
+    var isCameraEnabled: Bool {
+        model?.includeCamera ?? false
+    }
+
     func installWindowActions(
         openWindow: @escaping (String) -> Void,
         openEditor: @escaping (EditorSession) -> Void,
-        dismissWindow: @escaping (String) -> Void
+        dismissWindow: @escaping (String) -> Void,
+        shouldKeepCameraBubble: @escaping () -> Bool = { false }
     ) {
-        windowActions.install(openWindow: openWindow, openEditor: openEditor, dismissWindow: dismissWindow)
+        windowActions.install(
+            openWindow: openWindow,
+            openEditor: openEditor,
+            dismissWindow: dismissWindow,
+            shouldKeepCameraBubble: shouldKeepCameraBubble
+        )
         handleWindowCommand(model?.windowCommand)
     }
 
@@ -252,7 +262,10 @@ private struct AppWindowActionBridge: View {
                 appDelegate.installWindowActions(
                     openWindow: { id in openWindow(id: id) },
                     openEditor: { session in openWindow(id: "editor", value: session) },
-                    dismissWindow: { id in dismissWindow(id: id) }
+                    dismissWindow: { id in dismissWindow(id: id) },
+                    shouldKeepCameraBubble: { [weak appDelegate] in
+                        appDelegate?.isCameraEnabled ?? false
+                    }
                 )
             }
     }
@@ -264,6 +277,7 @@ final class AppWindowActions {
     private var openWindow: (String) -> Void = { _ in }
     private var openEditor: (EditorSession) -> Void = { _ in }
     private var dismissWindow: (String) -> Void = { _ in }
+    private var shouldKeepCameraBubble: () -> Bool = { false }
     private var hideApp: () -> Void = {
         NSApplication.shared.hide(nil)
     }
@@ -278,6 +292,7 @@ final class AppWindowActions {
         openWindow: @escaping (String) -> Void,
         openEditor: @escaping (EditorSession) -> Void,
         dismissWindow: @escaping (String) -> Void,
+        shouldKeepCameraBubble: @escaping () -> Bool = { false },
         activateApp: @escaping () -> Void = {
             NSApplication.shared.activate(ignoringOtherApps: true)
         },
@@ -291,6 +306,7 @@ final class AppWindowActions {
         self.openWindow = openWindow
         self.openEditor = openEditor
         self.dismissWindow = dismissWindow
+        self.shouldKeepCameraBubble = shouldKeepCameraBubble
         self.activateApp = activateApp
         self.hideApp = hideApp
         self.unhideApp = unhideApp
@@ -361,7 +377,7 @@ final class AppWindowActions {
             openWindow("area-selector")
         case .showStudio:
             unhideApp()
-            dismissCaptureWindows()
+            dismissCaptureWindows(alwaysDismissCameraBubble: true)
             if let editorSession = command.editorSession {
                 openEditor(editorSession)
             } else {
@@ -382,18 +398,22 @@ final class AppWindowActions {
         }
     }
 
-    private func dismissCaptureWindows() {
+    private func dismissCaptureWindows(alwaysDismissCameraBubble: Bool = false) {
         dismissWindow("hud")
         dismissWindow("source-selector")
         dismissWindow("area-selector")
         dismissWindow("microphone-selector")
         dismissWindow("camera-selector")
-        dismissWindow("camera-bubble")
+        if alwaysDismissCameraBubble || !shouldKeepCameraBubble() {
+            dismissWindow("camera-bubble")
+        }
     }
 
     private func hideAppWindowsForCapture() {
         dismissCaptureWindows()
-        hideApp()
+        if !shouldKeepCameraBubble() {
+            hideApp()
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -111,7 +111,7 @@ struct OpenRecorderApp: App {
                 }
         }
         .windowStyle(.hiddenTitleBar)
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
         .defaultSize(width: HUDWindowMetrics.defaultSize.width, height: HUDWindowMetrics.defaultSize.height)
 
         Window("Open Recorder Setup", id: "onboarding") {
@@ -577,77 +577,152 @@ private final class OpenRecorderStatusItemController: NSObject {
 @MainActor
 private final class GlobalRecordingHotKeyController {
     private weak var model: AppModel?
-    private var hotKeyRef: EventHotKeyRef?
+    private var hotKeyRefs: [UInt32: EventHotKeyRef] = [:]
+    private var registeredCombinations: [UInt32: KeyCombination] = [:]
     private var eventHandlerRef: EventHandlerRef?
     private var cancellables: Set<AnyCancellable> = []
 
     func attach(model: AppModel) {
         if self.model === model {
-            syncRegistration(captureState: model.captureState, runtimeIsRecording: model.capture.isRecording)
+            syncRegistration(
+                captureState: model.captureState,
+                runtimeIsRecording: model.capture.isRecording,
+                shortcuts: model.shortcutPreferences
+            )
             return
         }
 
-        unregister()
+        unregisterAll()
         cancellables.removeAll()
         self.model = model
 
         model.$captureState
             .sink { [weak self, weak model] state in
                 guard let model else { return }
-                self?.syncRegistration(captureState: state, runtimeIsRecording: model.capture.isRecording)
+                self?.syncRegistration(
+                    captureState: state,
+                    runtimeIsRecording: model.capture.isRecording,
+                    shortcuts: model.shortcutPreferences
+                )
             }
             .store(in: &cancellables)
 
         model.capture.$isRecording
             .sink { [weak self, weak model] isRecording in
                 guard let model else { return }
-                self?.syncRegistration(captureState: model.captureState, runtimeIsRecording: isRecording)
+                self?.syncRegistration(
+                    captureState: model.captureState,
+                    runtimeIsRecording: isRecording,
+                    shortcuts: model.shortcutPreferences
+                )
             }
             .store(in: &cancellables)
 
-        syncRegistration(captureState: model.captureState, runtimeIsRecording: model.capture.isRecording)
+        model.$shortcutPreferences
+            .sink { [weak self, weak model] shortcuts in
+                guard let model else { return }
+                self?.syncRegistration(
+                    captureState: model.captureState,
+                    runtimeIsRecording: model.capture.isRecording,
+                    shortcuts: shortcuts
+                )
+            }
+            .store(in: &cancellables)
+
+        syncRegistration(
+            captureState: model.captureState,
+            runtimeIsRecording: model.capture.isRecording,
+            shortcuts: model.shortcutPreferences
+        )
     }
 
-    private func syncRegistration(captureState: CaptureState, runtimeIsRecording: Bool) {
-        if captureState.shouldRegisterRecordingHotKey(runtimeIsRecording: runtimeIsRecording) {
-            registerIfNeeded()
-        } else {
-            unregister()
+    private func syncRegistration(
+        captureState: CaptureState,
+        runtimeIsRecording: Bool,
+        shortcuts: ShortcutPreferences
+    ) {
+        guard installEventHandlerIfNeeded() else { return }
+
+        let actionMap: [(UInt32, CaptureShortcutAction)] = [
+            (1, .toggleRecording),
+            (2, .deviceScreenshot),
+            (3, .dragScreenshot),
+            (4, .deviceScreenRecord),
+            (5, .dragScreenRecord)
+        ]
+
+        for (id, action) in actionMap {
+            let item = shortcuts.item(for: action)
+            let isAllowedByCaptureState: Bool
+            if action == .toggleRecording {
+                isAllowedByCaptureState = captureState.shouldRegisterRecordingHotKey(runtimeIsRecording: runtimeIsRecording)
+            } else {
+                isAllowedByCaptureState = true
+            }
+
+            if item.isEnabled && isAllowedByCaptureState {
+                registerIfNeeded(id: id, combination: item.keyCombination)
+            } else {
+                unregister(id: id)
+            }
         }
     }
 
-    private func registerIfNeeded() {
-        guard hotKeyRef == nil else { return }
+    private func registerIfNeeded(id: UInt32, combination: KeyCombination) {
+        if let existing = registeredCombinations[id], existing == combination, hotKeyRefs[id] != nil {
+            return
+        }
 
-        guard installEventHandlerIfNeeded() else { return }
+        unregister(id: id)
 
-        let hotKeyID = EventHotKeyID(signature: fourCharCode("ORcd"), id: 1)
+        var ref: EventHotKeyRef?
+        let hotKeyID = EventHotKeyID(signature: fourCharCode("ORhk"), id: id)
         let status = RegisterEventHotKey(
-            UInt32(kVK_ANSI_R),
-            UInt32(cmdKey),
+            combination.keyCode,
+            combination.carbonModifiers,
             hotKeyID,
             GetApplicationEventTarget(),
             0,
-            &hotKeyRef
+            &ref
         )
 
-        if status != noErr {
-            hotKeyRef = nil
-            unregister()
+        if status == noErr, let ref {
+            hotKeyRefs[id] = ref
+            registeredCombinations[id] = combination
         }
+    }
+
+    private func unregister(id: UInt32) {
+        if let ref = hotKeyRefs.removeValue(forKey: id) {
+            UnregisterEventHotKey(ref)
+        }
+        registeredCombinations.removeValue(forKey: id)
     }
 
     private func installEventHandlerIfNeeded() -> Bool {
         guard eventHandlerRef == nil else { return true }
 
         var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-        let callback: EventHandlerUPP = { _, _, userData in
-            guard let userData else { return noErr }
+        let callback: EventHandlerUPP = { _, eventRef, userData in
+            guard let userData, let eventRef else { return noErr }
+            var hotKeyID = EventHotKeyID()
+            let status = GetEventParameter(
+                eventRef,
+                EventParamName(kEventParamDirectObject),
+                EventParamType(typeEventHotKeyID),
+                nil,
+                MemoryLayout<EventHotKeyID>.size,
+                nil,
+                &hotKeyID
+            )
+            guard status == noErr else { return noErr }
+
             let controller = Unmanaged<GlobalRecordingHotKeyController>
                 .fromOpaque(userData)
                 .takeUnretainedValue()
+            let targetID = hotKeyID.id
             Task { @MainActor in
-                controller.model?.toggleRecordingShortcut()
+                controller.handleHotKey(id: targetID)
             }
             return noErr
         }
@@ -668,11 +743,30 @@ private final class GlobalRecordingHotKeyController {
         return status == noErr
     }
 
-    private func unregister() {
-        if let hotKeyRef {
-            UnregisterEventHotKey(hotKeyRef)
-            self.hotKeyRef = nil
+    private func handleHotKey(id: UInt32) {
+        guard let model else { return }
+        switch id {
+        case 1:
+            model.toggleRecordingShortcut()
+        case 2:
+            model.triggerDeviceScreenshot()
+        case 3:
+            model.triggerDragScreenshot()
+        case 4:
+            model.triggerDeviceScreenRecord()
+        case 5:
+            model.triggerDragScreenRecord()
+        default:
+            break
         }
+    }
+
+    private func unregisterAll() {
+        for (_, ref) in hotKeyRefs {
+            UnregisterEventHotKey(ref)
+        }
+        hotKeyRefs.removeAll()
+        registeredCombinations.removeAll()
 
         if let eventHandlerRef {
             RemoveEventHandler(eventHandlerRef)

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -131,6 +131,8 @@ struct OpenRecorderApp: App {
                 .background(AppWindowActionBridge(appDelegate: appDelegate))
         }
         .windowResizability(.contentSize)
+        .defaultLaunchBehavior(.suppressed)
+        .restorationBehavior(.disabled)
         .defaultSize(width: SourceSelectorWindowMetrics.width, height: SourceSelectorWindowMetrics.compactHeight)
 
         Window("Choose Microphone", id: "microphone-selector") {

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -135,7 +135,17 @@ final class RecordingCountdownOverlayController {
         window.contentView = NSHostingView(rootView: RecordingCountdownOverlay(state: state))
         self.window = window
         window.setFrame(frame, display: true)
+        // NSApp may have been hidden (via hideAppWindowsForCapture). Temporarily
+        // unhide the app so the countdown window can be shown, then re-hide all
+        // other app windows so only the overlay (at .screenSaver level) is visible.
+        NSApp.unhide(nil)
         window.orderFrontRegardless()
+        // Hide all other app windows except our countdown window
+        for appWindow in NSApp.windows where appWindow !== window {
+            if appWindow.isVisible {
+                appWindow.orderOut(nil)
+            }
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -23,6 +23,10 @@ enum RecordingCountdownTargetResolver {
                let screen = screens.first(where: { $0.displayID == displayID }) {
                 return screen.frame
             }
+            if let displayIndex = source.displayIndex,
+               displayIndex > 0, displayIndex <= screens.count {
+                return screens[displayIndex - 1].frame
+            }
             return fallback
         case .area:
             guard let area = source.area else { return fallback }
@@ -52,7 +56,11 @@ enum RecordingCountdownTargetResolver {
     private static func fallbackFrame(for source: CaptureSource, screens: [RecordingOverlayScreen]) -> CGRect {
         if let displayID = source.displayID,
            let screen = screens.first(where: { $0.displayID == displayID }) {
-            return screen.frame
+                return screen.frame
+        }
+        if let displayIndex = source.displayIndex,
+           displayIndex > 0, displayIndex <= screens.count {
+            return screens[displayIndex - 1].frame
         }
         return screens.first?.frame ?? CGRect(x: 0, y: 0, width: 900, height: 600)
     }
@@ -135,17 +143,9 @@ final class RecordingCountdownOverlayController {
         window.contentView = NSHostingView(rootView: RecordingCountdownOverlay(state: state))
         self.window = window
         window.setFrame(frame, display: true)
-        // NSApp may have been hidden (via hideAppWindowsForCapture). Temporarily
-        // unhide the app so the countdown window can be shown, then re-hide all
-        // other app windows so only the overlay (at .screenSaver level) is visible.
-        NSApp.unhide(nil)
+        window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
-        // Hide all other app windows except our countdown window
-        for appWindow in NSApp.windows where appWindow !== window {
-            if appWindow.isVisible {
-                appWindow.orderOut(nil)
-            }
-        }
+        NSApp.activate(ignoringOtherApps: true)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/RecordingPreferencesStore.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingPreferencesStore.swift
@@ -3,12 +3,24 @@ import Foundation
 struct RecordingPreferences: Equatable {
     var createsZoomsAutomatically: Bool
     var autoZoomAnimationPreset: TimelineZoomAnimationPreset
+    var shortcuts: ShortcutPreferences = .defaultPreferences
+
+    init(
+        createsZoomsAutomatically: Bool = true,
+        autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced,
+        shortcuts: ShortcutPreferences = .defaultPreferences
+    ) {
+        self.createsZoomsAutomatically = createsZoomsAutomatically
+        self.autoZoomAnimationPreset = autoZoomAnimationPreset
+        self.shortcuts = shortcuts
+    }
 }
 
 @MainActor
 struct RecordingPreferencesStore {
     private static let createsZoomsAutomaticallyKey = "recording.createZoomsAutomatically"
     private static let autoZoomAnimationPresetKey = "recording.autoZoomAnimationPreset"
+    private static let shortcutsKey = "recording.shortcuts"
 
     private let defaults: UserDefaults
 
@@ -17,11 +29,20 @@ struct RecordingPreferencesStore {
     }
 
     func load() -> RecordingPreferences {
-        RecordingPreferences(
+        let shortcuts: ShortcutPreferences
+        if let data = defaults.data(forKey: Self.shortcutsKey),
+           let decoded = try? JSONDecoder().decode(ShortcutPreferences.self, from: data) {
+            shortcuts = decoded
+        } else {
+            shortcuts = .defaultPreferences
+        }
+
+        return RecordingPreferences(
             createsZoomsAutomatically: defaults.object(forKey: Self.createsZoomsAutomaticallyKey) as? Bool ?? true,
             autoZoomAnimationPreset: TimelineZoomAnimationPreset.storedValue(
                 defaults.string(forKey: Self.autoZoomAnimationPresetKey)
-            )
+            ),
+            shortcuts: shortcuts
         )
     }
 
@@ -31,5 +52,11 @@ struct RecordingPreferencesStore {
 
     func setAutoZoomAnimationPreset(_ preset: TimelineZoomAnimationPreset) {
         defaults.set(preset.rawValue, forKey: Self.autoZoomAnimationPresetKey)
+    }
+
+    func setShortcuts(_ shortcuts: ShortcutPreferences) {
+        if let data = try? JSONEncoder().encode(shortcuts) {
+            defaults.set(data, forKey: Self.shortcutsKey)
+        }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/RecordingSessionBuilder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingSessionBuilder.swift
@@ -4,6 +4,7 @@ struct RecordingSessionBuilder {
     static func build(
         screenVideoURL: URL,
         facecamURL: URL?,
+        facecamSettings: FacecamSettings? = nil,
         sourceName: String?,
         showCursor: Bool,
         cursorTelemetryURL: URL?,
@@ -17,11 +18,13 @@ struct RecordingSessionBuilder {
             offsetMs = nil
         }
 
+        let initialSettings = (facecamSettings ?? defaultFacecamSettings(enabled: facecamURL != nil)).clamped
+
         return RecordingSession(
             screenVideoPath: screenVideoURL.path,
             facecamVideoPath: facecamURL?.path,
             facecamOffsetMs: offsetMs,
-            facecamSettings: defaultFacecamSettings(enabled: facecamURL != nil),
+            facecamSettings: initialSettings,
             sourceName: sourceName,
             showCursorOverlay: showCursor,
             cursorTelemetryPath: cursorTelemetryURL?.path

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
@@ -60,14 +60,7 @@ struct ScreenshotEditorStudioView: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .background(Theme.surface.opacity(0.88), in: RoundedRectangle(cornerRadius: Theme.radiusLg, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: Theme.radiusLg, style: .continuous)
-                .stroke(Theme.borderStrong.opacity(0.65), lineWidth: 1)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: Theme.radiusLg, style: .continuous))
-        .padding(16)
-        .background(Theme.appBgMuted)
+        .background(Theme.appBg)
         .sheet(isPresented: editor.exportDialogBinding) {
             ScreenshotExportDialog(
                 onSave: {

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
@@ -456,7 +456,7 @@ struct ScreenshotSettingsPanel: View {
             .padding(12)
             .background(Color.white.opacity(0.025))
         }
-        .studioEditorPaneChrome()
+        .studioEditorPaneChrome(bg: Theme.sidebarBg)
     }
 
     private var header: some View {

--- a/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
@@ -16,17 +16,55 @@ struct SettingsStudioView: View {
                 Text("Settings")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(Theme.fg)
-                SettingsSection(title: "Service") {
-                    SettingsServiceStatusRow(state: resolvedServiceState)
-                    SettingsRow(title: "Platform", value: serviceHealth?.platform ?? "macOS")
-                    Button {
-                        driver.send(.serviceRefreshRequested)
-                    } label: {
-                        Label(resolvedServiceState.isChecking ? "Checking Service…" : "Check Service", systemImage: "bolt.horizontal")
+
+                SettingsSection(title: "Global Shortcuts") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Use Open Recorder's quick shortcuts from any application to capture screens and recordings.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Theme.fgMuted)
+                            .padding(.bottom, 4)
+
+                        SettingsShortcutRow(
+                            action: .deviceScreenshot,
+                            item: driver.shortcutBinding(for: .deviceScreenshot)
+                        )
+                        Divider().overlay(Color.white.opacity(0.06))
+                        SettingsShortcutRow(
+                            action: .dragScreenshot,
+                            item: driver.shortcutBinding(for: .dragScreenshot)
+                        )
+                        Divider().overlay(Color.white.opacity(0.06))
+                        SettingsShortcutRow(
+                            action: .deviceScreenRecord,
+                            item: driver.shortcutBinding(for: .deviceScreenRecord)
+                        )
+                        Divider().overlay(Color.white.opacity(0.06))
+                        SettingsShortcutRow(
+                            action: .dragScreenRecord,
+                            item: driver.shortcutBinding(for: .dragScreenRecord)
+                        )
+                        Divider().overlay(Color.white.opacity(0.06))
+                        SettingsShortcutRow(
+                            action: .toggleRecording,
+                            item: driver.shortcutBinding(for: .toggleRecording)
+                        )
+
+                        HStack {
+                            Spacer()
+                            Button("Restore Default Shortcuts") {
+                                driver.send(.shortcutsResetToDefaults)
+                            }
+                            .buttonStyle(.borderless)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(Theme.accent)
+                        }
+                        .padding(.top, 4)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.regular)
-                    .disabled(resolvedServiceState.isChecking)
+                }
+
+                SettingsSection(title: "Recording") {
+                    SettingsToggleRow(title: "Create zooms automatically", isOn: driver.autoZoomBinding)
+                    SettingsZoomPresetPicker(selection: driver.autoZoomAnimationPresetBinding)
                 }
 
                 SettingsSection(title: "Folders") {
@@ -39,11 +77,6 @@ struct SettingsStudioView: View {
                     FolderRow(title: "Projects", path: paths?.projectsDir) {
                         driver.send(.folderOpenRequested($0))
                     }
-                }
-
-                SettingsSection(title: "Recording") {
-                    SettingsToggleRow(title: "Create zooms automatically", isOn: driver.autoZoomBinding)
-                    SettingsZoomPresetPicker(selection: driver.autoZoomAnimationPresetBinding)
                 }
 
                 SettingsSection(title: "Permissions") {
@@ -72,6 +105,19 @@ struct SettingsStudioView: View {
                         .controlSize(.regular)
                     }
                 }
+
+                SettingsSection(title: "Service") {
+                    SettingsServiceStatusRow(state: resolvedServiceState)
+                    SettingsRow(title: "Platform", value: serviceHealth?.platform ?? "macOS")
+                    Button {
+                        driver.send(.serviceRefreshRequested)
+                    } label: {
+                        Label(resolvedServiceState.isChecking ? "Checking Service…" : "Check Service", systemImage: "bolt.horizontal")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+                    .disabled(resolvedServiceState.isChecking)
+                }
             }
             .frame(maxWidth: 760, alignment: .leading)
             .padding(32)
@@ -90,6 +136,68 @@ struct SettingsStudioView: View {
     }
 }
 
+private struct SettingsShortcutRow: View {
+    var action: CaptureShortcutAction
+    @Binding var item: ShortcutItem
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(action.title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(item.isEnabled ? Theme.fg : Theme.fgMuted)
+                Text(action.subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.fgMuted.opacity(0.8))
+            }
+
+            Spacer(minLength: 8)
+
+            Menu {
+                ForEach(action.availablePresets) { preset in
+                    Button {
+                        item.keyCombination = preset
+                        item.isEnabled = true
+                    } label: {
+                        HStack {
+                            Text(preset.displayString)
+                            if item.keyCombination == preset {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    Text(item.keyCombination.displayString)
+                        .font(.system(size: 12, weight: .bold, design: .monospaced))
+                        .foregroundStyle(item.isEnabled ? Color.white : Theme.fgMuted)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.fgMuted)
+                }
+                .padding(.horizontal, 9)
+                .padding(.vertical, 4)
+                .background(item.isEnabled ? Color.white.opacity(0.12) : Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(item.isEnabled ? Color.white.opacity(0.22) : Color.white.opacity(0.08), lineWidth: 1)
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .disabled(!item.isEnabled)
+
+            Toggle("", isOn: $item.isEnabled)
+                .toggleStyle(.switch)
+                .tint(Theme.accent)
+                .labelsHidden()
+                .controlSize(.small)
+        }
+        .padding(.vertical, 3)
+    }
+}
+
 private struct SettingsZoomPresetPicker: View {
     @Binding var selection: TimelineZoomAnimationPreset
 
@@ -98,7 +206,7 @@ private struct SettingsZoomPresetPicker: View {
             ForEach(TimelineZoomAnimationPreset.allCases) { preset in
                 Text(preset.title)
                     .tag(preset)
-                }
+            }
         }
         .pickerStyle(.menu)
         .foregroundStyle(Theme.fgMuted)
@@ -152,7 +260,7 @@ struct SettingsRow: View {
 
 private struct SettingsServiceStatusRow: View {
     var state: SettingsServicePresentationState
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             LabeledContent {

--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -65,8 +65,8 @@ extension View {
     }
 
     @ViewBuilder
-    func studioEditorPaneChrome(clipContent: Bool = true) -> some View {
-        background(Theme.surface.opacity(0.88))
+    func studioEditorPaneChrome(bg: Color = Theme.canvasBg, clipContent: Bool = true) -> some View {
+        background(bg)
     }
 
     @ViewBuilder
@@ -1124,12 +1124,17 @@ enum Theme {
     static let springSmooth: Animation = .spring(response: 0.32, dampingFraction: 0.80)
     static let springBouncy: Animation = .spring(response: 0.38, dampingFraction: 0.74)
 
-    // Surfaces
-    static let appBg          = Color(red: 0.035, green: 0.035, blue: 0.043)
+    // Surfaces — Harmonious Multi-Tier Neutral Greys
+    static let appBg          = Color(red: 0.040, green: 0.040, blue: 0.048) // Canvas stage grey
+    static let canvasBg       = Color(red: 0.040, green: 0.040, blue: 0.048) // Canvas preview grey
+    static let navbarBg       = Color(red: 0.086, green: 0.086, blue: 0.098) // Top Navbar grey
+    static let sidebarBg      = Color(red: 0.068, green: 0.068, blue: 0.078) // Right Inspector panel grey
+    static let railBg         = Color(red: 0.056, green: 0.056, blue: 0.065) // Vertical icon rail grey
+    static let timelineBg     = Color(red: 0.062, green: 0.062, blue: 0.072) // Bottom Timeline dock grey
     static let appBgMuted     = Color(red: 0.055, green: 0.055, blue: 0.067)
-    static let surface        = Color(red: 0.075, green: 0.075, blue: 0.088)
-    static let surfaceRaised  = Color(red: 0.10, green: 0.10, blue: 0.12)
-    static let surfaceControl = Color(red: 0.12, green: 0.12, blue: 0.145)
+    static let surface        = Color(red: 0.086, green: 0.086, blue: 0.098)
+    static let surfaceRaised  = Color(red: 0.105, green: 0.105, blue: 0.122)
+    static let surfaceControl = Color(red: 0.125, green: 0.125, blue: 0.145)
 
     // Foregrounds
     static let fg         = Color.white

--- a/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SharedStudioViews.swift
@@ -67,10 +67,6 @@ extension View {
     @ViewBuilder
     func studioEditorPaneChrome(clipContent: Bool = true) -> some View {
         background(Theme.surface.opacity(0.88))
-            .overlay {
-                Rectangle()
-                    .stroke(Theme.borderStrong.opacity(0.44), lineWidth: 0.5)
-            }
     }
 
     @ViewBuilder
@@ -789,6 +785,7 @@ struct HUDPermissionGroup: View {
 struct HUDModeSwitcher: View {
     @Binding var mode: CaptureMode
     var isDisabled: Bool
+    @Namespace private var animation
 
     var body: some View {
         HStack(spacing: 3) {
@@ -814,25 +811,27 @@ struct HUDModeSwitcher: View {
     private func modeButton(mode targetMode: CaptureMode, symbolName: String, help: String) -> some View {
         let isSelected = mode == targetMode
         return StudioButton(hitTarget: .rounded(Theme.radiusSm), help: help) {
-            withAnimation(Theme.springFast) {
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.78)) {
                 mode = targetMode
             }
         } label: {
-            Image(systemName: symbolName)
-                .font(.system(size: 12, weight: .bold))
-                .frame(width: 30, height: 30)
-                .foregroundStyle(isSelected ? Color.white : Theme.fgMuted)
-                .background(
-                    isSelected ? Theme.accent : Color.clear,
-                    in: RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                )
-                .overlay {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                            .stroke(Theme.accent.opacity(0.8), lineWidth: 1)
-                    }
+            ZStack {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
+                        .fill(Theme.accent)
+                        .matchedGeometryEffect(id: "modeIndicator", in: animation)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
+                                .stroke(Theme.accent.opacity(0.8), lineWidth: 1)
+                        }
+                        .shadow(color: Theme.accent.opacity(0.35), radius: 5, y: 1)
                 }
-                .shadow(color: isSelected ? Theme.accent.opacity(0.35) : Color.clear, radius: 5, y: 1)
+
+                Image(systemName: symbolName)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(isSelected ? Color.white : Theme.fgMuted)
+            }
+            .frame(width: 30, height: 30)
         }
         .disabled(isDisabled)
     }

--- a/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
@@ -273,18 +273,16 @@ struct StudioNavBar: View {
     private let items: [AppSection] = [.projects]
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 6) {
             ForEach(items) { section in
-                StudioNavButton(
+                StudioIconNavButton(
                     title: section.title,
-                    symbolName: navSymbol(for: section),
-                    isActive: selectedSection == section
+                    symbolName: navSymbol(for: section)
                 ) {
                     onSelectSection(section)
                 }
             }
         }
-        .padding(.horizontal, 4)
         .frame(height: 32)
     }
 
@@ -307,20 +305,17 @@ struct StudioNavButton: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 6) {
-                Image(systemName: symbolName)
-                    .font(.system(size: Theme.iconSm, weight: isActive ? .semibold : .medium))
-                    .frame(width: 16, height: 16)
-                Text(title)
-                    .font(.system(size: 13, weight: isActive ? .semibold : .medium))
-                    .lineLimit(1)
-            }
-            .foregroundStyle(isActive ? Theme.accent : (isHovering ? Color.white : Theme.fgMuted))
-            .animation(.snappy(duration: 0.16), value: isHovering)
-            .animation(.snappy(duration: 0.18), value: isActive)
+            Image(systemName: symbolName)
+                .font(.system(size: 13, weight: isActive ? .bold : .medium))
+                .frame(width: 26, height: 26)
+                .foregroundStyle(isActive ? Color.white : (isHovering ? Color.white : Theme.fgMuted))
+                .animation(.snappy(duration: 0.16), value: isHovering)
+                .animation(.snappy(duration: 0.18), value: isActive)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .help(title)
+        .accessibilityLabel(title)
         .onHover { hovering in
             isHovering = hovering
         }
@@ -339,7 +334,7 @@ struct StudioIconNavButton: View {
                 .font(.system(size: 11, weight: .bold))
                 .foregroundStyle(isHovering ? Color.white : Theme.fgMuted)
                 .frame(width: 26, height: 26)
-                .background(isHovering ? Color.white.opacity(0.08) : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .help(title)
@@ -364,9 +359,9 @@ struct EditorHistoryButton: View {
                 .foregroundStyle(
                     isEnabled
                         ? (isHovering ? Color.white : Theme.fgMuted)
-                        : Theme.fgMuted.opacity(0.30)
+                        : Theme.fgDisabled
                 )
-                .background(isHovering && isEnabled ? Color.white.opacity(0.08) : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
@@ -387,17 +382,17 @@ struct StudioTitleBar: View {
     var body: some View {
         ZStack {
             HStack(spacing: 12) {
-                StudioNavBar(
-                    selectedSection: workspace.state.selectedSection,
-                    isScreenshotEditor: editorMediaKind == .screenshot,
-                    onSelectSection: { section in
-                        workspace.send(.sectionSelected(section))
-                    }
-                )
-
                 Spacer(minLength: 0)
 
                 HStack(spacing: 8) {
+                    StudioNavBar(
+                        selectedSection: workspace.state.selectedSection,
+                        isScreenshotEditor: editorMediaKind == .screenshot,
+                        onSelectSection: { section in
+                            workspace.send(.sectionSelected(section))
+                        }
+                    )
+
                     editorHistoryControls
                     exportButton
                 }
@@ -414,18 +409,13 @@ struct StudioTitleBar: View {
                 Rectangle()
                     .fill(.ultraThinMaterial)
                 Rectangle()
-                    .fill(Theme.surface.opacity(0.90))
+                    .fill(Theme.navbarBg.opacity(0.92))
                 LinearGradient(
                     colors: [Color.white.opacity(0.045), Color.clear],
                     startPoint: .top,
                     endPoint: .bottom
                 )
             }
-        }
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(Theme.borderStrong.opacity(0.56))
-                .frame(height: 1)
         }
         .simultaneousGesture(
             TapGesture().onEnded {
@@ -494,16 +484,13 @@ struct StudioTitleBar: View {
                         Image(systemName: "arrow.up.right.video.fill")
                             .font(.system(size: 10.5, weight: .bold))
                         Text("Export")
-                            .font(.system(size: 11.5, weight: .semibold))
+                            .font(.system(size: 11.5, weight: .bold))
                     }
                     .padding(.horizontal, 10)
                     .frame(height: 28)
-                    .background(Theme.accent, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                    .foregroundStyle(Color.white)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .stroke(Color.white.opacity(0.20), lineWidth: 1)
-                    }
+                    .background(Color.white, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .foregroundStyle(Color.black)
+                    .shadow(color: Color.black.opacity(0.25), radius: 3, y: 1)
                 }
             }
         } else if workspace.state.selectedSection == .editor, screenshotURL != nil {
@@ -519,16 +506,13 @@ struct StudioTitleBar: View {
                         Image(systemName: "square.and.arrow.up.fill")
                             .font(.system(size: 10.5, weight: .bold))
                         Text("Export")
-                            .font(.system(size: 11.5, weight: .semibold))
+                            .font(.system(size: 11.5, weight: .bold))
                     }
                     .padding(.horizontal, 10)
                     .frame(height: 28)
-                    .background(Theme.accent, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                    .foregroundStyle(Color.white)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .stroke(Color.white.opacity(0.20), lineWidth: 1)
-                    }
+                    .background(Color.white, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .foregroundStyle(Color.black)
+                    .shadow(color: Color.black.opacity(0.25), radius: 3, y: 1)
                 }
             }
         }

--- a/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/StudioShellViews.swift
@@ -269,9 +269,8 @@ struct StudioNavBar: View {
     var selectedSection: AppSection
     var isScreenshotEditor: Bool
     var onSelectSection: (AppSection) -> Void
-    var onToggleHelp: () -> Void
 
-    private let items: [AppSection] = [.editor, .projects]
+    private let items: [AppSection] = [.projects]
 
     var body: some View {
         HStack(spacing: 12) {
@@ -283,15 +282,6 @@ struct StudioNavBar: View {
                 ) {
                     onSelectSection(section)
                 }
-            }
-
-            Rectangle()
-                .fill(Theme.borderStrong.opacity(0.40))
-                .frame(width: 1, height: 14)
-                .padding(.horizontal, 2)
-
-            StudioIconNavButton(title: "Keyboard Shortcuts", symbolName: "questionmark") {
-                onToggleHelp()
             }
         }
         .padding(.horizontal, 4)
@@ -348,7 +338,8 @@ struct StudioIconNavButton: View {
             Image(systemName: symbolName)
                 .font(.system(size: 11, weight: .bold))
                 .foregroundStyle(isHovering ? Color.white : Theme.fgMuted)
-                .frame(width: 22, height: 22)
+                .frame(width: 26, height: 26)
+                .background(isHovering ? Color.white.opacity(0.08) : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
         .buttonStyle(.plain)
         .help(title)
@@ -363,21 +354,27 @@ struct EditorHistoryButton: View {
     var symbolName: String
     var isEnabled: Bool
     var action: () -> Void
+    @State private var isHovering = false
 
     var body: some View {
-        StudioButton(hitTarget: .rounded(Theme.radiusSm), help: title, action: action) {
+        Button(action: action) {
             Image(systemName: symbolName)
-                .font(.system(size: 12, weight: .semibold))
-                .frame(width: 28, height: 28)
-                .foregroundStyle(isEnabled ? Color.primary.opacity(0.86) : Color.secondary.opacity(0.38))
-                .background(isEnabled ? Theme.overlayStrong.opacity(0.82) : Color.clear, in: RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                        .stroke(isEnabled ? Theme.borderSubtle : Color.clear, lineWidth: 1)
-                }
+                .font(.system(size: 12.5, weight: .semibold))
+                .frame(width: 26, height: 26)
+                .foregroundStyle(
+                    isEnabled
+                        ? (isHovering ? Color.white : Theme.fgMuted)
+                        : Theme.fgMuted.opacity(0.30)
+                )
+                .background(isHovering && isEnabled ? Color.white.opacity(0.08) : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
+        .buttonStyle(.plain)
         .disabled(!isEnabled)
+        .help(title)
         .accessibilityLabel(title)
+        .onHover { hovering in
+            isHovering = hovering
+        }
     }
 }
 
@@ -385,6 +382,7 @@ struct StudioTitleBar: View {
     @EnvironmentObject private var model: AppModel
     var editorSession: EditorSession?
     var workspace: EditorWorkspaceDriver
+    @State private var isTitleHovered = false
 
     var body: some View {
         ZStack {
@@ -394,9 +392,6 @@ struct StudioTitleBar: View {
                     isScreenshotEditor: editorMediaKind == .screenshot,
                     onSelectSection: { section in
                         workspace.send(.sectionSelected(section))
-                    },
-                    onToggleHelp: {
-                        workspace.send(.shortcutsHelpToggled)
                     }
                 )
 
@@ -411,7 +406,6 @@ struct StudioTitleBar: View {
             titleLabel
                 .frame(maxWidth: 520)
                 .padding(.horizontal, 190)
-                .allowsHitTesting(false)
         }
         .frame(height: 52)
         .padding(.horizontal, 12)
@@ -451,56 +445,91 @@ struct StudioTitleBar: View {
                     workspace.redoActiveEditor(kind: editorMediaKind)
                 }
             }
-            .padding(3)
-            .background(Theme.overlay.opacity(0.88), in: RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                    .stroke(Theme.borderSubtle, lineWidth: 1)
-            }
         }
     }
 
     @ViewBuilder
     private var exportButton: some View {
         if workspace.state.selectedSection == .editor, let videoURL {
-            StudioButton(hitTarget: .rounded(Theme.radiusMd)) {
-                workspace.send(.videoExportRequested(videoURL, editorSessionID: editorSession?.id))
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "arrow.up.right.video.fill")
-                        .font(.system(size: Theme.iconSm, weight: .semibold))
-                    Text("Export Video")
+            HStack(spacing: 6) {
+                StudioIconNavButton(title: "Keyboard Shortcuts", symbolName: "questionmark") {
+                    workspace.send(.shortcutsHelpToggled)
+                }
+
+                Menu {
+                    Button("16:9 Widescreen (YouTube, Desktop)") {
+                        workspace.video.send(.previewAspectChanged(.wide))
+                    }
+                    Button("9:16 Vertical (Reels, TikTok, Shorts)") {
+                        workspace.video.send(.previewAspectChanged(.vertical))
+                    }
+                    Button("1:1 Square (Instagram, Feed)") {
+                        workspace.video.send(.previewAspectChanged(.square))
+                    }
+                    Button("4:5 Portrait (Social Post)") {
+                        workspace.video.send(.previewAspectChanged(.portrait))
+                    }
+                    Button("4:3 Classic") {
+                        workspace.video.send(.previewAspectChanged(.classic))
+                    }
+                    Divider()
+                    Button("Source Aspect (Auto)") {
+                        workspace.video.send(.previewAspectChanged(.auto))
+                    }
+                } label: {
+                    Image(systemName: "aspectratio")
                         .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Theme.fg)
+                        .frame(width: 28, height: 28)
+                        .background(Color.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
                 }
-                .padding(.horizontal, 14)
-                .frame(height: Theme.btnHeightMd)
-                .background(Theme.accent, in: RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous))
-                .foregroundStyle(Color.white)
-                .overlay {
-                    RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous)
-                        .stroke(Color.white.opacity(0.22), lineWidth: 1)
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .help("Presets")
+
+                StudioButton(hitTarget: .rounded(6)) {
+                    workspace.send(.videoExportRequested(videoURL, editorSessionID: editorSession?.id))
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "arrow.up.right.video.fill")
+                            .font(.system(size: 10.5, weight: .bold))
+                        Text("Export")
+                            .font(.system(size: 11.5, weight: .semibold))
+                    }
+                    .padding(.horizontal, 10)
+                    .frame(height: 28)
+                    .background(Theme.accent, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .foregroundStyle(Color.white)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(Color.white.opacity(0.20), lineWidth: 1)
+                    }
                 }
-                .shadow(color: Theme.accent.opacity(0.35), radius: 10, y: 3)
             }
         } else if workspace.state.selectedSection == .editor, screenshotURL != nil {
-            StudioButton(hitTarget: .rounded(Theme.radiusMd)) {
-                workspace.send(.screenshotExportRequested(screenshotURL, editorSessionID: editorSession?.id))
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "square.and.arrow.up.fill")
-                        .font(.system(size: Theme.iconSm, weight: .semibold))
-                    Text("Export PNG")
-                        .font(.system(size: 12, weight: .semibold))
+            HStack(spacing: 6) {
+                StudioIconNavButton(title: "Keyboard Shortcuts", symbolName: "questionmark") {
+                    workspace.send(.shortcutsHelpToggled)
                 }
-                .padding(.horizontal, 14)
-                .frame(height: Theme.btnHeightMd)
-                .background(Theme.accent, in: RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous))
-                .foregroundStyle(Color.white)
-                .overlay {
-                    RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous)
-                        .stroke(Color.white.opacity(0.22), lineWidth: 1)
+
+                StudioButton(hitTarget: .rounded(6)) {
+                    workspace.send(.screenshotExportRequested(screenshotURL, editorSessionID: editorSession?.id))
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "square.and.arrow.up.fill")
+                            .font(.system(size: 10.5, weight: .bold))
+                        Text("Export")
+                            .font(.system(size: 11.5, weight: .semibold))
+                    }
+                    .padding(.horizontal, 10)
+                    .frame(height: 28)
+                    .background(Theme.accent, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .foregroundStyle(Color.white)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(Color.white.opacity(0.20), lineWidth: 1)
+                    }
                 }
-                .shadow(color: Theme.accent.opacity(0.35), radius: 10, y: 3)
             }
         }
     }
@@ -514,20 +543,23 @@ struct StudioTitleBar: View {
     }
 
     private var titleLabel: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 6) {
             if workspace.state.selectedSection == .editor, let editorMediaKind {
                 Image(systemName: editorMediaKind.titleIconSystemName)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Theme.fgMuted.opacity(0.55))
                     .accessibilityHidden(true)
             }
             Text(title)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(isTitleHovered ? Color.white : Theme.fgMuted.opacity(0.65))
                 .lineLimit(1)
                 .truncationMode(.middle)
             workspaceStatusIndicator
         }
         .frame(maxWidth: .infinity, alignment: .center)
+        .contentShape(Rectangle())
+        .onHover { isTitleHovered = $0 }
     }
 
     @ViewBuilder

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -18,7 +18,7 @@ struct TimelineSelectionSidebar: View {
 
             selectionFooter
         }
-        .studioEditorPaneChrome()
+        .studioEditorPaneChrome(bg: Theme.sidebarBg)
     }
 
     private var selectionHeader: some View {

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -16,10 +16,6 @@ struct TimelineSelectionSidebar: View {
                 .padding(12)
             }
 
-            Rectangle()
-                .fill(Theme.border)
-                .frame(height: 1)
-
             selectionFooter
         }
         .studioEditorPaneChrome()

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -63,7 +63,7 @@ struct TimelinePanel: View {
                     .padding(.top, TimelineMetrics.trackTopPadding)
             }
         }
-        .studioEditorPaneChrome()
+        .studioEditorPaneChrome(bg: Theme.timelineBg)
         .focusable()
         .focused($isTimelineFocused)
         .focusEffectDisabled()
@@ -291,14 +291,14 @@ private struct TimelinePlayPauseButton: View {
         } label: {
             Image(systemName: playback.isPlaying ? "pause.fill" : "play.fill")
                 .font(.system(size: 14, weight: .bold))
-                .foregroundStyle(isHovering || playback.isPlaying ? Color.white : Color.white.opacity(0.85))
+                .foregroundStyle(playback.isPlaying || isHovering ? Color.white : Theme.fgMuted)
                 .frame(width: 28, height: 28)
                 .offset(x: playback.isPlaying ? 0 : 1)
-                .background(isHovering ? Color.white.opacity(0.08) : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(playback.player == nil)
-        .opacity(playback.player == nil ? 0.42 : 1)
+        .opacity(playback.player == nil ? 0.35 : 1)
         .help(title)
         .accessibilityLabel(title)
         .onHover { hovering in
@@ -315,12 +315,16 @@ private struct TimelineToolbarIconButton: View {
     @State private var isHovering = false
 
     var body: some View {
-        StudioButton(hitTarget: .rectangle, action: action) {
+        StudioButton(hitTarget: .rounded(6), action: action) {
             Image(systemName: symbolName)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Color.white.opacity(isEnabled ? 0.90 : 0.35))
-                .frame(width: 30, height: 30)
-                .background(Color.white.opacity(isHovering && isEnabled ? 0.10 : 0.001), in: Rectangle())
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(
+                    isEnabled
+                        ? (isHovering ? Color.white : Theme.fgMuted)
+                        : Theme.fgDisabled
+                )
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
         }
         .disabled(!isEnabled)
         .accessibilityLabel(title)
@@ -420,8 +424,7 @@ private struct TimelineZoomSlider: View {
                 trackHeight: 20,
                 hitHeight: 20,
                 fillColor: Color.white.opacity(0.20),
-                thumbWidth: 28,
-                thumbHeight: 14,
+                thumbSize: 14,
                 showStepDots: false,
                 showTooltip: false,
                 setsValueFromPointerLocation: true
@@ -817,57 +820,9 @@ enum PreviewPlaybackSpeedSelection {
     }
 }
 
-struct FilmstripPatternView: View {
-    var width: CGFloat
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 6) {
-                ForEach(0..<max(1, Int(width / 14)), id: \.self) { _ in
-                    RoundedRectangle(cornerRadius: 1, style: .continuous)
-                        .fill(Color.black.opacity(0.35))
-                        .frame(width: 5, height: 3.5)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 3)
-            .padding(.top, 3)
-
-            Spacer()
-
-            HStack(spacing: 6) {
-                ForEach(0..<max(1, Int(width / 14)), id: \.self) { _ in
-                    RoundedRectangle(cornerRadius: 1, style: .continuous)
-                        .fill(Color.black.opacity(0.35))
-                        .frame(width: 5, height: 3.5)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 3)
-            .padding(.bottom, 3)
-        }
-        .allowsHitTesting(false)
-    }
-}
-
 struct ClipWaveformTextureView: View {
     var body: some View {
-        GeometryReader { proxy in
-            Path { path in
-                let step: CGFloat = 5
-                let count = Int(proxy.size.width / step)
-                let midY = proxy.size.height * 0.65
-                for i in 0..<count {
-                    let x = CGFloat(i) * step + 2
-                    let sinVal = abs(sin(Double(i) * 0.38) * cos(Double(i) * 0.18)) * 0.75 + 0.25
-                    let h = proxy.size.height * 0.35 * CGFloat(sinVal)
-                    path.move(to: CGPoint(x: x, y: midY - h / 2))
-                    path.addLine(to: CGPoint(x: x, y: midY + h / 2))
-                }
-            }
-            .stroke(Color.white.opacity(0.12), style: StrokeStyle(lineWidth: 2, lineCap: .round))
-        }
-        .allowsHitTesting(false)
+        TimelineWaveformPreview(samples: [])
     }
 }
 
@@ -951,56 +906,96 @@ struct TimelineClipRow: View {
         return RoundedRectangle(cornerRadius: 6, style: .continuous)
             .fill(
                 isDeleted
-                    ? LinearGradient(colors: [Color.secondary.opacity(0.25), Color.secondary.opacity(0.15)], startPoint: .top, endPoint: .bottom)
+                    ? LinearGradient(
+                        colors: [Color.secondary.opacity(0.24), Color.secondary.opacity(0.14)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
                     : (isSelected
-                        ? LinearGradient(colors: [Theme.accent, Theme.accent.opacity(0.85)], startPoint: .top, endPoint: .bottom)
-                        : LinearGradient(colors: [Color(red: 0.16, green: 0.22, blue: 0.38), Color(red: 0.11, green: 0.15, blue: 0.28)], startPoint: .top, endPoint: .bottom))
+                        ? LinearGradient(
+                            colors: [Theme.accent.opacity(0.92), Theme.accent.opacity(0.76)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                        : LinearGradient(
+                            colors: [
+                                Color(red: 0.14, green: 0.18, blue: 0.32),
+                                Color(red: 0.09, green: 0.12, blue: 0.22)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ))
             )
             .overlay {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(
-                        isSelected ? Color.white.opacity(0.70) : (isDeleted ? Color.secondary.opacity(0.42) : Color.white.opacity(0.12)),
-                        lineWidth: isSelected ? 1.5 : 1
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(isSelected ? 0.65 : 0.18),
+                                Color.white.opacity(isSelected ? 0.25 : 0.05)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ),
+                        lineWidth: isSelected ? 1.5 : 1.0
                     )
             }
-            .overlay {
-                if !isDeleted {
-                    FilmstripPatternView(width: width)
-                }
-            }
+            .shadow(
+                color: isSelected ? Theme.accent.opacity(0.35) : Color.black.opacity(0.20),
+                radius: isSelected ? 6 : 2,
+                y: 1
+            )
             .overlay(alignment: .bottom) {
-                if let waveformSamples, !waveformSamples.isEmpty, !isDeleted {
-                    TimelineWaveformPreview(samples: waveformSamples)
-                        .frame(height: 35)
-                        .padding(.horizontal, 10)
-                        .padding(.bottom, 8)
-                        .allowsHitTesting(false)
-                } else if !isDeleted {
-                    ClipWaveformTextureView()
-                        .frame(height: 30)
+                if !isDeleted {
+                    TimelineWaveformPreview(samples: waveformSamples(for: segment) ?? (waveformSamples ?? []))
+                        .frame(height: 24)
                         .padding(.horizontal, 8)
-                        .padding(.bottom, 8)
+                        .padding(.bottom, 6)
                         .allowsHitTesting(false)
                 }
             }
-            .overlay(alignment: .top) {
-                if width > 82 {
-                    VStack(spacing: 2) {
-                        Label(isDeleted ? "Deleted" : "Clip \(segment.index + 1)", systemImage: isDeleted ? "trash" : "rectangle.on.rectangle")
-                            .font(.system(size: 10, weight: .semibold))
-                        Text("\(formatClipDuration(segment.end - segment.start)) @ \(TimelineClipSpeed.label(segment.speed))")
-                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+            .overlay(alignment: .topLeading) {
+                if width > 70 {
+                    HStack(spacing: 5) {
+                        Image(systemName: isDeleted ? "trash" : "rectangle.on.rectangle")
+                            .font(.system(size: 8.5, weight: .semibold))
+                        Text(isDeleted ? "Deleted" : "Clip \(segment.index + 1)")
+                            .font(.system(size: 9.5, weight: .semibold))
+                        Text("· \(formatClipDuration(segment.end - segment.start)) @ \(TimelineClipSpeed.label(segment.speed))")
+                            .font(.system(size: 9, weight: .medium, design: .monospaced))
                     }
                     .foregroundStyle(foreground)
-                    .shadow(color: Color.black.opacity(0.35), radius: 3, y: 1)
-                    .padding(.top, 11)
+                    .shadow(color: Color.black.opacity(0.40), radius: 2, y: 1)
+                    .padding(.top, 6)
+                    .padding(.leading, 10)
                     .allowsHitTesting(false)
                 }
             }
-            .overlay(alignment: .bottomLeading) { Text(formatPlaybackTime(segment.start)).font(.system(size: 8, weight: .medium, design: .monospaced)).foregroundStyle(foreground.opacity(0.65)).padding(.leading, 9).padding(.bottom, 5) }
-            .overlay(alignment: .bottomTrailing) { Text(formatPlaybackTime(segment.end)).font(.system(size: 8, weight: .medium, design: .monospaced)).foregroundStyle(foreground.opacity(0.65)).padding(.trailing, 9).padding(.bottom, 5) }
+            .overlay(alignment: .topTrailing) {
+                if width > 130 {
+                    Text(formatPlaybackTime(segment.end))
+                        .font(.system(size: 9, weight: .medium, design: .monospaced))
+                        .foregroundStyle(foreground.opacity(0.70))
+                        .shadow(color: Color.black.opacity(0.40), radius: 2, y: 1)
+                        .padding(.top, 6)
+                        .padding(.trailing, 10)
+                        .allowsHitTesting(false)
+                }
+            }
             .padding(.vertical, 5)
             .padding(.horizontal, 2)
+    }
+
+    private func waveformSamples(for segment: TimelineClipSegment) -> [Double]? {
+        guard let fullSamples = waveformSamples, !fullSamples.isEmpty, duration > 0 else {
+            return nil
+        }
+        let totalCount = fullSamples.count
+        let startRatio = max(0.0, min(segment.start / duration, 1.0))
+        let endRatio = max(startRatio, min(segment.end / duration, 1.0))
+        let startIdx = min(Int(startRatio * Double(totalCount)), totalCount - 1)
+        let endIdx = min(max(startIdx + 1, Int(endRatio * Double(totalCount))), totalCount)
+        return Array(fullSamples[startIdx..<endIdx])
     }
 
     private func isDeleted(_ segment: TimelineClipSegment) -> Bool {
@@ -1081,60 +1076,85 @@ struct TimelineWaveformPreview: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let chartSamples = TimelineWaveformChartSample.samples(from: samples, width: proxy.size.width)
-            if !chartSamples.isEmpty {
-                Chart(chartSamples) { sample in
-                    AreaMark(
-                        x: .value("Position", sample.position),
-                        yStart: .value("Lower amplitude", -sample.amplitude),
-                        yEnd: .value("Upper amplitude", sample.amplitude)
-                    )
-                    .interpolationMethod(.catmullRom)
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [
-                                Color(red: 0.28, green: 0.88, blue: 0.98).opacity(0.95), // Bright Cyan
-                                Color(red: 0.38, green: 0.52, blue: 1.00).opacity(0.90), // Electric Blue
-                                Color(red: 0.76, green: 0.35, blue: 0.96).opacity(0.85), // Vivid Violet
-                                Color(red: 0.95, green: 0.40, blue: 0.65).opacity(0.60)  // Magenta
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
+            let width = max(proxy.size.width, 1)
+            let barWidth: CGFloat = 2.5
+            let barSpacing: CGFloat = 1.6
+            let totalStep = barWidth + barSpacing
+            let barCount = max(1, Int(width / totalStep))
+            let downsampled = resample(samples: samples, count: barCount)
+
+            Canvas { context, size in
+                let midY = size.height / 2
+                let maxH = size.height - 4
+
+                // Pass 1: Soft peak glow behind loud/tallest bars
+                for i in 0..<barCount {
+                    let amp = CGFloat(i < downsampled.count ? downsampled[i] : 0.2)
+                    if amp > 0.48 {
+                        let peakIntensity = (amp - 0.48) / 0.52 // 0.0 to 1.0
+                        let barH = max(3.0, amp * maxH)
+                        let x = CGFloat(i) * totalStep
+                        let glowRect = CGRect(
+                            x: x - 2.0,
+                            y: midY - (barH + 4.0) / 2,
+                            width: barWidth + 4.0,
+                            height: barH + 4.0
                         )
-                    )
-
-                    LineMark(
-                        x: .value("Position", sample.position),
-                        y: .value("Upper crest", sample.amplitude)
-                    )
-                    .interpolationMethod(.catmullRom)
-                    .foregroundStyle(Color(red: 0.45, green: 0.95, blue: 1.0).opacity(0.85))
-                    .lineStyle(StrokeStyle(lineWidth: 1.0, lineCap: .round, lineJoin: .round))
-
-                    LineMark(
-                        x: .value("Position", sample.position),
-                        y: .value("Lower crest", -sample.amplitude)
-                    )
-                    .interpolationMethod(.catmullRom)
-                    .foregroundStyle(Color(red: 0.85, green: 0.45, blue: 0.95).opacity(0.65))
-                    .lineStyle(StrokeStyle(lineWidth: 0.8, lineCap: .round, lineJoin: .round))
+                        let glowPath = Path(roundedRect: glowRect, cornerRadius: (barWidth + 4.0) / 2)
+                        context.fill(glowPath, with: .color(Theme.accent.opacity(Double(0.40 * peakIntensity))))
+                    }
                 }
-                .chartXAxis(.hidden)
-                .chartYAxis(.hidden)
-                .chartLegend(.hidden)
-                .chartXScale(domain: 0...max(chartSamples.last?.position ?? 1, 1))
-                .chartYScale(domain: -1...1)
-                .chartPlotStyle { plotArea in
-                    plotArea
-                        .background(Color.clear)
-                        .overlay(alignment: .center) {
-                            Rectangle()
-                                .fill(Color.white.opacity(0.14))
-                                .frame(height: 1)
-                        }
+
+                // Pass 2: Main waveform bars using existing Theme.accent design token
+                let barShading = GraphicsContext.Shading.color(Theme.accent)
+
+                for i in 0..<barCount {
+                    let amp = CGFloat(i < downsampled.count ? downsampled[i] : 0.2)
+                    let barH = max(3.0, amp * maxH)
+                    let x = CGFloat(i) * totalStep
+                    let rect = CGRect(
+                        x: x,
+                        y: midY - barH / 2,
+                        width: barWidth,
+                        height: barH
+                    )
+                    let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                    context.fill(path, with: barShading)
                 }
-                .accessibilityHidden(true)
             }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func resample(samples: [Double], count: Int) -> [Double] {
+        guard count > 0 else { return [] }
+        guard !samples.isEmpty else {
+            // Organic audio rhythm pattern when audio track is silent or loading
+            return (0..<count).map { i in
+                let t = Double(i)
+                let wave1 = sin(t * 0.24) * 0.38
+                let wave2 = cos(t * 0.08) * 0.32
+                let wave3 = sin(t * 0.62) * 0.18
+                let combined = abs(wave1 + wave2 + wave3) + 0.12
+                return min(max(combined, 0.10), 0.92)
+            }
+        }
+        let step = Double(samples.count) / Double(count)
+        return (0..<count).map { i in
+            let startIdx = Int(Double(i) * step)
+            let endIdx = min(Int(Double(i + 1) * step), samples.count)
+            if startIdx < endIdx {
+                var maxVal = 0.0
+                for j in startIdx..<endIdx {
+                    maxVal = max(maxVal, samples[j])
+                }
+                let shaped = pow(maxVal, 0.58)
+                return max(0.10, min(shaped, 1.0))
+            } else if startIdx < samples.count {
+                let shaped = pow(samples[startIdx], 0.58)
+                return max(0.10, min(shaped, 1.0))
+            }
+            return 0.10
         }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -39,8 +39,6 @@ struct TimelinePanel: View {
         VStack(spacing: 0) {
             timelineToolbar
 
-            Rectangle().fill(Theme.border).frame(height: 1)
-
             ZStack(alignment: .top) {
                 Button {
                     edits.clearSelection()
@@ -127,11 +125,6 @@ struct TimelinePanel: View {
                 ) {
                     edits.addClipSplit(at: playback.currentTime, duration: playback.duration)
                 }
-
-                Rectangle()
-                    .fill(Theme.borderStrong.opacity(0.46))
-                    .frame(width: 1, height: 22)
-                    .padding(.horizontal, 3)
 
                 TimelinePreviewSpeedPicker(playback: playback)
 
@@ -293,26 +286,20 @@ private struct TimelinePlayPauseButton: View {
 
     var body: some View {
         let title = playback.isPlaying ? "Pause" : "Play"
-        StudioButton(hitTarget: .rounded(10)) {
+        Button {
             playback.togglePlayback()
         } label: {
             Image(systemName: playback.isPlaying ? "pause.fill" : "play.fill")
-                .font(.system(size: 13, weight: .bold))
-                .foregroundStyle(.white)
-                .frame(width: 34, height: 34)
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(isHovering || playback.isPlaying ? Color.white : Color.white.opacity(0.85))
+                .frame(width: 28, height: 28)
                 .offset(x: playback.isPlaying ? 0 : 1)
-                .background {
-                    Circle()
-                        .fill(playback.isPlaying ? Theme.accent.opacity(isHovering ? 0.95 : 0.86) : Color.white.opacity(isHovering ? 0.14 : 0.09))
-                }
-                .overlay {
-                    Circle()
-                        .stroke(playback.isPlaying ? Theme.accent.opacity(0.48) : Color.white.opacity(isHovering ? 0.24 : 0.12), lineWidth: 1)
-                }
-                .shadow(color: Theme.scrim, radius: 8, y: 3)
+                .background(isHovering ? Color.white.opacity(0.08) : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
+        .buttonStyle(.plain)
         .disabled(playback.player == nil)
         .opacity(playback.player == nil ? 0.42 : 1)
+        .help(title)
         .accessibilityLabel(title)
         .onHover { hovering in
             isHovering = hovering
@@ -363,19 +350,13 @@ private struct TimelineTimeDisplay: View {
             Text(formatPlaybackTime(currentTime))
                 .foregroundStyle(Color.white)
             Text("/")
-                .foregroundStyle(Theme.fgSubtle)
+                .foregroundStyle(Theme.fgSubtle.opacity(0.60))
             Text(formatPlaybackTime(duration))
                 .foregroundStyle(Theme.fgMuted)
         }
-        .font(.system(size: 11, weight: .bold, design: .monospaced))
+        .font(.system(size: 11.5, weight: .semibold, design: .monospaced))
         .monospacedDigit()
-        .padding(.horizontal, 10)
-        .frame(height: 28)
-        .background(Theme.surfaceRaised.opacity(0.92), in: RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: Theme.radiusSm, style: .continuous)
-                .stroke(Theme.borderStrong.opacity(0.75), lineWidth: 1)
-        }
+        .padding(.horizontal, 4)
         .accessibilityLabel("Playback time \(formatPlaybackTime(currentTime)) of \(formatPlaybackTime(duration))")
     }
 }
@@ -421,30 +402,41 @@ private struct TimelineZoomSlider: View {
     @Binding var isDragging: Bool
 
     var body: some View {
-        ElasticSlider(
-            value: sliderValue,
-            range: 0...1,
-            step: 0.01,
-            valueText: visibleDurationText,
-            onEditingChanged: { editing in
-                withAnimation(.easeOut(duration: 0.12)) {
-                    isDragging = editing
-                }
-            },
-            trackHeight: 24,
-            hitHeight: 24,
-            fillColor: Theme.accent,
-            thumbWidth: 34,
-            thumbHeight: 18,
-            showStepDots: true,
-            showTooltip: false,
-            setsValueFromPointerLocation: true
-        )
-        .frame(width: 140)
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.fgSubtle)
+
+            ElasticSlider(
+                value: sliderValue,
+                range: 0...1,
+                step: 0.01,
+                valueText: zoomPercentageText,
+                onEditingChanged: { editing in
+                    withAnimation(.easeOut(duration: 0.12)) {
+                        isDragging = editing
+                    }
+                },
+                trackHeight: 20,
+                hitHeight: 20,
+                fillColor: Color.white.opacity(0.20),
+                thumbWidth: 28,
+                thumbHeight: 14,
+                showStepDots: false,
+                showTooltip: false,
+                setsValueFromPointerLocation: true
+            )
+            .frame(width: 85)
+
+            Text(zoomPercentageText)
+                .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                .foregroundStyle(Theme.fgMuted)
+                .frame(width: 36, alignment: .trailing)
+        }
         .disabled(!isEnabled)
         .opacity(isEnabled ? 1 : 0.45)
-        .accessibilityLabel("Timeline zoom")
-        .help("Timeline zoom")
+        .accessibilityLabel("Timeline zoom \(zoomPercentageText)")
+        .help("Timeline zoom percentage")
     }
 
     private var sliderValue: Binding<Double> {
@@ -468,8 +460,11 @@ private struct TimelineZoomSlider: View {
         TimelineViewport.isZoomEnabled(duration: duration)
     }
 
-    private var visibleDurationText: String {
-        "\(Int(max(0, viewport.visibleDuration).rounded()))s visible"
+    private var zoomPercentageText: String {
+        guard duration > 0, viewport.visibleDuration > 0 else { return "100%" }
+        let zoomRatio = duration / max(viewport.visibleDuration, TimelineViewport.minimumVisibleDuration)
+        let percent = max(100, Int((zoomRatio * 100).rounded()))
+        return "\(percent)%"
     }
 }
 
@@ -663,10 +658,18 @@ struct TimelinePlayhead: View {
     var body: some View {
         GeometryReader { proxy in
             let x = viewport.x(for: currentTime, width: proxy.size.width, clamped: true) ?? 0
-            Rectangle()
-                .fill(Color(red: 0.40, green: 0.31, blue: 1.0).opacity(0.98))
-                .frame(width: TimelineMetrics.playheadWidth, height: proxy.size.height)
-                .offset(x: x - TimelineMetrics.playheadWidth / 2)
+            ZStack(alignment: .top) {
+                Rectangle()
+                    .fill(Color.white)
+                    .frame(width: 1.5, height: proxy.size.height)
+
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 10, height: 10)
+                    .shadow(color: Color.black.opacity(0.40), radius: 3, y: 1)
+                    .offset(y: -4)
+            }
+            .offset(x: x - 0.75)
         }
         .allowsHitTesting(false)
     }
@@ -814,6 +817,60 @@ enum PreviewPlaybackSpeedSelection {
     }
 }
 
+struct FilmstripPatternView: View {
+    var width: CGFloat
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                ForEach(0..<max(1, Int(width / 14)), id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(Color.black.opacity(0.35))
+                        .frame(width: 5, height: 3.5)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 3)
+            .padding(.top, 3)
+
+            Spacer()
+
+            HStack(spacing: 6) {
+                ForEach(0..<max(1, Int(width / 14)), id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(Color.black.opacity(0.35))
+                        .frame(width: 5, height: 3.5)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 3)
+            .padding(.bottom, 3)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+struct ClipWaveformTextureView: View {
+    var body: some View {
+        GeometryReader { proxy in
+            Path { path in
+                let step: CGFloat = 5
+                let count = Int(proxy.size.width / step)
+                let midY = proxy.size.height * 0.65
+                for i in 0..<count {
+                    let x = CGFloat(i) * step + 2
+                    let sinVal = abs(sin(Double(i) * 0.38) * cos(Double(i) * 0.18)) * 0.75 + 0.25
+                    let h = proxy.size.height * 0.35 * CGFloat(sinVal)
+                    path.move(to: CGPoint(x: x, y: midY - h / 2))
+                    path.addLine(to: CGPoint(x: x, y: midY + h / 2))
+                }
+            }
+            .stroke(Color.white.opacity(0.12), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+        }
+        .allowsHitTesting(false)
+    }
+}
+
 struct TimelineClipRow: View {
     var videoURL: URL?
     var duration: Double
@@ -891,24 +948,37 @@ struct TimelineClipRow: View {
 
     private func clipBody(segment: TimelineClipSegment, width: CGFloat, isSelected: Bool, isDeleted: Bool) -> some View {
         let foreground = isDeleted ? Color.white.opacity(0.48) : Theme.timelineClipForeground
-        return Rectangle()
+        return RoundedRectangle(cornerRadius: 6, style: .continuous)
             .fill(
                 isDeleted
-                    ? Color.secondary.opacity(isSelected ? 0.30 : 0.20)
-                    : (isSelected ? Theme.accent : Theme.timelineClip)
+                    ? LinearGradient(colors: [Color.secondary.opacity(0.25), Color.secondary.opacity(0.15)], startPoint: .top, endPoint: .bottom)
+                    : (isSelected
+                        ? LinearGradient(colors: [Theme.accent, Theme.accent.opacity(0.85)], startPoint: .top, endPoint: .bottom)
+                        : LinearGradient(colors: [Color(red: 0.16, green: 0.22, blue: 0.38), Color(red: 0.11, green: 0.15, blue: 0.28)], startPoint: .top, endPoint: .bottom))
             )
             .overlay {
-                Rectangle()
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .stroke(
-                        isSelected ? Theme.timelineHandle : (isDeleted ? Color.secondary.opacity(0.42) : Theme.timelineClipBorder),
-                        lineWidth: isSelected ? 2 : 1
+                        isSelected ? Color.white.opacity(0.70) : (isDeleted ? Color.secondary.opacity(0.42) : Color.white.opacity(0.12)),
+                        lineWidth: isSelected ? 1.5 : 1
                     )
+            }
+            .overlay {
+                if !isDeleted {
+                    FilmstripPatternView(width: width)
+                }
             }
             .overlay(alignment: .bottom) {
                 if let waveformSamples, !waveformSamples.isEmpty, !isDeleted {
                     TimelineWaveformPreview(samples: waveformSamples)
                         .frame(height: 35)
                         .padding(.horizontal, 10)
+                        .padding(.bottom, 8)
+                        .allowsHitTesting(false)
+                } else if !isDeleted {
+                    ClipWaveformTextureView()
+                        .frame(height: 30)
+                        .padding(.horizontal, 8)
                         .padding(.bottom, 8)
                         .allowsHitTesting(false)
                 }
@@ -983,13 +1053,26 @@ struct TimelineClipRow: View {
 }
 
 struct TimelineResizeHandle: View {
+    @State private var isHovering = false
+
     var body: some View {
-        Circle()
-            .fill(Theme.timelineHandle)
-            .frame(width: 20, height: 20)
-            .overlay { Image(systemName: "arrow.left.and.right").font(.system(size: 8, weight: .bold)).foregroundStyle(Color.black.opacity(0.82)) }
-            .overlay { Circle().stroke(Theme.scrim, lineWidth: 1) }
-            .shadow(color: Color.black.opacity(0.24), radius: 6, y: 3)
+        RoundedRectangle(cornerRadius: 3, style: .continuous)
+            .fill(isHovering ? Color.white : Color.white.opacity(0.90))
+            .frame(width: 7, height: 20)
+            .overlay {
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .stroke(Color.black.opacity(0.35), lineWidth: 0.8)
+            }
+            .overlay {
+                HStack(spacing: 1.5) {
+                    Rectangle().fill(Color.black.opacity(0.35)).frame(width: 1, height: 9)
+                    Rectangle().fill(Color.black.opacity(0.35)).frame(width: 1, height: 9)
+                }
+            }
+            .shadow(color: Color.black.opacity(0.35), radius: 3, y: 1)
+            .scaleEffect(isHovering ? 1.15 : 1.0)
+            .animation(.snappy(duration: 0.15), value: isHovering)
+            .onHover { isHovering = $0 }
     }
 }
 
@@ -1010,10 +1093,10 @@ struct TimelineWaveformPreview: View {
                     .foregroundStyle(
                         LinearGradient(
                             colors: [
-                                Color.white.opacity(0.94),
-                                Color.white.opacity(0.80),
-                                Theme.timelineHandle.opacity(0.68),
-                                Theme.timelineClipBorder.opacity(0.42)
+                                Color(red: 0.28, green: 0.88, blue: 0.98).opacity(0.95), // Bright Cyan
+                                Color(red: 0.38, green: 0.52, blue: 1.00).opacity(0.90), // Electric Blue
+                                Color(red: 0.76, green: 0.35, blue: 0.96).opacity(0.85), // Vivid Violet
+                                Color(red: 0.95, green: 0.40, blue: 0.65).opacity(0.60)  // Magenta
                             ],
                             startPoint: .top,
                             endPoint: .bottom
@@ -1025,15 +1108,15 @@ struct TimelineWaveformPreview: View {
                         y: .value("Upper crest", sample.amplitude)
                     )
                     .interpolationMethod(.catmullRom)
-                    .foregroundStyle(Color.white.opacity(0.28))
-                    .lineStyle(StrokeStyle(lineWidth: 0.8, lineCap: .round, lineJoin: .round))
+                    .foregroundStyle(Color(red: 0.45, green: 0.95, blue: 1.0).opacity(0.85))
+                    .lineStyle(StrokeStyle(lineWidth: 1.0, lineCap: .round, lineJoin: .round))
 
                     LineMark(
                         x: .value("Position", sample.position),
                         y: .value("Lower crest", -sample.amplitude)
                     )
                     .interpolationMethod(.catmullRom)
-                    .foregroundStyle(Theme.timelineHandle.opacity(0.18))
+                    .foregroundStyle(Color(red: 0.85, green: 0.45, blue: 0.95).opacity(0.65))
                     .lineStyle(StrokeStyle(lineWidth: 0.8, lineCap: .round, lineJoin: .round))
                 }
                 .chartXAxis(.hidden)
@@ -1280,8 +1363,8 @@ private struct TimelineCameraClipItem: View {
     var fallbackSettings: FacecamSettings?
     var edits: TimelineEditDriver
 
-    private var accent: Color {
-        clip.settings.clamped.enabled ? Theme.timelineCamera : Color.secondary.opacity(0.52)
+    private var greenColor: Color {
+        Color(red: 0.22, green: 0.85, blue: 0.46)
     }
 
     var body: some View {
@@ -1291,12 +1374,18 @@ private struct TimelineCameraClipItem: View {
         Button {
             edits.selectCameraClip(id: clip.id)
         } label: {
-            Rectangle()
-                .fill(accent.opacity(clip.settings.clamped.enabled ? (isSelected ? 0.55 : 0.34) : 0.18))
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(clip.settings.clamped.enabled ? (isSelected ? greenColor.opacity(0.24) : greenColor.opacity(0.08)) : Color.secondary.opacity(0.08))
                 .overlay {
-                    Rectangle()
-                        .stroke(accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1)
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .stroke(
+                            clip.settings.clamped.enabled
+                                ? (isSelected ? greenColor : greenColor.opacity(0.65))
+                                : Color.secondary.opacity(0.40),
+                            lineWidth: isSelected ? 1.8 : 1.0
+                        )
                 }
+                .shadow(color: isSelected && clip.settings.clamped.enabled ? greenColor.opacity(0.35) : Color.clear, radius: 4)
                 .overlay { label(width: itemWidth) }
         }
         .buttonStyle(.plain)
@@ -1331,7 +1420,7 @@ private struct TimelineCameraClipItem: View {
                 .font(.system(size: 10, weight: .bold))
                 .lineLimit(1)
         }
-        .foregroundStyle(.white.opacity(clip.settings.clamped.enabled ? 0.94 : 0.66))
+        .foregroundStyle(clip.settings.clamped.enabled ? (isSelected ? greenColor : greenColor.opacity(0.90)) : Color.secondary.opacity(0.70))
         .minimumScaleFactor(0.72)
         .padding(.horizontal, 8)
         .frame(maxWidth: max(1, width))
@@ -1384,36 +1473,66 @@ struct TimelineRegionItem: View {
     }
 
     private func regionBody(width: CGFloat) -> some View {
-        Rectangle()
-            .fill(kind.accent.opacity(isSelected ? 0.55 : 0.34))
-            .overlay { Rectangle().stroke(kind.accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1) }
-            .overlay { regionLabel(width: width) }
-            .overlay(alignment: .leading) {
-                if showsLeadingHandle {
-                    TimelineResizeHandle().offset(x: -9).gesture(resizeGesture(edge: .leading))
-                }
+        Group {
+            if kind == .zoom {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                (isSelected ? Theme.accent : Color(red: 0.38, green: 0.28, blue: 0.88)).opacity(isSelected ? 0.82 : 0.58),
+                                (isSelected ? Theme.accent.opacity(0.95) : Color(red: 0.28, green: 0.18, blue: 0.72)).opacity(isSelected ? 0.95 : 0.72)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(
+                                isSelected ? Color.white.opacity(0.88) : Color(red: 0.52, green: 0.44, blue: 0.98).opacity(0.70),
+                                lineWidth: isSelected ? 1.5 : 1
+                            )
+                    }
+                    .shadow(color: (isSelected ? Theme.accent : Color(red: 0.38, green: 0.28, blue: 0.88)).opacity(isSelected ? 0.40 : 0.20), radius: isSelected ? 6 : 3, y: 1)
+            } else {
+                Rectangle()
+                    .fill(kind.accent.opacity(isSelected ? 0.55 : 0.34))
+                    .overlay { Rectangle().stroke(kind.accent.opacity(isSelected ? 0.95 : 0.65), lineWidth: isSelected ? 2 : 1) }
             }
-            .overlay(alignment: .trailing) {
-                if showsTrailingHandle {
-                    TimelineResizeHandle().offset(x: 9).gesture(resizeGesture(edge: .trailing))
-                }
+        }
+        .overlay { regionLabel(width: width) }
+        .overlay(alignment: .leading) {
+            if showsLeadingHandle {
+                TimelineResizeHandle().offset(x: -9).gesture(resizeGesture(edge: .leading))
             }
+        }
+        .overlay(alignment: .trailing) {
+            if showsTrailingHandle {
+                TimelineResizeHandle().offset(x: 9).gesture(resizeGesture(edge: .trailing))
+            }
+        }
     }
 
     private func regionLabel(width: CGFloat) -> some View {
         HStack(spacing: 4) {
+            if kind == .zoom {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(Color.white.opacity(0.92))
+            }
+
             Text(region.label)
-                .font(.system(size: 10, weight: .bold))
+                .font(.system(size: 10, weight: .bold, design: .rounded))
                 .foregroundStyle(.white)
                 .lineLimit(1)
 
-            if region.showsAutoBadge, width > 52 {
+            if region.showsAutoBadge, width > 64 {
                 Text("Auto")
                     .font(.system(size: 8, weight: .bold))
                     .foregroundStyle(.white.opacity(0.92))
                     .padding(.horizontal, 4)
                     .padding(.vertical, 1)
-                    .background(Theme.borderStrong, in: Rectangle())
+                    .background(Color.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 3, style: .continuous))
             }
         }
         .minimumScaleFactor(0.75)

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -288,7 +288,8 @@ struct VideoPreviewPanel: View {
                         offsetMs: recordingSession?.facecamOffsetMs,
                         settings: facecamSettings
                     )
-                    .frame(width: proxy.size.width, height: proxy.size.height)
+                    .frame(width: recordingFrame.width, height: recordingFrame.height)
+                    .offset(x: recordingFrame.minX, y: recordingFrame.minY)
                     .transformEffect(facecamZoomTransform)
                 }
             }
@@ -758,8 +759,8 @@ struct FacecamOverlayLayout {
         }
 
         let baseLength = min(containerSize.width, containerSize.height)
-        let side = max(1, baseLength * CGFloat(resolved.size / 100))
-        let margin = baseLength * CGFloat(resolved.margin / 100)
+        let side = max(1, min(baseLength * CGFloat(resolved.size / 100), baseLength))
+        let margin = max(0, baseLength * CGFloat(resolved.margin / 100))
         let halfSide = side / 2
         let x: CGFloat
         let y: CGFloat
@@ -782,7 +783,17 @@ struct FacecamOverlayLayout {
             y = containerSize.height - margin - halfSide
         }
 
-        return CGRect(x: x - halfSide, y: y - halfSide, width: side, height: side)
+        let rawX = x - halfSide
+        let rawY = y - halfSide
+        let safeMinX: CGFloat = 0
+        let safeMaxX = max(safeMinX, containerSize.width - side)
+        let safeMinY: CGFloat = 0
+        let safeMaxY = max(safeMinY, containerSize.height - side)
+
+        let clampedX = max(safeMinX, min(rawX, safeMaxX))
+        let clampedY = max(safeMinY, min(rawY, safeMaxY))
+
+        return CGRect(x: clampedX, y: clampedY, width: side, height: side)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -224,6 +224,8 @@ final class WindowConfigurationView: NSView {
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
         window.standardWindowButton(.zoomButton)?.isHidden = true
         window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func configureMicrophoneSelector(_ window: NSWindow) {

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -447,6 +447,7 @@ struct WindowCommandBridge: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
     var shell: AppShellDriver
+    var isCameraEnabled: () -> Bool = { false }
 
     var body: some View {
         Color.clear
@@ -514,7 +515,7 @@ struct WindowCommandBridge: View {
             openWindow(id: "area-selector")
         case .showStudio:
             NSApp.unhide(nil)
-            dismissCaptureWindows()
+            dismissCaptureWindows(alwaysDismissCameraBubble: true)
             if let editorSession = command.editorSession {
                 openWindow(id: "editor", value: editorSession)
             } else {
@@ -535,18 +536,22 @@ struct WindowCommandBridge: View {
         }
     }
 
-    private func dismissCaptureWindows() {
+    private func dismissCaptureWindows(alwaysDismissCameraBubble: Bool = false) {
         dismissWindow(id: "hud")
         dismissWindow(id: "source-selector")
         dismissWindow(id: "area-selector")
         dismissWindow(id: "microphone-selector")
         dismissWindow(id: "camera-selector")
-        dismissWindow(id: "camera-bubble")
+        if alwaysDismissCameraBubble || !isCameraEnabled() {
+            dismissWindow(id: "camera-bubble")
+        }
     }
 
     private func hideAppWindowsForCapture() {
         dismissCaptureWindows()
-        NSApp.hide(nil)
+        if !isCameraEnabled() {
+            NSApp.hide(nil)
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -362,16 +362,8 @@ final class WindowConfigurationView: NSView {
 
     private func syncHUDToActiveSpace(_ window: NSWindow) {
         guard role == .hud, window.isVisible else { return }
-        let size = HUDWindowMetrics.clampedSize(
-            for: preferredSize ?? window.contentRect(forFrameRect: window.frame).size,
-            screen: window.screen ?? NSScreen.main
-        )
         window.collectionBehavior = HUDWindowChrome.collectionBehavior
         window.level = HUDWindowChrome.level
-        window.setContentSize(size)
-        window.minSize = size
-        window.maxSize = size
-        positionBottomCenter(window, contentSize: size)
         window.orderFrontRegardless()
     }
 }
@@ -565,5 +557,6 @@ struct HUDOverlayWindowView: View {
         CaptureHUD(options: model.captureOptions)
             .padding(.horizontal, 16)
             .padding(.vertical, 18)
+            .frame(width: HUDWindowMetrics.defaultSize.width, height: HUDWindowMetrics.defaultSize.height)
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureShortcutsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureShortcutsTests.swift
@@ -1,0 +1,108 @@
+import Carbon
+import XCTest
+@testable import OpenRecorderMac
+
+@MainActor
+final class CaptureShortcutsTests: XCTestCase {
+    func testDefaultShortcutsMapMatchesStandardConventions() {
+        let defaults = ShortcutPreferences.defaultPreferences
+
+        let screenshot = defaults.item(for: .deviceScreenshot)
+        XCTAssertTrue(screenshot.isEnabled)
+        XCTAssertEqual(screenshot.keyCombination.displayString, "⌥⇧3")
+        XCTAssertEqual(screenshot.keyCombination.keyCode, UInt32(kVK_ANSI_3))
+        XCTAssertTrue(screenshot.keyCombination.modifiers.contains(.option))
+        XCTAssertTrue(screenshot.keyCombination.modifiers.contains(.shift))
+
+        let dragScreenshot = defaults.item(for: .dragScreenshot)
+        XCTAssertTrue(dragScreenshot.isEnabled)
+        XCTAssertEqual(dragScreenshot.keyCombination.displayString, "⌥⇧4")
+
+        let screenRecord = defaults.item(for: .deviceScreenRecord)
+        XCTAssertTrue(screenRecord.isEnabled)
+        XCTAssertEqual(screenRecord.keyCombination.displayString, "⌥⇧5")
+
+        let dragRecord = defaults.item(for: .dragScreenRecord)
+        XCTAssertTrue(dragRecord.isEnabled)
+        XCTAssertEqual(dragRecord.keyCombination.displayString, "⌥⇧6")
+
+        let toggleRecording = defaults.item(for: .toggleRecording)
+        XCTAssertTrue(toggleRecording.isEnabled)
+        XCTAssertEqual(toggleRecording.keyCombination.displayString, "⌥⇧R")
+    }
+
+    func testKeyCombinationCarbonModifiers() {
+        let combo = KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.command, .shift, .option, .control])
+        let expectedCarbon = UInt32(cmdKey | shiftKey | optionKey | controlKey)
+        XCTAssertEqual(combo.carbonModifiers, expectedCarbon)
+    }
+
+    func testShortcutPreferencesRoundTripPersistence() throws {
+        let suiteName = "CaptureShortcutsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = RecordingPreferencesStore(defaults: defaults)
+        var prefs = store.load().shortcuts
+
+        var updatedItem = prefs.item(for: .deviceScreenshot)
+        updatedItem.keyCombination = KeyCombination(keyCode: UInt32(kVK_ANSI_S), modifiers: [.command, .shift])
+        updatedItem.isEnabled = false
+        prefs.setItem(updatedItem)
+
+        store.setShortcuts(prefs)
+
+        let reloaded = store.load().shortcuts
+        let reloadedItem = reloaded.item(for: .deviceScreenshot)
+        XCTAssertFalse(reloadedItem.isEnabled)
+        XCTAssertEqual(reloadedItem.keyCombination.displayString, "⇧⌘S")
+    }
+
+    func testSettingsDriverShortcutUpdates() {
+        var persistedShortcuts: ShortcutPreferences?
+        let driver = SettingsDriver(createZoomsAutomatically: true)
+        driver.configure(
+            persistShortcuts: { shortcuts in
+                persistedShortcuts = shortcuts
+            }
+        )
+
+        var item = driver.state.shortcuts.item(for: .dragScreenshot)
+        item.isEnabled = false
+        driver.send(.shortcutItemChanged(item))
+
+        XCTAssertFalse(driver.state.shortcuts.item(for: .dragScreenshot).isEnabled)
+        XCTAssertEqual(persistedShortcuts?.item(for: .dragScreenshot).isEnabled, false)
+
+        driver.send(.shortcutsResetToDefaults)
+        XCTAssertTrue(driver.state.shortcuts.item(for: .dragScreenshot).isEnabled)
+    }
+
+    func testAppModelShortcutTriggers() async {
+        let model = AppModel(
+            screenshotCapture: { _, _ in },
+            startRecordingCapture: { _, _, _ in Date() },
+            stopRecording: { URL(fileURLWithPath: "/tmp/test.mp4") }
+        )
+
+        model.cancelCapture()
+        model.triggerDeviceScreenshot()
+        XCTAssertEqual(model.captureMode, .screenshot)
+
+        model.cancelCapture()
+        model.triggerDragScreenshot()
+        XCTAssertEqual(model.captureMode, .screenshot)
+
+        model.cancelCapture()
+        model.triggerDeviceScreenRecord()
+        XCTAssertEqual(model.captureMode, .recording)
+
+        model.cancelCapture()
+        model.triggerDragScreenRecord()
+        XCTAssertEqual(model.captureMode, .recording)
+        XCTAssertTrue(model.isDragRecordingPending)
+
+        model.cancelCapture()
+        XCTAssertFalse(model.isDragRecordingPending)
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
@@ -317,7 +317,7 @@ final class CaptureStateReducerTests: XCTestCase {
 
         XCTAssertEqual(countdown.state.phase, .countingDownRecording(source))
         XCTAssertEqual(countdown.state.presentation, .hidden)
-        XCTAssertEqual(countdown.effects, [.dismissScreenSelection, .hideAppWindowsForCapture, .runRecordingStart(source, outputURL)])
+        XCTAssertEqual(countdown.effects, [.dismissScreenSelection, .dismissCaptureWindows, .runRecordingStart(source, outputURL)])
 
         let canceled = countdown.state.applying(.recordingStopRequested)
         XCTAssertEqual(canceled.state.phase, .setup(.recording))

--- a/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RecordingSessionBuilderTests.swift
@@ -134,4 +134,46 @@ final class RecordingSessionBuilderTests: XCTestCase {
         session.facecamVideoPath = "/tmp/facecam.mov"
         XCTAssertTrue(session.hasRecordedCamera)
     }
+
+    func testFacecamAnchorFromRelativeScreenPosition() {
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.5, relYFromTop: 0.5), .center)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.1, relYFromTop: 0.1), .topLeft)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.5, relYFromTop: 0.1), .top)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.9, relYFromTop: 0.1), .topRight)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.1, relYFromTop: 0.5), .left)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.9, relYFromTop: 0.5), .right)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.1, relYFromTop: 0.9), .bottomLeft)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.5, relYFromTop: 0.9), .bottom)
+        XCTAssertEqual(FacecamAnchor.from(relX: 0.9, relYFromTop: 0.9), .bottomRight)
+    }
+
+    func testBuildRecordingSessionPreservesCustomFacecamSettings() {
+        let screenURL = URL(fileURLWithPath: "/tmp/screen.mp4")
+        let facecamURL = URL(fileURLWithPath: "/tmp/facecam.mov")
+        let customSettings = FacecamSettings(
+            enabled: true,
+            shape: "square",
+            size: 28,
+            cornerRadius: 16,
+            borderWidth: 2,
+            borderColor: "#00FF00",
+            margin: 6,
+            anchor: "center"
+        )
+
+        let session = RecordingSessionBuilder.build(
+            screenVideoURL: screenURL,
+            facecamURL: facecamURL,
+            facecamSettings: customSettings,
+            sourceName: "Display 1",
+            showCursor: true,
+            cursorTelemetryURL: nil,
+            screenStartedAt: Date(),
+            facecamStartedAt: Date()
+        )
+
+        XCTAssertEqual(session.facecamSettings?.anchor, "center")
+        XCTAssertEqual(session.facecamSettings?.shape, "square")
+        XCTAssertEqual(session.facecamSettings?.size, 28)
+    }
 }

--- a/scripts/package-macos-app-shared.zsh
+++ b/scripts/package-macos-app-shared.zsh
@@ -141,7 +141,7 @@ if [[ "$install" == true ]]; then
 	rm -rf "$temp_bundle"
 	ditto "$bundle_dir" "$temp_bundle"
 	find "$temp_bundle" \( -name '._*' -o -name '.__CodeSignature' \) -delete
-	xattr -dr com.apple.quarantine "$temp_bundle" 2>/dev/null || true
+	xattr -r -d com.apple.quarantine "$temp_bundle" 2>/dev/null || true
 	rm -rf "$installed_bundle"
 	mv "$temp_bundle" "$installed_bundle"
 	/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$installed_bundle" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- **Camera Bubble Placement & Boundaries:** Added `FacecamAnchor.from(relX:relYFromTop:)` to map live on-screen bubble coordinates into the corresponding 9-grid anchor positions, and framed the overlay directly within the recording frame with boundary safety clamping so the camera bubble never clips or bleeds out of frame.
- **Timeline Waveform Accent & Peak Glow:** Waveform bars now dynamically use `Theme.accent` with soft peak amplitude halo glow behind loud moments (`amp > 0.48`).
- **Clean Gradient Timeline Clip:** Removed legacy dotted-dashed `FilmstripPatternView` perforations, adding a rich multi-stop slate-navy gradient with subtle specular top highlight stroke.
- **Capture Thread Safety:** Wrapped `AVCaptureSession` configuration atomically and delayed session publishing until `startRunning()` completes, eliminating concurrent preview layer access crashes.
- **Window Bridge Safety:** Decoupled `AppWindowActionBridge` from `@EnvironmentObject` to prevent SIGTRAP crashes during window destruction.

## Verification
- All 613 unit tests passing in `apps/macos`.
- Tested recording, dragging camera bubble, editor timeline inspection, and video playback.