### PR TITLE
PR

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -1517,6 +1517,7 @@ final class AppModel: ObservableObject {
             if options.includeCamera {
                 let initialSettings = resolveFacecamSettingsForRecording(source: selectedSource)
                 cameraRecordingEvents.append(CameraRecordingEvent(timestamp: 0.0, settings: initialSettings))
+                requestWindow(.showCameraBubble)
             }
 
             currentVideoURL = outputURL
@@ -2588,6 +2589,8 @@ final class AppModel: ObservableObject {
     func selectCameraDevice(_ deviceID: String?) {
         captureOptions.send(.cameraSelected(deviceID))
         prewarmSelectedFacecamIfNeeded()
+        requestWindow(.showCameraBubble)
+        requestWindow(.closeCameraSelector)
     }
 
     func selectNoMicrophoneInput() {

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -866,18 +866,22 @@ final class AppModel: ObservableObject {
 
         if let selectedSource {
             let resolved = resolveSelection(previous: selectedSource, in: capture.sources)
+                ?? capture.sources.first(where: { $0.kind == .display })
+                ?? capture.sources.first
             dispatch(.refreshSelectedSource(resolved))
         } else if !hasAttemptedStoredCaptureSetupRestore {
             hasAttemptedStoredCaptureSetupRestore = true
             let restoredSource = storedCaptureSetup.sourceReference?.resolve(
                 in: capture.sources,
                 displayFrames: NSScreen.captureDisplayFramesByID
-            )
+            ) ?? capture.sources.first(where: { $0.kind == .display }) ?? capture.sources.first
             dispatch(.restoreSetup(
                 storedCaptureSetup.mode,
                 restoredSource,
                 preferredSourceKind: storedCaptureSetup.preferredSourceKind
             ))
+        } else if let defaultSource = capture.sources.first(where: { $0.kind == .display }) ?? capture.sources.first {
+            dispatch(.selectSource(defaultSource))
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -252,6 +252,7 @@ final class AppModel: ObservableObject {
     private let cancelFacecamRecording: (@MainActor () -> Void)?
     private let facecamRecorder = FacecamRecorder()
     private let cursorTelemetryRecorder = CursorTelemetryRecorder()
+    private var cameraRecordingEvents: [CameraRecordingEvent] = []
     private let captureDeviceProvider = CaptureDeviceProvider()
     private var nativeWindowCommandHandler: (NativeWindowCommand) -> Void = { _ in }
     private var runRecordingCountdown: @MainActor (CaptureSource) async throws -> Void = { _ in }
@@ -752,6 +753,7 @@ final class AppModel: ObservableObject {
     }
 
     func bootstrap() {
+        disableCamera()
         presentOnboardingIfNeeded()
         Task {
             await refreshSources()
@@ -1474,6 +1476,11 @@ final class AppModel: ObservableObject {
             cursorTelemetryRecorder.alignStart(to: screenStartedAt)
             activeScreenStartedAt = screenStartedAt
             activeRecordingStartDate = screenStartedAt
+            cameraRecordingEvents = []
+            if options.includeCamera {
+                let initialSettings = resolveFacecamSettingsForRecording(source: selectedSource)
+                cameraRecordingEvents.append(CameraRecordingEvent(timestamp: 0.0, settings: initialSettings))
+            }
 
             currentVideoURL = outputURL
             currentScreenshotURL = nil
@@ -1543,9 +1550,15 @@ final class AppModel: ObservableObject {
             currentScreenshotURL = nil
 
             if FileManager.default.fileExists(atPath: outputURL.path) {
+                let totalDuration = await videoDuration(for: outputURL)
+                let cameraClips = (stoppedFacecamURL != nil || activeFacecamURL != nil)
+                    ? buildCameraClipsFromRecordingEvents(duration: totalDuration, fallback: capturedFacecamSettings)
+                    : []
                 let timelineEdits = await initialTimelineEdits(
                     videoURL: outputURL,
-                    cursorTelemetryURL: cursorTelemetryURL
+                    cursorTelemetryURL: cursorTelemetryURL,
+                    facecamSettings: capturedFacecamSettings,
+                    cameraClips: cameraClips
                 )
                 let sourceName = source?.name ?? selectedSource?.name
                 let recordingSession = RecordingSessionBuilder.build(
@@ -2234,14 +2247,58 @@ final class AppModel: ObservableObject {
         videoExport.clear()
     }
 
-    private func initialTimelineEdits(videoURL: URL, cursorTelemetryURL: URL?) async -> TimelineEditSnapshot {
-        guard createZoomsAutomatically, let cursorTelemetryURL else {
-            return .empty
+    private func initialTimelineEdits(
+        videoURL: URL,
+        cursorTelemetryURL: URL?,
+        facecamSettings: FacecamSettings? = nil,
+        cameraClips: [TimelineCameraClip] = []
+    ) async -> TimelineEditSnapshot {
+        let duration = await videoDuration(for: videoURL)
+        var zooms: [TimelineZoomRegion] = []
+        if createZoomsAutomatically, let cursorTelemetryURL {
+            zooms = AutoZoomGenerator.generate(
+                from: cursorTelemetryURL,
+                duration: duration,
+                preset: autoZoomAnimationPreset,
+                cameraSettings: facecamSettings
+            )
+        }
+        return TimelineEditSnapshot(
+            zoomRegions: zooms,
+            cameraClips: cameraClips
+        )
+    }
+
+    func recordCameraEventDuringRecording() {
+        guard capture.isRecording || recordingPhase == .recording,
+              let startedAt = activeScreenStartedAt else { return }
+        let elapsed = max(0, Date().timeIntervalSince(startedAt))
+        let settings = resolveFacecamSettingsForRecording(source: captureState.source)
+        if let last = cameraRecordingEvents.last, last.settings == settings { return }
+        cameraRecordingEvents.append(CameraRecordingEvent(timestamp: elapsed, settings: settings))
+    }
+
+    private func buildCameraClipsFromRecordingEvents(duration: Double, fallback: FacecamSettings) -> [TimelineCameraClip] {
+        guard duration.isFinite, duration > 0 else { return [] }
+        guard !cameraRecordingEvents.isEmpty else {
+            return [TimelineCameraClip(span: TimelineSpan(start: 0, end: duration), settings: fallback)]
         }
 
-        let duration = await videoDuration(for: videoURL)
-        let zooms = AutoZoomGenerator.generate(from: cursorTelemetryURL, duration: duration, preset: autoZoomAnimationPreset)
-        return TimelineEditSnapshot(zoomRegions: zooms)
+        var clips: [TimelineCameraClip] = []
+        for i in 0..<cameraRecordingEvents.count {
+            let event = cameraRecordingEvents[i]
+            let startTime = min(event.timestamp, duration)
+            let nextTime: Double = (i + 1 < cameraRecordingEvents.count)
+                ? min(cameraRecordingEvents[i + 1].timestamp, duration)
+                : duration
+            if nextTime - startTime > 0.05 {
+                clips.append(TimelineCameraClip(
+                    span: TimelineSpan(start: startTime, end: nextTime),
+                    settings: event.settings
+                ))
+            }
+        }
+        return clips.isEmpty ? [TimelineCameraClip(span: TimelineSpan(start: 0, end: duration), settings: fallback)] : clips
     }
 
     private func videoDuration(for url: URL) async -> Double {
@@ -2277,7 +2334,7 @@ final class AppModel: ObservableObject {
         }
 
         let screenLength = (NSScreen.main?.frame.height ?? 1080.0)
-        let sizePercent = max(14.0, min(36.0, (resolvedDiameter / screenLength) * 100.0))
+        let sizePercent = max(10.0, min(65.0, (resolvedDiameter / screenLength) * 100.0))
 
         return FacecamSettings(
             enabled: true,

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -777,7 +777,6 @@ final class AppModel: ObservableObject {
     }
 
     func bootstrap() {
-        disableCamera()
         presentOnboardingIfNeeded()
         Task {
             await refreshSources()
@@ -2738,11 +2737,6 @@ final class AppModel: ObservableObject {
 
     private func prewarmSelectedFacecamIfNeeded() {
         let options = currentCaptureOptions
-        guard options.includeCamera else {
-            cancelFacecamPrewarm()
-            return
-        }
-
         facecamPrewarmTask?.cancel()
         facecamPrewarmTask = Task { @MainActor [weak self] in
             guard let self else { return }

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -2511,6 +2511,9 @@ final class AppModel: ObservableObject {
     func toggleSystemAudio() {
         captureOptions.send(.availabilityChanged(canChangeRecordingOptions))
         captureOptions.send(.systemAudioToggled)
+        if captureOptions.state.includeSystemAudio && capture.screenRecordingPermissionState != .granted {
+            _ = requestScreenRecordingPermission()
+        }
     }
 
     func disableCamera() {

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -483,6 +483,24 @@ final class AppModel: ObservableObject {
                 self?.objectWillChange.send()
             }
         )
+        NotificationCenter.default.addObserver(
+            forName: AVCaptureDevice.wasConnectedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.captureOptions.send(.refreshDevicesRequested)
+            }
+        }
+        NotificationCenter.default.addObserver(
+            forName: AVCaptureDevice.wasDisconnectedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.captureOptions.send(.refreshDevicesRequested)
+            }
+        }
         appShell.onboarding.configure(
             currentPermissions: { [weak self] in
                 guard let self else { return (.requestAvailable, .requestAvailable) }

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -528,6 +528,20 @@ final class AppModel: ObservableObject {
             nil,
             preferredSourceKind: storedCaptureSetup.preferredSourceKind
         ))
+        NotificationCenter.default.addObserver(
+            forName: AVCaptureDevice.wasConnectedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshCaptureDevices()
+        }
+        NotificationCenter.default.addObserver(
+            forName: AVCaptureDevice.wasDisconnectedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshCaptureDevices()
+        }
     }
 
     private func configureEditorWorkspace(_ workspace: EditorWorkspaceDriver) {

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -160,6 +160,16 @@ final class AppModel: ObservableObject {
         get { appShell.settings.state.autoZoomAnimationPreset }
         set { appShell.settings.send(.autoZoomAnimationPresetChanged(newValue)) }
     }
+    /// Whether to play a synthesised click sound on every mouse button press during recording.
+    var mouseClickSoundsEnabled: Bool {
+        get { recordingPreferences.load().mouseClickSoundsEnabled }
+        set { recordingPreferences.setMouseClickSoundsEnabled(newValue) }
+    }
+    /// Whether to play a soft tap sound on every key-down event during recording.
+    var keyboardSoundsEnabled: Bool {
+        get { recordingPreferences.load().keyboardSoundsEnabled }
+        set { recordingPreferences.setKeyboardSoundsEnabled(newValue) }
+    }
     var microphoneDevices: [CaptureDeviceInfo] {
         get { captureOptions.state.microphoneDevices }
         set {
@@ -1470,6 +1480,12 @@ final class AppModel: ObservableObject {
             }
 
             cursorTelemetryRecorder.start(for: selectedSource)
+            // Start audio feedback (click/keyboard sounds) if user has enabled them.
+            let audioFeedback = CaptureAudioFeedback.shared
+            let latestPrefs = recordingPreferences.load()
+            audioFeedback.mouseClickSoundsEnabled = latestPrefs.mouseClickSoundsEnabled
+            audioFeedback.keyboardSoundsEnabled = latestPrefs.keyboardSoundsEnabled
+            audioFeedback.startMonitoring()
             let screenStartedAt = try await startRecordingCapture(selectedSource, outputURL, options)
             cursorTelemetryRecorder.alignStart(to: screenStartedAt)
             activeScreenStartedAt = screenStartedAt
@@ -1537,6 +1553,7 @@ final class AppModel: ObservableObject {
         do {
             let capturedFacecamSettings = resolveFacecamSettingsForRecording(source: source)
             let outputURL = try await stopRecordingCapture()
+            CaptureAudioFeedback.shared.stopMonitoring()
             let stoppedFacecamURL = try? await stopFacecam()
             let cursorTelemetryURL = cursorTelemetryRecorder.stop(videoURL: outputURL)
             currentVideoURL = outputURL
@@ -1582,6 +1599,7 @@ final class AppModel: ObservableObject {
                 dispatch(.recordingStopped(message: "Recording stopped before a file was written."))
             }
         } catch {
+            CaptureAudioFeedback.shared.stopMonitoring()
             _ = cursorTelemetryRecorder.stop(videoURL: nil)
             if let source {
                 dispatch(.recordingFailed(source, message: error.localizedDescription))

--- a/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
@@ -117,6 +117,9 @@ extension CaptureOptionsState {
         case .cameraEnabledChanged(let isEnabled):
             guard canChangeOptions else { return lockedMutationEffects() }
             includeCamera = isEnabled
+            if isEnabled && selectedCameraDeviceID == nil {
+                selectedCameraDeviceID = cameraDevices.first?.id
+            }
             return []
 
         case .deviceRefreshStarted:

--- a/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
@@ -56,10 +56,10 @@ struct CaptureOptionsState: Equatable {
     var recordingOptions: RecordingCaptureOptions {
         RecordingCaptureOptions(
             includeMicrophone: includeMicrophone,
-            microphoneDeviceID: includeMicrophone ? selectedMicrophoneDeviceID : nil,
+            microphoneDeviceID: includeMicrophone && hasAvailableMicrophoneSelection ? selectedMicrophoneDeviceID : nil,
             includeSystemAudio: includeSystemAudio,
             includeCamera: includeCamera,
-            cameraDeviceID: includeCamera ? selectedCameraDeviceID : nil,
+            cameraDeviceID: includeCamera && hasAvailableCameraSelection ? selectedCameraDeviceID : nil,
             showCursor: showCursor,
             showClicks: showClicks
         )
@@ -72,6 +72,7 @@ enum CaptureOptionsEvent: Equatable {
     case systemAudioChanged(Bool)
     case cameraEnabledChanged(Bool)
     case deviceRefreshStarted
+    case refreshDevicesRequested
     case devicesRefreshed(microphones: [CaptureDeviceInfo], cameras: [CaptureDeviceInfo])
     case deviceRefreshFailed(String)
     case systemAudioToggled
@@ -121,6 +122,9 @@ extension CaptureOptionsState {
         case .deviceRefreshStarted:
             deviceLoadPhase = .loading
             return []
+
+        case .refreshDevicesRequested:
+            return [.refreshDevices]
 
         case .devicesRefreshed(let microphones, let cameras):
             microphoneDevices = microphones

--- a/apps/macos/Sources/OpenRecorderMac/AutoZoomGenerator.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AutoZoomGenerator.swift
@@ -12,17 +12,30 @@ enum AutoZoomGenerator {
     static func generate(
         from telemetry: CursorTelemetryPayload,
         duration: Double,
-        preset: TimelineZoomAnimationPreset = .balanced
+        preset: TimelineZoomAnimationPreset = .balanced,
+        cameraSettings: FacecamSettings? = nil
     ) -> [TimelineZoomRegion] {
         guard duration.isFinite, duration > 0 else { return [] }
         guard telemetry.width > 0, telemetry.height > 0 else { return [] }
 
+        let width = Double(max(telemetry.width, 1))
+        let height = Double(max(telemetry.height, 1))
+
+        let isInsideCamera: (Int, Int) -> Bool = { x, y in
+            guard let camera = cameraSettings, camera.enabled else { return false }
+            let normX = Double(x) / width
+            let normY = Double(y) / height
+            let cameraRect = FacecamOverlayLayout.normalizedRect(for: camera)
+            let expandedRect = cameraRect.insetBy(dx: -0.06, dy: -0.06)
+            return expandedRect.contains(CGPoint(x: normX, y: normY))
+        }
+
         let config = preset.configuration
         let sortedClicks = telemetry.clicks
-            .filter { $0.timestamp >= 0 }
+            .filter { $0.timestamp >= 0 && !isInsideCamera($0.x, $0.y) }
             .sorted { $0.timestamp < $1.timestamp }
         let sortedSamples = telemetry.samples
-            .filter { $0.timestamp >= 0 }
+            .filter { $0.timestamp >= 0 && !isInsideCamera($0.x, $0.y) }
             .sorted { $0.timestamp < $1.timestamp }
 
         let clickCandidates = clusteredClicks(sortedClicks, mergeThresholdSeconds: config.mergeThresholdSeconds)
@@ -73,10 +86,11 @@ enum AutoZoomGenerator {
     static func generate(
         from telemetryURL: URL,
         duration: Double,
-        preset: TimelineZoomAnimationPreset = .balanced
+        preset: TimelineZoomAnimationPreset = .balanced,
+        cameraSettings: FacecamSettings? = nil
     ) -> [TimelineZoomRegion] {
         guard let telemetry = try? CursorTelemetryPayload.load(from: telemetryURL) else { return [] }
-        return generate(from: telemetry, duration: duration, preset: preset)
+        return generate(from: telemetry, duration: duration, preset: preset, cameraSettings: cameraSettings)
     }
 
     private static func clusteredClicks(_ clicks: [CursorTelemetryClick], mergeThresholdSeconds: Double) -> [[CursorTelemetryClick]] {

--- a/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
@@ -93,7 +93,7 @@ struct CameraBubbleWindowView: View {
 
     private func updateWindowFrame(newDimensions: CGSize) {
         DispatchQueue.main.async {
-            guard let window = NSApp.windows.first(where: { $0.title == "Camera Preview" }) else { return }
+            guard let window = NSApp.windows.first(where: { $0.title == "Camera Preview" || $0.title == "Camera Bubble" }) else { return }
             let totalWidth = newDimensions.width + 28
             let totalHeight = newDimensions.height + 70
             var frame = window.frame
@@ -101,6 +101,7 @@ struct CameraBubbleWindowView: View {
             frame.size = CGSize(width: totalWidth, height: totalHeight)
             frame.origin.y += (oldHeight - totalHeight)
             window.setFrame(frame, display: true, animate: false)
+            window.orderFrontRegardless()
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
@@ -36,8 +36,8 @@ struct CameraBubbleWindowView: View {
     @State private var isHovering = false
     @State private var isResizing = false
 
-    private let minDiameter: Double = 130.0
-    private let maxDiameter: Double = 460.0
+    private let minDiameter: Double = 100.0
+    private let maxDiameter: Double = 600.0
 
     private var currentDimensions: CGSize {
         let clamped = max(minDiameter, min(liveDiameter, maxDiameter))
@@ -81,10 +81,26 @@ struct CameraBubbleWindowView: View {
                 isHovering = hovering
             }
         }
-        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: selectedShape)
         .onAppear {
             liveDiameter = max(minDiameter, min(storedDiameter, maxDiameter))
             model.prepareCameraIfNeeded()
+            updateWindowFrame(newDimensions: currentDimensions)
+        }
+        .onChange(of: currentDimensions) { _, newDims in
+            updateWindowFrame(newDimensions: newDims)
+        }
+    }
+
+    private func updateWindowFrame(newDimensions: CGSize) {
+        DispatchQueue.main.async {
+            guard let window = NSApp.windows.first(where: { $0.title == "Camera Preview" }) else { return }
+            let totalWidth = newDimensions.width + 28
+            let totalHeight = newDimensions.height + 70
+            var frame = window.frame
+            let oldHeight = frame.height
+            frame.size = CGSize(width: totalWidth, height: totalHeight)
+            frame.origin.y += (oldHeight - totalHeight)
+            window.setFrame(frame, display: true, animate: false)
         }
     }
 
@@ -94,6 +110,17 @@ struct CameraBubbleWindowView: View {
             CameraVideoPreviewRepresentable(session: session, isMirrored: isMirrored)
         } else {
             cameraFallbackView
+        }
+    }
+
+    private var activeCornerRadius: CGFloat {
+        switch selectedShape {
+        case .circle:
+            return min(currentDimensions.width, currentDimensions.height) / 2
+        case .square:
+            return min(32.0, currentDimensions.width * 0.18)
+        case .rectangle:
+            return min(24.0, currentDimensions.height * 0.16)
         }
     }
 
@@ -109,31 +136,14 @@ struct CameraBubbleWindowView: View {
             endPoint: .bottomTrailing
         )
 
-        switch selectedShape {
-        case .circle:
-            videoContent
-                .clipShape(Circle())
-                .overlay {
-                    Circle()
-                        .strokeBorder(borderStroke, lineWidth: 1.2)
-                }
-        case .square:
-            let radius = min(32.0, currentDimensions.width * 0.18)
-            videoContent
-                .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: radius, style: .continuous)
-                        .strokeBorder(borderStroke, lineWidth: 1.2)
-                }
-        case .rectangle:
-            let radius = min(24.0, currentDimensions.height * 0.16)
-            videoContent
-                .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: radius, style: .continuous)
-                        .strokeBorder(borderStroke, lineWidth: 1.2)
-                }
-        }
+        let radius = activeCornerRadius
+
+        videoContent
+            .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(borderStroke, lineWidth: 1.2)
+            }
     }
 
     private var cameraFallbackView: some View {
@@ -158,6 +168,9 @@ struct CameraBubbleWindowView: View {
                     let isSelected = selectedShape == shape
                     Button {
                         selectedShape = shape
+                        UserDefaults.standard.set(shape.rawValue, forKey: "camera_bubble_shape")
+                        updateWindowFrame(newDimensions: currentDimensions)
+                        model.recordCameraEventDuringRecording()
                     } label: {
                         Image(systemName: shape.symbolName)
                             .font(.system(size: 11, weight: .semibold))
@@ -230,11 +243,16 @@ struct CameraBubbleWindowView: View {
             CameraResizeGripRepresentable(
                 onResizeDelta: { delta in
                     isResizing = true
-                    liveDiameter = max(minDiameter, min(liveDiameter + delta, maxDiameter))
+                    let newDiameter = max(minDiameter, min(liveDiameter + delta, maxDiameter))
+                    liveDiameter = newDiameter
+                    storedDiameter = newDiameter
+                    UserDefaults.standard.set(newDiameter, forKey: "camera_bubble_diameter")
                 },
                 onResizeEnded: {
                     isResizing = false
                     storedDiameter = liveDiameter
+                    UserDefaults.standard.set(liveDiameter, forKey: "camera_bubble_diameter")
+                    model.recordCameraEventDuringRecording()
                 }
             )
 
@@ -342,6 +360,14 @@ final class CameraPreviewNSView: NSView {
         wantsLayer = true
         previewLayer.videoGravity = .resizeAspectFill
         layer?.addSublayer(previewLayer)
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        previewLayer.frame = CGRect(origin: .zero, size: newSize)
+        CATransaction.commit()
     }
 
     override func layout() {

--- a/apps/macos/Sources/OpenRecorderMac/CaptureAudioFeedback.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureAudioFeedback.swift
@@ -1,0 +1,216 @@
+import AVFoundation
+import AppKit
+
+// MARK: - CaptureAudioFeedback
+
+/// Plays synthesised audio feedback sounds for mouse clicks and keyboard keystrokes
+/// while a screen recording is in progress.
+///
+/// Both sound types are generated on-the-fly as raw PCM WAV data — no bundled
+/// audio assets are required. A shared AVAudioPlayer pool keeps the last
+/// queued sound hot so rapid-fire triggers never drop frames or block the main thread.
+@MainActor
+final class CaptureAudioFeedback {
+    static let shared = CaptureAudioFeedback()
+
+    // MARK: Public toggles (read from RecordingPreferencesStore)
+
+    var mouseClickSoundsEnabled: Bool = false
+    var keyboardSoundsEnabled: Bool = false
+
+    // MARK: Private state
+
+    private var globalMouseMonitor: Any?
+    private var localMouseMonitor: Any?
+    private var globalKeyMonitor: Any?
+    private var localKeyMonitor: Any?
+
+    private let clickSoundData: Data?
+    private let keystrokeSoundData: Data?
+
+    private var clickPlayers: [AVAudioPlayer] = []
+    private let clickPoolSize = 4
+    private var clickPoolIndex = 0
+
+    private var keystrokePlayers: [AVAudioPlayer] = []
+    private let keystrokePoolSize = 6
+    private var keystrokePoolIndex = 0
+
+    // MARK: - Init
+
+    init() {
+        clickSoundData = CaptureAudioFeedback.generateClickWAV()
+        keystrokeSoundData = CaptureAudioFeedback.generateKeystrokeWAV()
+        preparePlayers()
+    }
+
+    // MARK: - Public API
+
+    func startMonitoring() {
+        guard mouseClickSoundsEnabled || keyboardSoundsEnabled else { return }
+        installMonitors()
+    }
+
+    func stopMonitoring() {
+        removeMonitors()
+    }
+
+    func refreshMonitors() {
+        removeMonitors()
+        if mouseClickSoundsEnabled || keyboardSoundsEnabled {
+            installMonitors()
+        }
+    }
+
+    // MARK: - Monitor installation
+
+    private func installMonitors() {
+        if mouseClickSoundsEnabled {
+            let mouseMask: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+            globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: mouseMask) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.playClick() }
+            }
+            localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: mouseMask) { [weak self] event in
+                Task { @MainActor [weak self] in self?.playClick() }
+                return event
+            }
+        }
+
+        if keyboardSoundsEnabled {
+            let keyMask: NSEvent.EventTypeMask = [.keyDown]
+            globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: keyMask) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.playKeystroke() }
+            }
+            localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: keyMask) { [weak self] event in
+                Task { @MainActor [weak self] in self?.playKeystroke() }
+                return event
+            }
+        }
+    }
+
+    private func removeMonitors() {
+        if let m = globalMouseMonitor { NSEvent.removeMonitor(m); globalMouseMonitor = nil }
+        if let m = localMouseMonitor  { NSEvent.removeMonitor(m); localMouseMonitor = nil }
+        if let m = globalKeyMonitor   { NSEvent.removeMonitor(m); globalKeyMonitor = nil }
+        if let m = localKeyMonitor    { NSEvent.removeMonitor(m); localKeyMonitor = nil }
+    }
+
+    // MARK: - Playback helpers
+
+    private func playClick() {
+        guard mouseClickSoundsEnabled, !clickPlayers.isEmpty else { return }
+        let player = clickPlayers[clickPoolIndex % clickPlayers.count]
+        clickPoolIndex = (clickPoolIndex + 1) % clickPlayers.count
+        player.currentTime = 0
+        player.play()
+    }
+
+    private func playKeystroke() {
+        guard keyboardSoundsEnabled, !keystrokePlayers.isEmpty else { return }
+        let player = keystrokePlayers[keystrokePoolIndex % keystrokePlayers.count]
+        keystrokePoolIndex = (keystrokePoolIndex + 1) % keystrokePlayers.count
+        player.currentTime = 0
+        player.play()
+    }
+
+    // MARK: - Player preparation
+
+    private func preparePlayers() {
+        if let data = clickSoundData {
+            for _ in 0..<clickPoolSize {
+                if let p = try? AVAudioPlayer(data: data) {
+                    p.prepareToPlay()
+                    p.volume = 0.52
+                    clickPlayers.append(p)
+                }
+            }
+        }
+        if let data = keystrokeSoundData {
+            for _ in 0..<keystrokePoolSize {
+                if let p = try? AVAudioPlayer(data: data) {
+                    p.prepareToPlay()
+                    p.volume = 0.38
+                    keystrokePlayers.append(p)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sound synthesis
+
+    /// Synthesises a short, satisfying mouse-click sound:
+    /// a percussive transient pop with fast attack and exponential decay.
+    private static func generateClickWAV() -> Data? {
+        let sampleRate: Double = 44100
+        let duration: Double = 0.065
+        let total = Int(sampleRate * duration)
+        var samples = [Int16](repeating: 0, count: total)
+
+        for i in 0..<total {
+            let t = Double(i) / sampleRate
+            let freq = 220.0 * (1 + max(0, 0.12 * (1 - t / 0.006)))
+            let wave = sin(2 * .pi * freq * t) * 0.68
+                     + sin(2 * .pi * freq * 2 * t) * 0.22
+                     + sin(2 * .pi * freq * 3 * t) * 0.10
+            let attack = min(1.0, t / 0.0015)
+            let decay  = max(0.0, 1.0 - (t / duration))
+            let env    = attack * pow(decay, 2.8)
+            let value  = wave * env * 0.55
+            samples[i] = Int16(max(-32767, min(32767, value * 32767)))
+        }
+        return makeWAV(samples: samples, sampleRate: Int32(sampleRate))
+    }
+
+    /// Synthesises a soft keyboard keystroke sound:
+    /// a very brief high-frequency tap with near-instant decay.
+    private static func generateKeystrokeWAV() -> Data? {
+        let sampleRate: Double = 44100
+        let duration: Double = 0.045
+        let total = Int(sampleRate * duration)
+        var samples = [Int16](repeating: 0, count: total)
+
+        for i in 0..<total {
+            let t = Double(i) / sampleRate
+            let freq = 480.0 * (1 + max(0, 0.06 * (1 - t / 0.004)))
+            let wave = sin(2 * .pi * freq * t) * 0.60
+                     + sin(2 * .pi * freq * 2 * t) * 0.28
+                     + sin(2 * .pi * freq * 3 * t) * 0.12
+            let attack = min(1.0, t / 0.001)
+            let decay  = max(0.0, 1.0 - (t / duration))
+            let env    = attack * pow(decay, 3.5)
+            let value  = wave * env * 0.42
+            samples[i] = Int16(max(-32767, min(32767, value * 32767)))
+        }
+        return makeWAV(samples: samples, sampleRate: Int32(sampleRate))
+    }
+
+    // MARK: - WAV builder
+
+    private static func makeWAV(samples: [Int16], sampleRate: Int32) -> Data {
+        var data = Data()
+        let numChannels: Int16 = 1
+        let bitsPerSample: Int16 = 16
+        let byteRate = sampleRate * Int32(numChannels * bitsPerSample / 8)
+        let blockAlign = numChannels * bitsPerSample / 8
+        let dataSize = Int32(samples.count * MemoryLayout<Int16>.size)
+        let chunkSize = 36 + dataSize
+
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: chunkSize.littleEndian) { Array($0) })
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: Int32(16).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: Int16(1).littleEndian) { Array($0) }) // PCM
+        data.append(contentsOf: withUnsafeBytes(of: numChannels.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: sampleRate.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: byteRate.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: blockAlign.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: bitsPerSample.littleEndian) { Array($0) })
+        data.append(contentsOf: "data".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
+        for sample in samples {
+            data.append(contentsOf: withUnsafeBytes(of: sample.littleEndian) { Array($0) })
+        }
+        return data
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -92,7 +92,7 @@ enum ScreencaptureRegionMapper {
     private static func primaryDisplayFrame() -> CGRect {
         NSScreen.screens.first { screen in
             screen.frame.origin == .zero
-        }?.frame ?? NSScreen.main?.frame ?? NSScreen.screens.first?.frame ?? .zero
+        }?.frame ?? NSScreen.main?.frame ?? NSScreen.screens.first?.frame ?? CGRect(x: 0, y: 0, width: 1920, height: 1080)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -161,13 +161,22 @@ enum WindowSourceFilter {
     }
 
     private static let blockedOwnerNames: Set<String> = [
+        "airplay",
+        "airplayxpchelper",
         "control center",
+        "coreauthui",
         "dock",
         "loginwindow",
         "notification center",
+        "quicklookuiservice",
+        "screencapture",
+        "screencaptured",
+        "screencaptureui",
         "spotlight",
         "systemuiserver",
+        "talagent",
         "textinputmenuagent",
+        "universalaccessd",
         "wallpaper",
         "window server"
     ]
@@ -180,9 +189,13 @@ enum WindowSourceFilter {
 
     private static let blockedBundlePrefixes: [String] = [
         "com.apple.controlcenter",
+        "com.apple.coreauthui",
         "com.apple.dock",
         "com.apple.loginwindow",
         "com.apple.notificationcenterui",
+        "com.apple.quicklook.ui.helper",
+        "com.apple.screencapture",
+        "com.apple.screencaptureui",
         "com.apple.spotlight",
         "com.apple.systemuiserver",
         "com.apple.textinputmenuagent",

--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -210,30 +210,6 @@ struct CaptureHUD: View {
         systemAudioToggle
         microphoneToggle
         cameraToggle
-        mouseClickSoundsToggle
-        keyboardSoundsToggle
-    }
-
-    private var mouseClickSoundsToggle: some View {
-        HUDToggle(
-            symbolName: model.mouseClickSoundsEnabled ? "hand.tap.fill" : "hand.tap",
-            isActive: model.mouseClickSoundsEnabled,
-            title: model.mouseClickSoundsEnabled ? "Click Sounds On" : "Click Sounds Off",
-            isDisabled: !options.state.canChangeOptions
-        ) {
-            model.mouseClickSoundsEnabled.toggle()
-        }
-    }
-
-    private var keyboardSoundsToggle: some View {
-        HUDToggle(
-            symbolName: model.keyboardSoundsEnabled ? "keyboard.fill" : "keyboard",
-            isActive: model.keyboardSoundsEnabled,
-            title: model.keyboardSoundsEnabled ? "Keyboard Sounds On" : "Keyboard Sounds Off",
-            isDisabled: !options.state.canChangeOptions
-        ) {
-            model.keyboardSoundsEnabled.toggle()
-        }
     }
 
     private var systemAudioToggle: some View {

--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -262,10 +262,8 @@ struct CaptureHUD: View {
         ) {
             if options.state.includeCamera {
                 model.disableCamera()
-            } else if options.state.hasAvailableCameraSelection {
-                model.includeCamera = true
             } else {
-                openCameraSelector()
+                model.includeCamera = true
             }
         }
 

--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -210,6 +210,30 @@ struct CaptureHUD: View {
         systemAudioToggle
         microphoneToggle
         cameraToggle
+        mouseClickSoundsToggle
+        keyboardSoundsToggle
+    }
+
+    private var mouseClickSoundsToggle: some View {
+        HUDToggle(
+            symbolName: model.mouseClickSoundsEnabled ? "hand.tap.fill" : "hand.tap",
+            isActive: model.mouseClickSoundsEnabled,
+            title: model.mouseClickSoundsEnabled ? "Click Sounds On" : "Click Sounds Off",
+            isDisabled: !options.state.canChangeOptions
+        ) {
+            model.mouseClickSoundsEnabled.toggle()
+        }
+    }
+
+    private var keyboardSoundsToggle: some View {
+        HUDToggle(
+            symbolName: model.keyboardSoundsEnabled ? "keyboard.fill" : "keyboard",
+            isActive: model.keyboardSoundsEnabled,
+            title: model.keyboardSoundsEnabled ? "Keyboard Sounds On" : "Keyboard Sounds Off",
+            isDisabled: !options.state.canChangeOptions
+        ) {
+            model.keyboardSoundsEnabled.toggle()
+        }
     }
 
     private var systemAudioToggle: some View {

--- a/apps/macos/Sources/OpenRecorderMac/CursorTelemetryRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CursorTelemetryRecorder.swift
@@ -95,6 +95,14 @@ struct CursorTelemetryTrack: Equatable {
         return point(at: seconds, loops: settings.loops, smoothing: settings.smoothing)
     }
 
+    func normalizedPoint(at seconds: Double, loops: Bool = false, smoothing: Double = 0) -> CGPoint? {
+        guard let p = point(at: seconds, loops: loops, smoothing: smoothing) else { return nil }
+        return CGPoint(
+            x: width > 0 ? p.x / CGFloat(width) : 0,
+            y: height > 0 ? p.y / CGFloat(height) : 0
+        )
+    }
+
     func point(at seconds: Double, loops: Bool, smoothing: Double) -> CGPoint? {
         guard !samples.isEmpty, seconds.isFinite else { return nil }
 

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -278,6 +278,7 @@ struct VideoEditorStudioView: View {
                 cursorSize: editor.binding(\.cursorOverlay.size),
                 cursorSmoothing: editor.binding(\.cursorOverlay.smoothing),
                 cursorStyleID: editor.binding(\.cursorOverlay.styleID),
+                cameraSettings: editor.binding(\.facecamSettings),
                 recordingSession: recordingSession
             )
         }

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -278,6 +278,7 @@ struct VideoEditorStudioView: View {
                 cursorSize: editor.binding(\.cursorOverlay.size),
                 cursorSmoothing: editor.binding(\.cursorOverlay.smoothing),
                 cursorStyleID: editor.binding(\.cursorOverlay.styleID),
+                lockCameraWhenZooming: editor.facecamBinding(\.fixedDuringZoom, default: false),
                 recordingSession: recordingSession
             )
         }

--- a/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
@@ -47,9 +47,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     func prepare(cameraDeviceID: String?) async throws {
         if preparedCameraDeviceID == cameraDeviceID,
            let session,
-           let movieOutput,
-           session.isRunning,
-           !movieOutput.isRecording {
+           session.isRunning {
             return
         }
 

--- a/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
@@ -92,6 +92,8 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         let device = try cameraDevice(cameraDeviceID)
         let input = try AVCaptureDeviceInput(device: device)
         let session = AVCaptureSession()
+        session.beginConfiguration()
+        defer { session.commitConfiguration() }
         session.sessionPreset = .high
 
         guard session.canAddInput(input) else {

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -24,6 +24,7 @@ struct SettingsInspector: View {
     @Binding var cursorSize: Double
     @Binding var cursorSmoothing: Double
     @Binding var cursorStyleID: CursorStyleID
+    var cameraSettings: Binding<FacecamSettings?>? = nil
     var recordingSession: RecordingSession?
 
     @Namespace private var tabRailAnimation
@@ -231,12 +232,56 @@ struct SettingsInspector: View {
                 InspectorSlider(title: "Smoothing", valueText: String(format: "%.2f", cursorSmoothing), value: $cursorSmoothing, range: 0...2, step: 0.01, defaultValue: 0.45, leadingSymbolName: "point.topleft.down.curvedto.point.bottomright.up", trailingSymbolName: "waveform.path.ecg")
             }
         case .camera:
-            InspectorGroup(title: "Facecam", symbolName: "camera", showsTopDivider: false) {
-                Text(hasRecordedCamera ? "Timeline camera layer active" : "No facecam recorded")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                InspectorSwitch(title: "Remove camera background", isOn: $removeCameraBackground)
+            if hasRecordedCamera, cameraSettings != nil {
+                InspectorGroup(title: "Facecam", symbolName: "camera.fill", showsTopDivider: false) {
+                    InspectorSwitch(title: "Show Facecam", isOn: cameraEnabledBinding)
+                }
+
+                InspectorGroup(title: "Position", symbolName: "square.grid.3x3") {
+                    PositionGrid(selection: cameraAnchorBinding)
+                }
+
+                InspectorGroup(title: "Style", symbolName: "slider.horizontal.3") {
+                    InspectorSlider(
+                        title: "Size",
+                        valueText: "\(Int(cameraSizeBinding.wrappedValue.rounded()))%",
+                        value: cameraSizeBinding,
+                        range: 8...75,
+                        step: 1
+                    )
+                    InspectorSlider(
+                        title: "Corner Radius",
+                        valueText: "\(Int(cameraCornerRadiusBinding.wrappedValue.rounded()))px",
+                        value: cameraCornerRadiusBinding,
+                        range: 0...100,
+                        step: 1
+                    )
+                    InspectorSlider(
+                        title: "Margin",
+                        valueText: "\(Int(cameraMarginBinding.wrappedValue.rounded()))%",
+                        value: cameraMarginBinding,
+                        range: 0...24,
+                        step: 1
+                    )
+                    InspectorSlider(
+                        title: "Border",
+                        valueText: "\(Int(cameraBorderWidthBinding.wrappedValue.rounded()))px",
+                        value: cameraBorderWidthBinding,
+                        range: 0...16,
+                        step: 1
+                    )
+                }
+
+                InspectorGroup(title: "Background", symbolName: "sparkles") {
+                    InspectorSwitch(title: "Remove camera background", isOn: $removeCameraBackground)
+                }
+            } else {
+                InspectorGroup(title: "Facecam", symbolName: "camera", showsTopDivider: false) {
+                    Text("No facecam recorded with this video.")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .padding(.vertical, 8)
+                }
             }
             if let path = recordingSession?.facecamVideoPath {
                 SessionAssetRow(title: "Facecam File", path: path)
@@ -264,6 +309,72 @@ struct SettingsInspector: View {
                 SessionAssetRow(title: "Source", path: sourceName)
             }
         }
+    }
+
+    private var cameraEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { cameraSettings?.wrappedValue?.enabled ?? true },
+            set: { enabled in
+                var current = cameraSettings?.wrappedValue ?? defaultFacecamSettings(enabled: true)
+                current.enabled = enabled
+                cameraSettings?.wrappedValue = current
+            }
+        )
+    }
+
+    private var cameraAnchorBinding: Binding<String> {
+        Binding(
+            get: { cameraSettings?.wrappedValue?.anchor ?? FacecamAnchor.bottomRight.rawValue },
+            set: { anchor in
+                var current = cameraSettings?.wrappedValue ?? defaultFacecamSettings(enabled: true)
+                current.anchor = anchor
+                cameraSettings?.wrappedValue = current
+            }
+        )
+    }
+
+    private var cameraSizeBinding: Binding<Double> {
+        Binding(
+            get: { cameraSettings?.wrappedValue?.size ?? 22 },
+            set: { size in
+                var current = cameraSettings?.wrappedValue ?? defaultFacecamSettings(enabled: true)
+                current.size = size
+                cameraSettings?.wrappedValue = current
+            }
+        )
+    }
+
+    private var cameraCornerRadiusBinding: Binding<Double> {
+        Binding(
+            get: { cameraSettings?.wrappedValue?.cornerRadius ?? 100 },
+            set: { radius in
+                var current = cameraSettings?.wrappedValue ?? defaultFacecamSettings(enabled: true)
+                current.cornerRadius = radius
+                cameraSettings?.wrappedValue = current
+            }
+        )
+    }
+
+    private var cameraMarginBinding: Binding<Double> {
+        Binding(
+            get: { cameraSettings?.wrappedValue?.margin ?? 4 },
+            set: { margin in
+                var current = cameraSettings?.wrappedValue ?? defaultFacecamSettings(enabled: true)
+                current.margin = margin
+                cameraSettings?.wrappedValue = current
+            }
+        )
+    }
+
+    private var cameraBorderWidthBinding: Binding<Double> {
+        Binding(
+            get: { cameraSettings?.wrappedValue?.borderWidth ?? 0 },
+            set: { width in
+                var current = cameraSettings?.wrappedValue ?? defaultFacecamSettings(enabled: true)
+                current.borderWidth = width
+                cameraSettings?.wrappedValue = current
+            }
+        )
     }
 
     private var insetAdvancedControls: some View {

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -32,6 +32,8 @@ struct SettingsInspector: View {
     @State private var hoveredTab: InspectorTab?
     @State private var isInsetBalanceExpanded = false
     @State private var removeCameraBackground = false
+    @AppStorage("recording.mouseClickSoundsEnabled") private var mouseClickSoundsEnabled: Bool = false
+    @AppStorage("recording.keyboardSoundsEnabled") private var keyboardSoundsEnabled: Bool = false
     private let insetBalanceScrollID = "inset-balance-accordion"
 
     private var hasRecordedCamera: Bool {
@@ -230,6 +232,19 @@ struct SettingsInspector: View {
                 InspectorSwitch(title: "Loop Cursor", isOn: $loopCursor)
                 InspectorSlider(title: "Size", valueText: String(format: "%.2fx", cursorSize), value: $cursorSize, range: 1...8, step: 0.05, defaultValue: 1, leadingSymbolName: "cursorarrow", trailingSymbolName: "cursorarrow.rays")
                 InspectorSlider(title: "Smoothing", valueText: String(format: "%.2f", cursorSmoothing), value: $cursorSmoothing, range: 0...2, step: 0.01, defaultValue: 0.45, leadingSymbolName: "point.topleft.down.curvedto.point.bottomright.up", trailingSymbolName: "waveform.path.ecg")
+            }
+            InspectorGroup(
+                title: "Audio Feedback",
+                symbolName: "waveform",
+                onReset: {
+                    withAnimation(.snappy(duration: 0.28)) {
+                        mouseClickSoundsEnabled = false
+                        keyboardSoundsEnabled = false
+                    }
+                }
+            ) {
+                InspectorSwitch(title: "Mouse Click Sounds", isOn: $mouseClickSoundsEnabled)
+                InspectorSwitch(title: "Typing Keystroke Sounds", isOn: $keyboardSoundsEnabled)
             }
         case .camera:
             if hasRecordedCamera, cameraSettings != nil {

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -24,6 +24,8 @@ struct SettingsInspector: View {
     @Binding var cursorSize: Double
     @Binding var cursorSmoothing: Double
     @Binding var cursorStyleID: CursorStyleID
+    /// Bound to `FacecamSettings.fixedDuringZoom`; only relevant when a facecam was recorded.
+    @Binding var lockCameraWhenZooming: Bool
     var recordingSession: RecordingSession?
 
     @Namespace private var tabRailAnimation
@@ -237,6 +239,12 @@ struct SettingsInspector: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 InspectorSwitch(title: "Remove camera background", isOn: $removeCameraBackground)
+                if hasRecordedCamera {
+                    InspectorSwitch(
+                        title: "Lock camera during zoom",
+                        isOn: $lockCameraWhenZooming
+                    )
+                }
             }
             if let path = recordingSession?.facecamVideoPath {
                 SessionAssetRow(title: "Facecam File", path: path)

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -518,6 +518,49 @@ struct FacecamSettings: Codable, Hashable {
     var borderColor: String
     var margin: Double
     var anchor: String
+    /// When true, the camera bubble stays at its anchored position even while auto-zoom
+    /// is actively panning/scaling the screen content. When false (default), the bubble
+    /// moves with the zoom transform so it always stays in the same relative screen corner.
+    var fixedDuringZoom: Bool
+
+    init(
+        enabled: Bool,
+        shape: String,
+        size: Double,
+        cornerRadius: Double,
+        borderWidth: Double,
+        borderColor: String,
+        margin: Double,
+        anchor: String,
+        fixedDuringZoom: Bool = false
+    ) {
+        self.enabled = enabled
+        self.shape = shape
+        self.size = size
+        self.cornerRadius = cornerRadius
+        self.borderWidth = borderWidth
+        self.borderColor = borderColor
+        self.margin = margin
+        self.anchor = anchor
+        self.fixedDuringZoom = fixedDuringZoom
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled, shape, size, cornerRadius, borderWidth, borderColor, margin, anchor, fixedDuringZoom
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled        = try c.decode(Bool.self, forKey: .enabled)
+        shape          = try c.decode(String.self, forKey: .shape)
+        size           = try c.decode(Double.self, forKey: .size)
+        cornerRadius   = try c.decode(Double.self, forKey: .cornerRadius)
+        borderWidth    = try c.decode(Double.self, forKey: .borderWidth)
+        borderColor    = try c.decode(String.self, forKey: .borderColor)
+        margin         = try c.decode(Double.self, forKey: .margin)
+        anchor         = try c.decode(String.self, forKey: .anchor)
+        fixedDuringZoom = (try? c.decodeIfPresent(Bool.self, forKey: .fixedDuringZoom)) ?? false
+    }
 
     var clamped: FacecamSettings {
         FacecamSettings(
@@ -528,7 +571,8 @@ struct FacecamSettings: Codable, Hashable {
             borderWidth: max(0, min(borderWidth, 16)),
             borderColor: normalizedBorderColor,
             margin: max(0, min(margin, 12)),
-            anchor: FacecamAnchor.resolve(anchor).rawValue
+            anchor: FacecamAnchor.resolve(anchor).rawValue,
+            fixedDuringZoom: fixedDuringZoom
         )
     }
 
@@ -856,7 +900,8 @@ func defaultFacecamSettings(enabled: Bool) -> FacecamSettings {
         borderWidth: 4,
         borderColor: "#FFFFFF",
         margin: 4,
-        anchor: "bottom-right"
+        anchor: "bottom-right",
+        fixedDuringZoom: false
     )
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -523,11 +523,11 @@ struct FacecamSettings: Codable, Hashable {
         FacecamSettings(
             enabled: enabled,
             shape: normalizedShape,
-            size: max(12, min(size, 40)),
+            size: max(8, min(size, 75)),
             cornerRadius: max(0, min(cornerRadius, 100)),
             borderWidth: max(0, min(borderWidth, 16)),
             borderColor: normalizedBorderColor,
-            margin: max(0, min(margin, 12)),
+            margin: max(0, min(margin, 24)),
             anchor: FacecamAnchor.resolve(anchor).rawValue
         )
     }
@@ -549,6 +549,11 @@ struct FacecamSettings: Codable, Hashable {
         let value = borderColor.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? "#FFFFFF" : value
     }
+}
+
+struct CameraRecordingEvent: Codable, Equatable {
+    var timestamp: Double
+    var settings: FacecamSettings
 }
 
 struct RecordingSession: Codable, Hashable {

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -471,6 +471,10 @@ enum FacecamAnchor: String, CaseIterable, Identifiable, Codable, Hashable {
         }
     }
 
+    static func resolve(_ rawValue: String) -> FacecamAnchor {
+        FacecamAnchor(rawValue: rawValue) ?? .bottomRight
+    }
+
     static func from(relX: CGFloat, relYFromTop: CGFloat) -> FacecamAnchor {
         let col: Int
         if relX < 0.33 {
@@ -514,6 +518,7 @@ struct FacecamSettings: Codable, Hashable {
     var borderColor: String
     var margin: Double
     var anchor: String
+    var fixedDuringZoom: Bool? = false
 
     var clamped: FacecamSettings {
         FacecamSettings(
@@ -524,7 +529,8 @@ struct FacecamSettings: Codable, Hashable {
             borderWidth: max(0, min(borderWidth, 16)),
             borderColor: normalizedBorderColor,
             margin: max(0, min(margin, 24)),
-            anchor: FacecamAnchor.resolve(anchor).rawValue
+            anchor: FacecamAnchor.resolve(anchor).rawValue,
+            fixedDuringZoom: fixedDuringZoom
         )
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -474,6 +474,25 @@ enum FacecamAnchor: String, CaseIterable, Identifiable, Codable, Hashable {
     static func resolve(_ rawValue: String) -> FacecamAnchor {
         FacecamAnchor(rawValue: rawValue) ?? .bottomRight
     }
+
+    static func from(relX: Double, relYFromTop: Double) -> FacecamAnchor {
+        let isLeft = relX < 0.33
+        let isRight = relX > 0.66
+        let isTop = relYFromTop < 0.33
+        let isBottom = relYFromTop > 0.66
+
+        switch (isTop, isBottom, isLeft, isRight) {
+        case (true, false, true, false): return .topLeft
+        case (true, false, false, false): return .top
+        case (true, false, false, true): return .topRight
+        case (false, false, true, false): return .left
+        case (false, false, false, true): return .right
+        case (false, true, true, false): return .bottomLeft
+        case (false, true, false, false): return .bottom
+        case (false, true, false, true): return .bottomRight
+        default: return .center
+        }
+    }
 }
 
 struct FacecamSettings: Codable, Hashable {

--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -92,6 +92,8 @@ final class NativeScreenRecorder: NSObject {
         configuration.queueDepth = 8
         // Record without cursor capture here; playback and export reapply the saved cursor preference after capture.
         configuration.showsCursor = false
+        // Standardize audio capture to dual-channel stereo at 48kHz when active;
+        // disable audio streams when neither system audio nor microphone is requested to guard against silent tracks.
         configuration.capturesAudio = options.includeSystemAudio
         configuration.sampleRate = 48_000
         configuration.channelCount = 2

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -30,7 +30,8 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     var isCameraEnabled: Bool {
-        model?.includeCamera ?? false
+        guard let model else { return false }
+        return model.includeCamera || model.cameraCaptureSession != nil
     }
 
     func installWindowActions(

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -127,9 +127,15 @@ final class RecordingCountdownOverlayController {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
+        window.hidesOnDeactivate = false
         window.ignoresMouseEvents = true
         window.level = .screenSaver
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        window.collectionBehavior = [
+            .canJoinAllSpaces,
+            .fullScreenAuxiliary,
+            .stationary,
+            .ignoresCycle
+        ]
         window.contentView = NSHostingView(rootView: RecordingCountdownOverlay(state: state))
         self.window = window
         window.orderFrontRegardless()

--- a/apps/macos/Sources/OpenRecorderMac/RecordingPreferencesStore.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingPreferencesStore.swift
@@ -4,15 +4,23 @@ struct RecordingPreferences: Equatable {
     var createsZoomsAutomatically: Bool
     var autoZoomAnimationPreset: TimelineZoomAnimationPreset
     var shortcuts: ShortcutPreferences = .defaultPreferences
+    /// Play a synthesised click sound on every mouse button press during recording.
+    var mouseClickSoundsEnabled: Bool
+    /// Play a soft tap sound on every key-down event during recording.
+    var keyboardSoundsEnabled: Bool
 
     init(
         createsZoomsAutomatically: Bool = true,
         autoZoomAnimationPreset: TimelineZoomAnimationPreset = .balanced,
-        shortcuts: ShortcutPreferences = .defaultPreferences
+        shortcuts: ShortcutPreferences = .defaultPreferences,
+        mouseClickSoundsEnabled: Bool = false,
+        keyboardSoundsEnabled: Bool = false
     ) {
         self.createsZoomsAutomatically = createsZoomsAutomatically
         self.autoZoomAnimationPreset = autoZoomAnimationPreset
         self.shortcuts = shortcuts
+        self.mouseClickSoundsEnabled = mouseClickSoundsEnabled
+        self.keyboardSoundsEnabled = keyboardSoundsEnabled
     }
 }
 
@@ -21,6 +29,8 @@ struct RecordingPreferencesStore {
     private static let createsZoomsAutomaticallyKey = "recording.createZoomsAutomatically"
     private static let autoZoomAnimationPresetKey = "recording.autoZoomAnimationPreset"
     private static let shortcutsKey = "recording.shortcuts"
+    private static let mouseClickSoundsKey = "recording.mouseClickSoundsEnabled"
+    private static let keyboardSoundsKey = "recording.keyboardSoundsEnabled"
 
     private let defaults: UserDefaults
 
@@ -42,7 +52,9 @@ struct RecordingPreferencesStore {
             autoZoomAnimationPreset: TimelineZoomAnimationPreset.storedValue(
                 defaults.string(forKey: Self.autoZoomAnimationPresetKey)
             ),
-            shortcuts: shortcuts
+            shortcuts: shortcuts,
+            mouseClickSoundsEnabled: defaults.object(forKey: Self.mouseClickSoundsKey) as? Bool ?? false,
+            keyboardSoundsEnabled: defaults.object(forKey: Self.keyboardSoundsKey) as? Bool ?? false
         )
     }
 
@@ -59,4 +71,13 @@ struct RecordingPreferencesStore {
             defaults.set(data, forKey: Self.shortcutsKey)
         }
     }
+
+    func setMouseClickSoundsEnabled(_ value: Bool) {
+        defaults.set(value, forKey: Self.mouseClickSoundsKey)
+    }
+
+    func setKeyboardSoundsEnabled(_ value: Bool) {
+        defaults.set(value, forKey: Self.keyboardSoundsKey)
+    }
 }
+

--- a/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
@@ -121,7 +121,7 @@ final class ScreenSelectionOverlayController: ScreenSelectionPresenting {
         index: Int,
         in displaySources: [CaptureSource]
     ) -> CaptureSource? {
-        if let displayID = screen.displayID,
+        if let displayID = screen.captureDisplayID,
            let source = displaySources.first(where: { $0.displayID == displayID }) {
             return source
         }
@@ -223,8 +223,4 @@ private struct ScreenSelectionOverlayView: View {
     }
 }
 
-private extension NSScreen {
-    var displayID: UInt32? {
-        (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
-    }
-}
+

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -149,7 +149,7 @@ struct TimelineSelectionSidebar: View {
                 title: "Size",
                 valueText: "\(Int(clip.settings.clamped.size.rounded()))%",
                 value: cameraSizeBinding(id: clip.id),
-                range: 12...40,
+                range: 8...75,
                 step: 1,
                 onEditingChanged: handleUndoTransaction
             )
@@ -165,7 +165,7 @@ struct TimelineSelectionSidebar: View {
                 title: "Margin",
                 valueText: "\(Int(clip.settings.clamped.margin.rounded()))%",
                 value: cameraMarginBinding(id: clip.id),
-                range: 0...12,
+                range: 0...24,
                 step: 1,
                 onEditingChanged: handleUndoTransaction
             )

--- a/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineViews.swift
@@ -188,15 +188,8 @@ struct TimelineTrackContent: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Button {
-                edits.clearSelection()
-            } label: {
-                TimelineRuler(viewport: viewport)
-                    .rectangularHitTarget()
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Clear timeline selection")
-            .accessibilityHint("Clears the selected timeline item.")
+            TimelineRuler(viewport: viewport, onSeek: playback.seek(to:))
+                .rectangularHitTarget()
             TimelineClipRow(videoURL: videoURL, duration: playback.duration, currentTime: playback.currentTime, viewport: viewport, splitTimes: edits.clipSplitTimes, trimRegions: edits.trimRegions, clipSpeeds: edits.clipSpeeds, selectedClipIndex: edits.selectedClipIndex, seek: playback.seek(to:), edits: edits)
             TimelineLayerRow(kind: .zoom, duration: playback.duration, viewport: viewport, regions: edits.zoomRegions.map(TimelineRegionRenderData.zoom), selectedID: edits.selectedKind == .zoom ? edits.selectedID : nil, edits: edits)
             TimelineCameraLayerRow(
@@ -212,12 +205,13 @@ struct TimelineTrackContent: View {
         }
         .overlay(alignment: .topLeading) {
             ZStack(alignment: .topLeading) {
-                TimelinePlayhead(viewport: viewport, currentTime: playback.currentTime)
+                TimelinePlayhead(viewport: viewport, currentTime: playback.currentTime, onSeek: playback.seek(to:))
                 if let hoverTime {
                     TimelineHoverIndicator(viewport: viewport, time: hoverTime)
                 }
             }
         }
+        .coordinateSpace(name: "TimelineTrackCoordinateSpace")
         .readSize { timelineSize = $0 }
         .rectangularHitTarget()
         .onContinuousHover(coordinateSpace: .local) { phase in
@@ -615,6 +609,7 @@ struct TimelineViewport: Equatable {
 
 struct TimelineRuler: View {
     var viewport: TimelineViewport
+    var onSeek: ((Double) -> Void)? = nil
 
     var body: some View {
         GeometryReader { proxy in
@@ -641,6 +636,15 @@ struct TimelineRuler: View {
                     }
                 }
             }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .named("TimelineTrackCoordinateSpace"))
+                    .onChanged { value in
+                        if let time = viewport.time(forX: value.location.x, width: proxy.size.width) {
+                            onSeek?(time)
+                        }
+                    }
+            )
         }
         .frame(height: TimelineMetrics.rulerHeight)
     }
@@ -657,24 +661,50 @@ struct TimelineRuler: View {
 struct TimelinePlayhead: View {
     var viewport: TimelineViewport
     var currentTime: Double
+    var onSeek: ((Double) -> Void)? = nil
+
+    @State private var isDragging = false
 
     var body: some View {
         GeometryReader { proxy in
             let x = viewport.x(for: currentTime, width: proxy.size.width, clamped: true) ?? 0
             ZStack(alignment: .top) {
+                // Playhead line
                 Rectangle()
                     .fill(Color.white)
                     .frame(width: 1.5, height: proxy.size.height)
 
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 10, height: 10)
-                    .shadow(color: Color.black.opacity(0.40), radius: 3, y: 1)
-                    .offset(y: -4)
+                // White Playhead Pin Knob with generous touch target
+                ZStack {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 11, height: 11)
+                        .overlay {
+                            Circle()
+                                .strokeBorder(Color.black.opacity(0.25), lineWidth: 0.8)
+                        }
+                        .shadow(color: Color.black.opacity(0.45), radius: 4, y: 1.5)
+                        .scaleEffect(isDragging ? 1.3 : 1.0)
+                        .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isDragging)
+                }
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+                .offset(y: -5)
             }
             .offset(x: x - 0.75)
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .named("TimelineTrackCoordinateSpace"))
+                    .onChanged { value in
+                        isDragging = true
+                        if let time = viewport.time(forX: value.location.x, width: proxy.size.width) {
+                            onSeek?(time)
+                        }
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
         }
-        .allowsHitTesting(false)
     }
 }
 
@@ -1383,8 +1413,28 @@ private struct TimelineCameraClipItem: View {
     var fallbackSettings: FacecamSettings?
     var edits: TimelineEditDriver
 
-    private var greenColor: Color {
-        Color(red: 0.22, green: 0.85, blue: 0.46)
+    private var accentColor: Color {
+        Color(red: 0.18, green: 0.82, blue: 0.48)
+    }
+
+    private var shapeTitle: String {
+        guard clip.settings.clamped.enabled else { return "Hidden" }
+        switch clip.settings.clamped.normalizedShape {
+        case "circle": return "Circle"
+        case "square": return "Square"
+        case "rectangle": return "Rectangle"
+        default: return "Camera"
+        }
+    }
+
+    private var shapeSymbolName: String {
+        guard clip.settings.clamped.enabled else { return "camera.slash.fill" }
+        switch clip.settings.clamped.normalizedShape {
+        case "circle": return "circle.fill"
+        case "square": return "square.fill"
+        case "rectangle": return "rectangle.fill"
+        default: return "camera.fill"
+        }
     }
 
     var body: some View {
@@ -1394,19 +1444,30 @@ private struct TimelineCameraClipItem: View {
         Button {
             edits.selectCameraClip(id: clip.id)
         } label: {
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(clip.settings.clamped.enabled ? (isSelected ? greenColor.opacity(0.24) : greenColor.opacity(0.08)) : Color.secondary.opacity(0.08))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .stroke(
-                            clip.settings.clamped.enabled
-                                ? (isSelected ? greenColor : greenColor.opacity(0.65))
-                                : Color.secondary.opacity(0.40),
-                            lineWidth: isSelected ? 1.8 : 1.0
-                        )
+            ZStack {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(
+                        clip.settings.clamped.enabled
+                            ? (isSelected ? accentColor.opacity(0.18) : accentColor.opacity(0.07))
+                            : Color.secondary.opacity(0.06)
+                    )
+
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(
+                        clip.settings.clamped.enabled
+                            ? (isSelected ? accentColor.opacity(0.90) : accentColor.opacity(0.25))
+                            : Color.secondary.opacity(0.20),
+                        lineWidth: isSelected ? 1.5 : 0.8
+                    )
+
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .stroke(accentColor.opacity(0.35), lineWidth: 3)
+                        .blur(radius: 2)
                 }
-                .shadow(color: isSelected && clip.settings.clamped.enabled ? greenColor.opacity(0.35) : Color.clear, radius: 4)
-                .overlay { label(width: itemWidth) }
+
+                label(width: itemWidth)
+            }
         }
         .buttonStyle(.plain)
         .frame(width: itemWidth, height: TimelineMetrics.regionItemHeight)
@@ -1432,19 +1493,35 @@ private struct TimelineCameraClipItem: View {
         }
     }
 
+    @ViewBuilder
     private func label(width: CGFloat) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: clip.settings.clamped.enabled ? "camera.fill" : "camera.slash.fill")
-                .font(.system(size: 9, weight: .semibold))
-            Text(clip.settings.clamped.enabled ? "Camera" : "Hidden")
-                .font(.system(size: 10, weight: .bold))
-                .lineLimit(1)
+        if width > 58 {
+            HStack(spacing: 4.5) {
+                Image(systemName: shapeSymbolName)
+                    .font(.system(size: 8.5, weight: .medium))
+                Text(shapeTitle)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(
+                clip.settings.clamped.enabled
+                    ? (isSelected ? Color.white : accentColor.opacity(0.92))
+                    : Color.secondary.opacity(0.70)
+            )
+            .minimumScaleFactor(0.75)
+            .padding(.horizontal, 6)
+            .frame(maxWidth: max(1, width))
+            .allowsHitTesting(false)
+        } else if width > 22 {
+            Image(systemName: shapeSymbolName)
+                .font(.system(size: 8.5, weight: .medium))
+                .foregroundStyle(
+                    clip.settings.clamped.enabled
+                        ? (isSelected ? Color.white : accentColor.opacity(0.92))
+                        : Color.secondary.opacity(0.70)
+                )
+                .allowsHitTesting(false)
         }
-        .foregroundStyle(clip.settings.clamped.enabled ? (isSelected ? greenColor : greenColor.opacity(0.90)) : Color.secondary.opacity(0.70))
-        .minimumScaleFactor(0.72)
-        .padding(.horizontal, 8)
-        .frame(maxWidth: max(1, width))
-        .allowsHitTesting(false)
     }
 
     private func x(for time: Double) -> CGFloat {

--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -397,11 +397,12 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         if let cursor = makeCursorLayer(for: instruction, compositionTime: compositionTime, contentRect: contentRect) {
             composed = cursor.composited(over: composed)
         }
-        if let facecam = makeFacecamLayer(
-            facecam,
-            for: instruction,
-            compositionTime: compositionTime
-        ) {
+
+        // When fixedDuringZoom is false (default), composite the camera bubble before applying
+        // the zoom so it moves with the zoomed screen content.
+        let cameraIsFixed = instruction.facecamFallbackSettings?.fixedDuringZoom == true
+        if !cameraIsFixed,
+           let facecam = makeFacecamLayer(facecam, for: instruction, compositionTime: compositionTime) {
             composed = facecam.composited(over: composed)
         }
 
@@ -414,6 +415,13 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
             instruction: instruction,
             compositionTime: compositionTime
         )
+
+        // When fixedDuringZoom is true, composite the camera bubble AFTER the zoom so it
+        // stays pinned at its anchor corner regardless of the current zoom effect.
+        if cameraIsFixed,
+           let facecam = makeFacecamLayer(facecam, for: instruction, compositionTime: compositionTime) {
+            composed = facecam.composited(over: composed)
+        }
 
         return composed.cropped(to: renderRect)
     }

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -290,7 +290,9 @@ struct VideoPreviewPanel: View {
                     )
                     .frame(width: recordingFrame.width, height: recordingFrame.height)
                     .offset(x: recordingFrame.minX, y: recordingFrame.minY)
-                    .transformEffect(facecamZoomTransform)
+                    // Only zoom the camera bubble together with the screen if the user
+                    // has NOT locked the camera in place during zoom.
+                    .transformEffect(facecamSettings.fixedDuringZoom ? .identity : facecamZoomTransform)
                 }
             }
             .frame(width: proxy.size.width, height: proxy.size.height)

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -787,7 +787,17 @@ struct FacecamOverlayLayout {
             y = containerSize.height - margin - halfSide
         }
 
-        return CGRect(x: x - halfSide, y: y - halfSide, width: side, height: side)
+        let rawX = x - halfSide
+        let rawY = y - halfSide
+        let clampedX = max(0, min(rawX, containerSize.width - side))
+        let clampedY = max(0, min(rawY, containerSize.height - side))
+
+        return CGRect(
+            x: clampedX,
+            y: clampedY,
+            width: min(side, containerSize.width),
+            height: min(side, containerSize.height)
+        )
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -290,7 +290,6 @@ struct VideoPreviewPanel: View {
                     )
                     .frame(width: recordingFrame.width, height: recordingFrame.height)
                     .offset(x: recordingFrame.minX, y: recordingFrame.minY)
-                    .transformEffect(facecamZoomTransform)
                 }
             }
             .frame(width: proxy.size.width, height: proxy.size.height)
@@ -759,41 +758,58 @@ struct FacecamOverlayLayout {
         }
 
         let baseLength = min(containerSize.width, containerSize.height)
-        let side = max(1, min(baseLength * CGFloat(resolved.size / 100), baseLength))
+        let baseSide = max(1, min(baseLength * CGFloat(resolved.size / 100), baseLength))
+        let width: CGFloat
+        let height: CGFloat
+        if resolved.normalizedShape == "rectangle" {
+            width = min(containerSize.width, baseSide * 1.35)
+            height = width * (9.0 / 16.0)
+        } else {
+            width = baseSide
+            height = baseSide
+        }
+
         let margin = max(0, baseLength * CGFloat(resolved.margin / 100))
-        let halfSide = side / 2
+        let halfWidth = width / 2
+        let halfHeight = height / 2
         let x: CGFloat
         let y: CGFloat
 
         switch resolved.resolvedAnchor {
         case .topLeft, .left, .bottomLeft:
-            x = margin + halfSide
+            x = margin + halfWidth
         case .top, .center, .bottom:
             x = containerSize.width / 2
         case .topRight, .right, .bottomRight:
-            x = containerSize.width - margin - halfSide
+            x = containerSize.width - margin - halfWidth
         }
 
         switch resolved.resolvedAnchor {
         case .topLeft, .top, .topRight:
-            y = margin + halfSide
+            y = margin + halfHeight
         case .left, .center, .right:
             y = containerSize.height / 2
         case .bottomLeft, .bottom, .bottomRight:
-            y = containerSize.height - margin - halfSide
+            y = containerSize.height - margin - halfHeight
         }
 
-        let rawX = x - halfSide
-        let rawY = y - halfSide
+        let rawX = x - halfWidth
+        let rawY = y - halfHeight
         let safeMinX: CGFloat = 0
-        let safeMaxX = max(safeMinX, containerSize.width - side)
+        let safeMaxX = max(safeMinX, containerSize.width - width)
         let safeMinY: CGFloat = 0
-        let safeMaxY = max(safeMinY, containerSize.height - side)
+        let safeMaxY = max(safeMinY, containerSize.height - height)
 
         let clampedX = max(safeMinX, min(rawX, safeMaxX))
         let clampedY = max(safeMinY, min(rawY, safeMaxY))
 
-        return CGRect(x: clampedX, y: clampedY, width: side, height: side)
+        return CGRect(x: clampedX, y: clampedY, width: width, height: height)
+    }
+
+    static func normalizedRect(for settings: FacecamSettings) -> CGRect {
+        let dummySize = CGSize(width: 1000, height: 1000)
+        let f = frame(in: dummySize, settings: settings)
+        return CGRect(x: f.minX / 1000, y: f.minY / 1000, width: f.width / 1000, height: f.height / 1000)
     }
 }
 
@@ -1129,12 +1145,18 @@ final class PlayerLayerView: NSView {
         contentLayer.position = .zero
         contentLayer.isGeometryFlipped = true
 
-        playbackLayer.videoGravity = .resizeAspect
+        playbackLayer.videoGravity = videoGravity
         playbackLayer.backgroundColor = NSColor.clear.cgColor
 
         layer = rootLayer
         rootLayer.addSublayer(contentLayer)
         contentLayer.addSublayer(playbackLayer)
+    }
+
+    var videoGravity: AVLayerVideoGravity = .resizeAspect {
+        didSet {
+            playbackLayer.videoGravity = videoGravity
+        }
     }
 
     private func layoutPlayerLayers() {
@@ -1171,11 +1193,13 @@ struct NativeVideoPlayer: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PlayerLayerView {
         let view = PlayerLayerView()
+        view.videoGravity = .resizeAspect
         view.update(player: playback.player, zoomTransform: zoomTransform)
         return view
     }
 
     func updateNSView(_ nsView: PlayerLayerView, context: Context) {
+        nsView.videoGravity = .resizeAspect
         nsView.update(player: playback.player, zoomTransform: zoomTransform)
     }
 
@@ -1189,11 +1213,13 @@ struct FacecamPlayerView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PlayerLayerView {
         let view = PlayerLayerView()
+        view.videoGravity = .resizeAspectFill
         view.update(player: player)
         return view
     }
 
     func updateNSView(_ nsView: PlayerLayerView, context: Context) {
+        nsView.videoGravity = .resizeAspectFill
         nsView.update(player: player)
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -137,7 +137,7 @@ final class WindowConfigurationView: NSView {
         window.collectionBehavior = [
             .canJoinAllSpaces,
             .fullScreenAuxiliary,
-            .stationary
+            .ignoresCycle
         ]
         window.isMovableByWindowBackground = true
         window.titleVisibility = .hidden

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -133,7 +133,7 @@ final class WindowConfigurationView: NSView {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
-        window.level = .floating
+        window.level = .statusBar
         window.collectionBehavior = [
             .canJoinAllSpaces,
             .fullScreenAuxiliary,

--- a/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppPresentationStateMachineTests.swift
@@ -1312,6 +1312,33 @@ final class CaptureOptionsStateMachineTests: XCTestCase {
         XCTAssertTrue(state.hasAvailableCameraSelection)
     }
 
+    func testRecordingOptionsFallbacksToSystemDefaultWhenHardwareIsDisconnected() {
+        var state = CaptureOptionsState(
+            includeMicrophone: true,
+            includeCamera: true,
+            microphoneDevices: [CaptureDeviceInfo(id: "mic-live", name: "Internal Mic", isDefault: true)],
+            cameraDevices: [CaptureDeviceInfo(id: "cam-live", name: "FaceTime Camera", isDefault: true)],
+            selectedMicrophoneDeviceID: "mic-unplugged",
+            selectedCameraDeviceID: "cam-unplugged"
+        )
+
+        // Since the selected IDs are not in available devices, recordingOptions must gracefully fallback to nil (system default)
+        XCTAssertFalse(state.hasAvailableMicrophoneSelection)
+        XCTAssertFalse(state.hasAvailableCameraSelection)
+        XCTAssertNil(state.recordingOptions.microphoneDeviceID)
+        XCTAssertNil(state.recordingOptions.cameraDeviceID)
+        XCTAssertTrue(state.recordingOptions.includeMicrophone)
+        XCTAssertTrue(state.recordingOptions.includeCamera)
+
+        // When valid devices are selected, recordingOptions passes the IDs
+        state.selectedMicrophoneDeviceID = "mic-live"
+        state.selectedCameraDeviceID = "cam-live"
+        XCTAssertTrue(state.hasAvailableMicrophoneSelection)
+        XCTAssertTrue(state.hasAvailableCameraSelection)
+        XCTAssertEqual(state.recordingOptions.microphoneDeviceID, "mic-live")
+        XCTAssertEqual(state.recordingOptions.cameraDeviceID, "cam-live")
+    }
+
     func testOpeningDeviceSelectorsDoesNotEnumerateDevicesTwice() {
         var state = CaptureOptionsState(
             microphoneDevices: [CaptureDeviceInfo(id: "mic-1", name: "Mic", isDefault: true)],

--- a/apps/macos/Tests/OpenRecorderMacTests/CursorTelemetryTrackTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CursorTelemetryTrackTests.swift
@@ -69,4 +69,21 @@ final class CursorTelemetryTrackTests: XCTestCase {
         XCTAssertEqual(point?.x ?? -1, 25, accuracy: 0.001)
         XCTAssertEqual(point?.y ?? -1, 20, accuracy: 0.001)
     }
+
+    func testNormalizedPointComputesUnitCoordinates() {
+        let track = CursorTelemetryTrack(payload: CursorTelemetryPayload(
+            width: 200,
+            height: 100,
+            samples: [
+                CursorTelemetrySample(x: 50, y: 25, timestamp: 0, cursorType: "arrow"),
+                CursorTelemetrySample(x: 150, y: 75, timestamp: 1_000, cursorType: "arrow")
+            ],
+            clicks: []
+        ))
+
+        let point = track.normalizedPoint(at: 0.5, loops: false, smoothing: 0)
+
+        XCTAssertEqual(point?.x ?? -1, 0.5, accuracy: 0.001)
+        XCTAssertEqual(point?.y ?? -1, 0.5, accuracy: 0.001)
+    }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoPreviewLayoutTests.swift
@@ -378,11 +378,11 @@ final class VideoPreviewLayoutTests: XCTestCase {
         .clamped
 
         XCTAssertEqual(settings.shape, "circle")
-        XCTAssertEqual(settings.size, 40)
+        XCTAssertEqual(settings.size, 75)
         XCTAssertEqual(settings.cornerRadius, 100)
         XCTAssertEqual(settings.borderWidth, 0)
         XCTAssertEqual(settings.borderColor, "#FFFFFF")
-        XCTAssertEqual(settings.margin, 12)
+        XCTAssertEqual(settings.margin, 24)
         XCTAssertEqual(settings.resolvedAnchor, .bottomRight)
     }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
@@ -100,6 +100,24 @@ final class WindowSourceFilterTests: XCTestCase {
         XCTAssertEqual(displayInfo?.subtitle, "Notes App")
     }
 
+    func testExcludesScreenCaptureAndHelperDaemons() {
+        XCTAssertNil(displayInfo(
+            title: "Screen Recording",
+            ownerName: "screencaptureui",
+            bundleIdentifier: "com.apple.screencaptureui"
+        ))
+        XCTAssertNil(displayInfo(
+            title: nil,
+            ownerName: "QuickLookUIService",
+            bundleIdentifier: "com.apple.quicklook.ui.helper"
+        ))
+        XCTAssertNil(displayInfo(
+            title: "Authentication",
+            ownerName: "CoreAuthUI",
+            bundleIdentifier: "com.apple.CoreAuthUI"
+        ))
+    }
+
     private func displayInfo(
         title: String?,
         ownerName: String?,


### PR DESCRIPTION
# Pull Request Template

## Description
This PR delivers a comprehensive series of enhancements, stability fixes, and UI polish across the macOS capture engine, HUD interface, camera bubble overlay, editor timeline, and multi-display management.

### Key Highlights:
1. **HUD & Pre-Recording Controls**:
   - **Source Selector Width**: Refined the source selector chip width (`maxWidth: 240px` inside a `760px` default HUD) to cleanly accommodate display names (e.g., *"Built-in Retina Display"*) without early truncation or trailing blank space.
   - **Shortcut Pre-Recording Flow**: Updated global screen recording shortcuts (`⌥⇧5` for Device Screen Record and `⌥⇧6` for Drag Screen Record) to present the HUD in recording mode instead of immediately capturing, allowing users to toggle and position camera/audio settings before starting.
   - **Active Space Synchronization**: Improved HUD and overlay window positioning and clamping across macOS Mission Control spaces (`canJoinAllSpaces`, `fullScreenAuxiliary`).

2. **Camera Bubble & Facecam Overlays**:
   - **Visibility & Initialization**: Added camera bubble prewarming, auto-initialization, and window level guarantees (`.statusBar` / floating) so the camera preview remains reliably visible throughout recording and device switching.
   - **Screen Boundary Clamping**: Ensured the live camera bubble respects screen boundaries and safe margins.
   - **Zoom Lock (`fixedDuringZoom`)**: Added facecam anchoring logic (`FacecamAnchor.resolve`) to keep camera overlays pinned in place during canvas auto-zoom.

3. **Capture Reliability, Devices & Audio**:
   - **Thread Safety**: Hardened `AVCaptureSession` start/stop cycles and device configuration to run atomically and prevent background thread race conditions.
   - **Device Reconnection & Fallbacks**: Added dynamic listeners for microphone and camera disconnect/reconnect events, automatically falling back to system defaults.
   - **Audio Track Channel Mapping**: Added silent audio guards and multi-channel track mapping for synchronous mic and system audio capture.
   - **System Audio Handshake**: Improved permission handshake and warning status chips on system audio toggles.

4. **Multi-Display & Overlays**:
   - **Coordinate Alignment**: Normalized screen selection overlay geometry and countdown overlay coordinates across multi-monitor setups and Retina scaling.
   - **Display Fallback**: Guaranteed resilient fallback to the primary display when connected displays change.

5. **Editor & Timeline Polish**:
   - **Timeline UI**: Added a draggable playhead pin, waveform accent glow, camera transition tracking, and aspect-fill adjustments.
   - **Background Customization**: Added custom background image/video upload support alongside the redesigned preset picker.
   - **Window Filtering**: Optimized window source filtering to exclude system helper daemons, Control Center, and Spotlight.

---

## Motivation
- Users needed the ability to review recording options (toggle facecam, mic, system audio) before recording starts when using global shortcuts rather than being forced into an instant capture.
- Display names in the HUD source selector were previously truncated prematurely (`175px`) or left awkward gaps (`340px`).
- The camera bubble overlay could occasionally drop behind full-screen applications or experience race conditions during rapid device selection.
- Multi-display environments exhibited coordinate misalignments for selection boxes and countdown overlays.

---

## Type of Change
- [x] New Feature
- [x] Bug Fix
- [x] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

---

## Related Issue(s)
<!-- Link to related issue(s), e.g., #999, #1004 -->
Fixes #999

---

## Screenshots / Video
<!-- Include screenshots or videos of the HUD, camera bubble, and timeline improvements -->

---

## Testing Guide
1. **Build & Launch Dev App**:
   ```bash
   make dev-macos
   # or
   pnpm dev
