### PR TITLE
Fix display source selection from the HUD

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
@@ -594,10 +594,10 @@ struct CaptureState: Hashable {
             let mode = modeForSelection()
             switch sourceType {
             case .screen:
-                next.setPhase(.screenSelecting(mode), clearSource: false)
+                next.setPhase(.selectingSource(mode), clearSource: false)
                 next.preferredSourceKind = .display
-                statusMessage = "Choose a screen."
-                effects.append(.dismissScreenSelection)
+                statusMessage = "Choose what to capture."
+                effects.append(.showSourceSelector)
             case .window:
                 next.setPhase(.selectingSource(mode), clearSource: false)
                 next.preferredSourceKind = .window

--- a/apps/macos/Sources/OpenRecorderMac/SourceSelectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SourceSelectorViews.swift
@@ -372,7 +372,7 @@ struct SourceGrid: View {
     var body: some View {
         if sourceTab == .screens && sources.count == 1, let singleSource = sources.first {
             singleScreenLayout(singleSource)
-        } else if sourceTab == .windows {
+        } else if sourceTab == .windows || (sourceTab == .screens && sources.count > 2) {
             ScrollView(.vertical, showsIndicators: true) {
                 grid
                     .padding(.horizontal, 2)

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
@@ -65,9 +65,9 @@ final class CaptureStateReducerTests: XCTestCase {
 
     func testChoosingSourceTypesMovesToDeclarativeSelectionStates() {
         let screen = CaptureState.choosingSourceType(.screenshot).applying(.chooseSourceType(.screen))
-        XCTAssertEqual(screen.state.phase, .screenSelecting(.screenshot))
+        XCTAssertEqual(screen.state.phase, .selectingSource(.screenshot))
         XCTAssertEqual(screen.state.preferredSourceKind, .display)
-        XCTAssertEqual(screen.effects, [.dismissScreenSelection])
+        XCTAssertEqual(screen.effects, [.showSourceSelector])
 
         let window = CaptureState.choosingSourceType(.recording).applying(.chooseSourceType(.window))
         XCTAssertEqual(window.state.phase, .selectingSource(.recording))


### PR DESCRIPTION
## Description

Routes display selection through the unified source picker instead of the legacy screen-selection overlay.

## Motivation

Opening the source selector from the HUD could bypass its CTA title and picker controls. On multi-monitor Macs, the legacy path also created one overlay per display.

## Type of Change

- [x] Bug Fix

## Testing Guide

- `make test-macos`
- Ran the macOS dev app and opened the HUD source selector. It now presents the titled “Choose Source” picker with Screens, Windows, and Area controls.
- Confirmed the picker grid scrolls for three or more display sources.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have performed manual native-app verification.
- [x] No changelog update is needed for this bug fix.