### PR TITLE
feat: display HUD over full-screen apps and support multi-monitor area dragging

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -246,6 +246,7 @@ final class AppModel: ObservableObject {
     private let recordingPreferences: RecordingPreferencesStore
     private let captureSetupPreferencesStore: CaptureSetupPreferencesStore
     private let screenSelectionPresenter: ScreenSelectionPresenting
+    private let areaSelectionPresenter: AreaSelectionPresenting
     private let screenshotCapture: @MainActor (CaptureSource, URL) throws -> Void
     private let startRecordingCapture: @MainActor (CaptureSource, URL, RecordingCaptureOptions) async throws -> Date
     private let stopRecordingCapture: @MainActor () async throws -> URL
@@ -276,6 +277,7 @@ final class AppModel: ObservableObject {
         recordingPreferences: RecordingPreferencesStore = RecordingPreferencesStore(),
         captureSetupPreferencesStore: CaptureSetupPreferencesStore = .ephemeral(),
         screenSelectionPresenter: ScreenSelectionPresenting = ScreenSelectionOverlayController(),
+        areaSelectionPresenter: AreaSelectionPresenting = AreaSelectionOverlayController(),
         captureUIHideDelayNanoseconds: UInt64 = 180_000_000,
         screenshotCapture: (@MainActor (CaptureSource, URL) throws -> Void)? = nil,
         startRecordingCapture: (@MainActor (CaptureSource, URL, RecordingCaptureOptions) async throws -> Date)? = nil,
@@ -305,6 +307,7 @@ final class AppModel: ObservableObject {
         self.captureSetupPreferencesStore = captureSetupPreferencesStore
         self.storedCaptureSetup = captureSetupPreferencesStore.load()
         self.screenSelectionPresenter = screenSelectionPresenter
+        self.areaSelectionPresenter = areaSelectionPresenter
         self.captureUIHideDelayNanoseconds = captureUIHideDelayNanoseconds
         self.capture = capture
         self.screenshotCapture = screenshotCapture ?? { source, outputURL in
@@ -452,6 +455,7 @@ final class AppModel: ObservableObject {
                     self?.requestWindow(.hideRecordingSetup)
                 },
                 hideAppWindowsForCapture: { [weak self] in
+                    self?.areaSelectionPresenter.dismiss()
                     self?.requestWindow(.hideAppWindowsForCapture)
                 },
                 focusActiveCaptureWindow: { [weak self] in
@@ -1185,9 +1189,23 @@ final class AppModel: ObservableObject {
             return
         }
         dispatch(.requestInteractiveAreaSelection)
+        presentInteractiveAreaSelection()
+    }
+
+    private func presentInteractiveAreaSelection() {
+        areaSelectionPresenter.present(
+            mode: captureMode,
+            onSelect: { [weak self] area in
+                self?.completeInteractiveAreaSelection(area)
+            },
+            onCancel: { [weak self] in
+                self?.cancelInteractiveAreaSelection()
+            }
+        )
     }
 
     func completeInteractiveAreaSelection(_ area: CaptureArea) {
+        areaSelectionPresenter.dismiss()
         guard !rejectActionWhileTerminationIsPending() else { return }
         let source = interactiveAreaSource(area: area)
         let shouldCaptureScreenshotImmediately = captureMode == .screenshot
@@ -1212,11 +1230,13 @@ final class AppModel: ObservableObject {
     }
 
     func cancelInteractiveAreaSelection() {
+        areaSelectionPresenter.dismiss()
         isDragRecordingPending = false
         dispatch(.cancelInteractiveAreaSelection)
     }
 
     func cancelCapture() {
+        areaSelectionPresenter.dismiss()
         isDragRecordingPending = false
         capturePreflightGeneration += 1
         capturePreflightTask?.cancel()

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -1239,14 +1239,8 @@ final class AppModel: ObservableObject {
         }
         guard ensureScreenRecordingPermissionForCapture() else { return }
 
-        let displaySource = capture.sources.first(where: { $0.kind == .display })
-            ?? selectedSource
-            ?? CaptureSource(id: "display:primary", kind: .display, name: "Entire Screen", subtitle: "", displayIndex: nil, displayID: nil, windowID: nil, area: nil, thumbnailData: nil)
-
         dispatch(.beginCapture(.screenshot, runtimeIsRecording: false))
-        dispatch(.selectSource(displaySource))
-        persistCaptureSetup(source: displaySource)
-        takeScreenshot()
+        requestSourceSelector(kind: .display)
     }
 
     @MainActor
@@ -1272,14 +1266,8 @@ final class AppModel: ObservableObject {
         }
         guard ensureScreenRecordingPermissionForCapture() else { return }
 
-        let displaySource = capture.sources.first(where: { $0.kind == .display })
-            ?? selectedSource
-            ?? CaptureSource(id: "display:primary", kind: .display, name: "Entire Screen", subtitle: "", displayIndex: nil, displayID: nil, windowID: nil, area: nil, thumbnailData: nil)
-
         dispatch(.beginCapture(.recording, runtimeIsRecording: false))
-        dispatch(.selectSource(displaySource))
-        persistCaptureSetup(source: displaySource)
-        showHUD()
+        requestSourceSelector(kind: .display)
     }
 
     @MainActor
@@ -1292,7 +1280,7 @@ final class AppModel: ObservableObject {
         guard ensureScreenRecordingPermissionForCapture() else { return }
 
         dispatch(.beginCapture(.recording, runtimeIsRecording: false))
-        isDragRecordingPending = false
+        isDragRecordingPending = true
         requestInteractiveAreaSelection()
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
@@ -1,13 +1,207 @@
 import AVFoundation
 import AppKit
+import Carbon.HIToolbox
 import CoreGraphics
 import SwiftUI
 import UniformTypeIdentifiers
 
-struct AreaSelectionWindowView: View {
-    @EnvironmentObject private var model: AppModel
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.dismissWindow) private var dismissWindow
+enum AreaSelectionOverlayChrome {
+    static let level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+    static let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel]
+    static let collectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .ignoresCycle
+    ]
+}
+
+@MainActor
+protocol AreaSelectionPresenting: AnyObject {
+    func present(
+        mode: CaptureMode,
+        onSelect: @escaping (CaptureArea) -> Void,
+        onCancel: @escaping () -> Void
+    )
+    func dismiss()
+}
+
+@MainActor
+final class AreaSelectionOverlayController: AreaSelectionPresenting {
+    private var windows: [NSWindow] = []
+    private var keyMonitor: Any?
+    private var globalKeyMonitor: Any?
+    private var spaceObserver: NSObjectProtocol?
+    private var screenObserver: NSObjectProtocol?
+    private var onSelect: ((CaptureArea) -> Void)?
+    private var onCancel: (() -> Void)?
+    private var mode: CaptureMode = .recording
+
+    func present(
+        mode: CaptureMode,
+        onSelect: @escaping (CaptureArea) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        dismiss()
+        self.mode = mode
+        self.onSelect = onSelect
+        self.onCancel = onCancel
+
+        installKeyMonitor()
+        installSpaceAndScreenObservers()
+        rebuildWindows()
+    }
+
+    func dismiss() {
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
+        }
+        if let globalKeyMonitor {
+            NSEvent.removeMonitor(globalKeyMonitor)
+        }
+        if let spaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(spaceObserver)
+        }
+        if let screenObserver {
+            NotificationCenter.default.removeObserver(screenObserver)
+        }
+        keyMonitor = nil
+        globalKeyMonitor = nil
+        spaceObserver = nil
+        screenObserver = nil
+        onSelect = nil
+        onCancel = nil
+        windows.forEach { $0.close() }
+        windows.removeAll()
+    }
+
+    private func rebuildWindows() {
+        windows.forEach { $0.close() }
+        windows.removeAll()
+
+        for screen in NSScreen.screens {
+            let window = AreaSelectionOverlayPanel(
+                contentRect: screen.frame,
+                styleMask: AreaSelectionOverlayChrome.styleMask,
+                backing: .buffered,
+                defer: false
+            )
+            window.onCancel = { [weak self] in
+                self?.handleCancel()
+            }
+            window.isReleasedWhenClosed = false
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.hasShadow = false
+            window.hidesOnDeactivate = false
+            window.isFloatingPanel = true
+            window.worksWhenModal = true
+            window.becomesKeyOnlyIfNeeded = false
+            window.level = AreaSelectionOverlayChrome.level
+            window.collectionBehavior = AreaSelectionOverlayChrome.collectionBehavior
+            window.isMovableByWindowBackground = false
+            window.acceptsMouseMovedEvents = true
+            window.contentView = NSHostingView(rootView: AreaSelectionScreenOverlayView(
+                screen: screen,
+                mode: mode,
+                onSelect: { [weak self] area in
+                    self?.handleSelect(area)
+                },
+                onCancel: { [weak self] in
+                    self?.handleCancel()
+                }
+            ))
+            windows.append(window)
+            window.orderFrontRegardless()
+        }
+
+        if let mainScreenWindow = windows.first(where: { $0.screen == NSScreen.main }) ?? windows.first {
+            mainScreenWindow.makeKeyAndOrderFront(nil)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func handleSelect(_ area: CaptureArea) {
+        let callback = onSelect
+        dismiss()
+        callback?(area)
+    }
+
+    private func handleCancel() {
+        let callback = onCancel
+        dismiss()
+        callback?()
+    }
+
+    private func installSpaceAndScreenObservers() {
+        spaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.windows.forEach { $0.orderFrontRegardless() }
+            }
+        }
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.rebuildWindows()
+            }
+        }
+    }
+
+    private func installKeyMonitor() {
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            if event.isEscapeKey {
+                self.handleCancel()
+                return nil
+            }
+            return event
+        }
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.isEscapeKey else { return }
+            Task { @MainActor [weak self] in
+                self?.handleCancel()
+            }
+        }
+    }
+}
+
+final class AreaSelectionOverlayPanel: NSPanel {
+    var onCancel: (() -> Void)?
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    override func cancelOperation(_ sender: Any?) {
+        onCancel?()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.isEscapeKey {
+            onCancel?()
+            return
+        }
+        super.keyDown(with: event)
+    }
+}
+
+private extension NSEvent {
+    var isEscapeKey: Bool {
+        keyCode == UInt16(kVK_Escape) || charactersIgnoringModifiers == "\u{1B}"
+    }
+}
+
+struct AreaSelectionScreenOverlayView: View {
+    var screen: NSScreen
+    var mode: CaptureMode
+    var onSelect: (CaptureArea) -> Void
+    var onCancel: () -> Void
+
     @State private var dragStart: CGPoint?
     @State private var dragCurrent: CGPoint?
     @State private var isFinishingSelection = false
@@ -25,10 +219,13 @@ struct AreaSelectionWindowView: View {
                         .overlay {
                             Rectangle()
                                 .stroke(Color.white, lineWidth: 2)
+                                .shadow(color: Color.black.opacity(0.4), radius: 2)
                         }
-                        .background(Theme.border)
+                        .background(Theme.border.opacity(0.12))
                         .frame(width: selectionRect.width, height: selectionRect.height)
                         .position(x: selectionRect.midX, y: selectionRect.midY)
+
+                    dimensionBadge(for: selectionRect)
                 }
 
                 VStack(spacing: 8) {
@@ -36,7 +233,7 @@ struct AreaSelectionWindowView: View {
                         .font(.system(size: 26, weight: .medium))
                     Text("Drag to select an area")
                         .font(.system(size: 18, weight: .semibold))
-                    Text(model.captureMode == .recording
+                    Text(mode == .recording
                         ? "Release to set the recording area. Press Esc to cancel."
                         : "Release to capture this area. Press Esc to cancel.")
                         .font(.system(size: 13, weight: .medium))
@@ -58,22 +255,16 @@ struct AreaSelectionWindowView: View {
         .focusable()
         .focused($selectionHasFocus)
         .onKeyPress(.escape) {
-            model.cancelInteractiveAreaSelection()
-            dismiss()
-            dismissWindow(id: "area-selector")
+            onCancel()
             return .handled
         }
-        .focusedValue(\.areaSelectionIsFocused, true)
+        .onExitCommand(perform: onCancel)
         .onAppear {
             dragStart = nil
             dragCurrent = nil
             isFinishingSelection = false
             DispatchQueue.main.async {
                 selectionHasFocus = true
-                if !model.isAreaSelectionActive {
-                    dismiss()
-                    dismissWindow(id: "area-selector")
-                }
             }
         }
     }
@@ -86,6 +277,26 @@ struct AreaSelectionWindowView: View {
             width: abs(dragCurrent.x - dragStart.x),
             height: abs(dragCurrent.y - dragStart.y)
         )
+    }
+
+    @ViewBuilder
+    private func dimensionBadge(for rect: CGRect) -> some View {
+        let badgeWidth: CGFloat = 110
+        let badgeX = min(max(rect.midX, badgeWidth / 2 + 8), screen.frame.width - badgeWidth / 2 - 8)
+        let badgeY = rect.maxY + 18 < screen.frame.height - 30
+            ? rect.maxY + 18
+            : max(rect.minY - 18, 30)
+
+        Text("\(Int(rect.width.rounded())) × \(Int(rect.height.rounded())) px")
+            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            .foregroundStyle(Color.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Color.black.opacity(0.72), in: Capsule())
+            .overlay {
+                Capsule().stroke(Color.white.opacity(0.2), lineWidth: 1)
+            }
+            .position(x: badgeX, y: badgeY)
     }
 
     private func selectionGesture(in size: CGSize) -> some Gesture {
@@ -112,12 +323,8 @@ struct AreaSelectionWindowView: View {
                     isFinishingSelection = true
                 }
 
-                DispatchQueue.main.async {
-                    dismiss()
-                    dismissWindow(id: "area-selector")
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                    model.completeInteractiveAreaSelection(area)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    onSelect(area)
                 }
             }
     }
@@ -130,15 +337,43 @@ struct AreaSelectionWindowView: View {
     }
 
     private func captureArea(for rect: CGRect) -> CaptureArea {
-        let screen = NSApp.keyWindow?.screen ?? NSScreen.main
-        let screenFrame = screen?.frame ?? NSRect(origin: .zero, size: CGSize(width: 900, height: 600))
+        let screenFrame = screen.frame
+        let displayID = (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
         return CaptureArea(
             x: Int((screenFrame.minX + rect.minX).rounded()),
             y: Int((screenFrame.maxY - rect.maxY).rounded()),
             width: max(Int(rect.width.rounded()), 1),
             height: max(Int(rect.height.rounded()), 1),
-            displayID: (screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+            displayID: displayID
         )
+    }
+}
+
+struct AreaSelectionWindowView: View {
+    @EnvironmentObject private var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismissWindow) private var dismissWindow
+    @State private var dragStart: CGPoint?
+    @State private var dragCurrent: CGPoint?
+    @State private var isFinishingSelection = false
+    @FocusState private var selectionHasFocus: Bool
+
+    var body: some View {
+        AreaSelectionScreenOverlayView(
+            screen: NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first ?? NSScreen(),
+            mode: model.captureMode,
+            onSelect: { area in
+                dismiss()
+                dismissWindow(id: "area-selector")
+                model.completeInteractiveAreaSelection(area)
+            },
+            onCancel: {
+                model.cancelInteractiveAreaSelection()
+                dismiss()
+                dismissWindow(id: "area-selector")
+            }
+        )
+        .focusedValue(\.areaSelectionIsFocused, true)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -143,7 +143,6 @@ final class RecordingCountdownOverlayController {
         window.collectionBehavior = [
             .canJoinAllSpaces,
             .fullScreenAuxiliary,
-            .stationary,
             .ignoresCycle
         ]
         window.contentView = NSHostingView(rootView: RecordingCountdownOverlay(state: state))

--- a/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenSelectionOverlay.swift
@@ -8,7 +8,6 @@ enum ScreenSelectionOverlayChrome {
     static let collectionBehavior: NSWindow.CollectionBehavior = [
         .canJoinAllSpaces,
         .fullScreenAuxiliary,
-        .stationary,
         .ignoresCycle
     ]
 }

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -19,7 +19,7 @@ enum HUDWindowChrome {
     static let collectionBehavior: NSWindow.CollectionBehavior = [
         .canJoinAllSpaces,
         .fullScreenAuxiliary,
-        .stationary
+        .ignoresCycle
     ]
     static let level: NSWindow.Level = .screenSaver
     static let activeSpaceSyncDelay: TimeInterval = 0.18
@@ -167,6 +167,7 @@ final class WindowConfigurationView: NSView {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
+        window.hidesOnDeactivate = false
         window.level = HUDWindowChrome.level
         window.collectionBehavior = HUDWindowChrome.collectionBehavior
         window.isMovableByWindowBackground = true
@@ -368,6 +369,7 @@ final class WindowConfigurationView: NSView {
         guard role == .hud, window.isVisible else { return }
         window.collectionBehavior = HUDWindowChrome.collectionBehavior
         window.level = HUDWindowChrome.level
+        window.hidesOnDeactivate = false
         if let screen = window.screen ?? NSScreen.main {
             let clamped = HUDWindowMetrics.clampedOrigin(
                 for: window.frame.size,

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -702,6 +702,49 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(presenter.dismissCallCount, 1)
     }
 
+    func testRequestingInteractiveAreaSelectionPresentsMultiScreenAreaPresenter() {
+        let presenter = AreaSelectionPresenterSpy()
+        let model = AppModel(areaSelectionPresenter: presenter)
+
+        model.beginCapture(.recording)
+        model.requestInteractiveAreaSelection()
+
+        XCTAssertEqual(presenter.presentCallCount, 1)
+        XCTAssertEqual(presenter.presentedMode, .recording)
+        XCTAssertEqual(model.hudState.phase, .areaSelecting(.recording))
+        XCTAssertTrue(model.isAreaSelectionActive)
+    }
+
+    func testCompletingInteractiveAreaSelectionDismissesAreaPresenter() {
+        let presenter = AreaSelectionPresenterSpy()
+        let model = AppModel(areaSelectionPresenter: presenter)
+
+        model.beginCapture(.recording)
+        model.requestInteractiveAreaSelection()
+        XCTAssertEqual(presenter.presentCallCount, 1)
+
+        let area = CaptureArea(x: 100, y: 200, width: 640, height: 360, displayID: 1)
+        model.completeInteractiveAreaSelection(area)
+
+        XCTAssertEqual(presenter.dismissCallCount, 1)
+        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertEqual(model.selectedSource?.area, area)
+    }
+
+    func testCancelingInteractiveAreaSelectionDismissesAreaPresenter() {
+        let presenter = AreaSelectionPresenterSpy()
+        let model = AppModel(areaSelectionPresenter: presenter)
+
+        model.beginCapture(.recording)
+        model.requestInteractiveAreaSelection()
+        XCTAssertEqual(presenter.presentCallCount, 1)
+
+        model.cancelInteractiveAreaSelection()
+
+        XCTAssertEqual(presenter.dismissCallCount, 1)
+        XCTAssertFalse(model.isAreaSelectionActive)
+    }
+
     func testScreenshotEditorReleasesCaptureSlot() {
         let model = AppModel()
         let url = URL(fileURLWithPath: "/tmp/example-screenshot.png")
@@ -2218,6 +2261,38 @@ private final class ScreenSelectionPresenterSpy: ScreenSelectionPresenting {
 
     func select(_ source: CaptureSource) {
         onSelect?(source)
+    }
+
+    func cancel() {
+        onCancel?()
+    }
+}
+
+@MainActor
+private final class AreaSelectionPresenterSpy: AreaSelectionPresenting {
+    var presentedMode: CaptureMode?
+    var presentCallCount = 0
+    var dismissCallCount = 0
+    var onSelect: ((CaptureArea) -> Void)?
+    var onCancel: (() -> Void)?
+
+    func present(
+        mode: CaptureMode,
+        onSelect: @escaping (CaptureArea) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        presentCallCount += 1
+        presentedMode = mode
+        self.onSelect = onSelect
+        self.onCancel = onCancel
+    }
+
+    func dismiss() {
+        dismissCallCount += 1
+    }
+
+    func select(_ area: CaptureArea) {
+        onSelect?(area)
     }
 
     func cancel() {

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureShortcutsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureShortcutsTests.swift
@@ -96,12 +96,11 @@ final class CaptureShortcutsTests: XCTestCase {
         model.cancelCapture()
         model.triggerDeviceScreenRecord()
         XCTAssertEqual(model.captureMode, .recording)
-        XCTAssertEqual(model.selectedSource?.kind, .display)
 
         model.cancelCapture()
         model.triggerDragScreenRecord()
         XCTAssertEqual(model.captureMode, .recording)
-        XCTAssertFalse(model.isDragRecordingPending)
+        XCTAssertTrue(model.isDragRecordingPending)
 
         model.cancelCapture()
         XCTAssertFalse(model.isDragRecordingPending)

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
@@ -8,7 +8,8 @@ final class HUDWindowMetricsTests: XCTestCase {
 
         XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
         XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
-        XCTAssertTrue(behavior.contains(.stationary))
+        XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.stationary))
         XCTAssertEqual(HUDWindowChrome.level, .screenSaver)
     }
 
@@ -18,9 +19,20 @@ final class HUDWindowMetricsTests: XCTestCase {
         XCTAssertTrue(ScreenSelectionOverlayChrome.styleMask.contains(.nonactivatingPanel))
         XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
         XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
-        XCTAssertTrue(behavior.contains(.stationary))
         XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.stationary))
         XCTAssertGreaterThan(ScreenSelectionOverlayChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
+    }
+
+    func testAreaSelectionOverlayChromeCanCoverFullscreenSpaces() {
+        let behavior = AreaSelectionOverlayChrome.collectionBehavior
+
+        XCTAssertTrue(AreaSelectionOverlayChrome.styleMask.contains(.nonactivatingPanel))
+        XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
+        XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.stationary))
+        XCTAssertGreaterThan(AreaSelectionOverlayChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
     }
 
     func testDefaultWidthMatchesCondensedHUDLayout() {


### PR DESCRIPTION
## Description
- Updates HUD window chrome and overlay collection behaviors to display over full-screen macOS apps and remain interactive across space swipes (e.g. 3-finger swipe to a full-screen app).
- Introduces multi-monitor interactive area drag selection across all active displays (\`NSScreen.screens\`), correctly calculating display-relative coordinates and \`displayID\` for any screen dragged on.

## Motivation
Previously, the recording HUD and drag area selection overlay did not appear over full-screen apps because \`.stationary\` pinned windows to the desktop wallpaper layer (which full-screen spaces do not have). In addition, area selection only created a single window bound to one screen, preventing area drag selection across multiple monitors.

## Type of Change
- [x] New Feature
- [x] Bug Fix
- [x] Refactor / Code Cleanup

## Testing Guide
1. Run automated tests in \`apps/macos\`:
   \`\`\`bash
   swift test
   \`\`\`
2. Launch Open Recorder while a full-screen app is active (or 3-finger swipe to a full-screen app) and verify the recording HUD floats and stays interactive above the full-screen space.
3. Click "Area" / drag selection across multiple monitors or on a full-screen space and drag to select any region on any display. Verify that recording/screenshotting captures the exact dragged region.

## Checklist
- [x] I have performed a self-review of my code.
- [x] All unit tests pass cleanly (623 tests).