### PR TITLE
Fix HUD/countdown fullscreen visibility and camera-on-without-toggle bug

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -1478,12 +1478,20 @@ final class AppModel: ObservableObject {
         do {
             var options = pendingRecordingOptions ?? currentCaptureOptions
             pendingRecordingOptions = nil
+            facecamLog.notice("runRecordingStartFlow: options.includeCamera=\(options.includeCamera, privacy: .public) deviceID=\(options.cameraDeviceID ?? "default", privacy: .public)")
 
             if options.includeCamera {
                 do {
                     try await prepareFacecam(cameraDeviceID: options.cameraDeviceID)
                 } catch {
+                    facecamLog.error("prepareFacecam threw: \(error.localizedDescription, privacy: .public)")
                     captureOptions.send(.cameraDisabledForCaptureFailure)
+                    // .cameraDisabledForCaptureFailure only flips the includeCamera flag —
+                    // it doesn't tear down the camera session or close the bubble, so
+                    // without this the camera light and preview stay on for a recording
+                    // that silently has no facecam in it.
+                    cancelFacecam()
+                    requestWindow(.closeCameraBubble)
                     options.includeCamera = false
                     options.cameraDeviceID = nil
                     statusMessage = "Recording without facecam: \(error.localizedDescription)"
@@ -1506,8 +1514,12 @@ final class AppModel: ObservableObject {
                 do {
                     activeFacecamStartedAt = try await startFacecam(outputURL: url, cameraDeviceID: cameraDeviceID)
                     activeFacecamURL = url
+                    facecamLog.notice("startFacecam succeeded, url=\(url.lastPathComponent, privacy: .public)")
                 } catch {
+                    facecamLog.error("startFacecam threw: \(error.localizedDescription, privacy: .public)")
                     captureOptions.send(.cameraDisabledForCaptureFailure)
+                    cancelFacecam()
+                    requestWindow(.closeCameraBubble)
                     options.includeCamera = false
                     options.cameraDeviceID = nil
                     try? FileManager.default.removeItem(at: url)
@@ -1598,7 +1610,12 @@ final class AppModel: ObservableObject {
             let capturedFacecamSettings = resolveFacecamSettingsForRecording(source: source)
             let outputURL = try await stopRecordingCapture()
             CaptureAudioFeedback.shared.stopMonitoring()
-            let stoppedFacecamURL = try? await stopFacecam()
+            var stoppedFacecamURL: URL?
+            do {
+                stoppedFacecamURL = try await stopFacecam()
+            } catch {
+                facecamLog.error("stopFacecam threw: \(error.localizedDescription, privacy: .public)")
+            }
             let cursorTelemetryURL = cursorTelemetryRecorder.stop(videoURL: outputURL)
             currentVideoURL = outputURL
             currentScreenshotURL = nil
@@ -1606,6 +1623,7 @@ final class AppModel: ObservableObject {
             if FileManager.default.fileExists(atPath: outputURL.path) {
                 let totalDuration = await videoDuration(for: outputURL)
                 let facecamURL = stoppedFacecamURL ?? activeFacecamURL
+                facecamLog.notice("runRecordingStopFlow: stoppedFacecamURL=\(stoppedFacecamURL?.lastPathComponent ?? "nil", privacy: .public) activeFacecamURL=\(self.activeFacecamURL?.lastPathComponent ?? "nil", privacy: .public) resolved=\(facecamURL?.lastPathComponent ?? "nil", privacy: .public)")
                 let cameraClips = (facecamURL != nil)
                     ? buildCameraClipsFromRecordingEvents(duration: totalDuration, fallback: capturedFacecamSettings)
                     : []

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -1480,6 +1480,16 @@ final class AppModel: ObservableObject {
             pendingRecordingOptions = nil
             facecamLog.notice("runRecordingStartFlow: options.includeCamera=\(options.includeCamera, privacy: .public) deviceID=\(options.cameraDeviceID ?? "default", privacy: .public)")
 
+            if !options.includeCamera, facecamRecorder.isPrepared || facecamRecorder.isRecording {
+                // The camera toggle is off for this recording, but something else already
+                // spun up a live session (a stray prewarm, a leftover from a previous
+                // recording, etc). Never let a recording without includeCamera carry a
+                // running camera session or a visible bubble into it.
+                facecamLog.error("runRecordingStartFlow: camera was running despite includeCamera=false; forcing it off")
+                cancelFacecam()
+                requestWindow(.closeCameraBubble)
+            }
+
             if options.includeCamera {
                 do {
                     try await prepareFacecam(cameraDeviceID: options.cameraDeviceID)
@@ -1500,6 +1510,15 @@ final class AppModel: ObservableObject {
 
             try await runRecordingCountdown(selectedSource)
             guard !Task.isCancelled else { return }
+
+            if !options.includeCamera, facecamRecorder.isPrepared || facecamRecorder.isRecording {
+                // Same guard as above, repeated post-countdown: whatever is turning the
+                // camera on without includeCamera has shown up mid-countdown before, so a
+                // single check before the countdown isn't enough.
+                facecamLog.error("post-countdown: camera was running despite includeCamera=false; forcing it off")
+                cancelFacecam()
+                requestWindow(.closeCameraBubble)
+            }
 
             dispatch(.recordingStarting(selectedSource))
 
@@ -2621,6 +2640,7 @@ final class AppModel: ObservableObject {
     }
 
     func selectCameraDevice(_ deviceID: String?) {
+        facecamLog.notice("selectCameraDevice(\(deviceID ?? "default", privacy: .public)) called")
         captureOptions.send(.cameraSelected(deviceID))
         prewarmSelectedFacecamIfNeeded()
         requestWindow(.showCameraBubble)

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -2772,8 +2772,18 @@ final class AppModel: ObservableObject {
     }
 
     private func prepareFacecam(cameraDeviceID: String?) async throws {
-        facecamPrewarmTask?.cancel()
-        facecamPrewarmTask = nil
+        if let prewarmTask = facecamPrewarmTask {
+            facecamPrewarmTask = nil
+            prewarmTask.cancel()
+            // Task.cancel() is cooperative and FacecamRecorder.prepare() never checks
+            // isCancelled, so the prewarm's in-flight prepare() call keeps running. Wait
+            // for it to actually finish before calling prepare() again below, otherwise
+            // the two calls race on FacecamRecorder's session/movieOutput: each builds its
+            // own AVCaptureSession, and whichever assignment lands last silently orphans
+            // the other (still-running) session — leaving the camera light stuck on and
+            // recording through a session that may never have been fully wired up.
+            await prewarmTask.value
+        }
         if let prepareFacecamRecording {
             try await prepareFacecamRecording(cameraDeviceID)
         } else {

--- a/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CameraBubbleViews.swift
@@ -82,6 +82,16 @@ struct CameraBubbleWindowView: View {
             }
         }
         .onAppear {
+            // NSApp.unhide(nil)/activate calls made elsewhere operate on the whole app and
+            // can bring this window on screen (SwiftUI can instantiate a Window(id:) scene's
+            // content ahead of any explicit openWindow call, suppressed launch behavior only
+            // stops the *initial* show) without ever going through requestWindow(.showCameraBubble).
+            // Refuse to arm the camera — and get out of the way immediately — unless the
+            // user actually turned it on.
+            guard model.includeCamera else {
+                model.requestWindow(.closeCameraBubble)
+                return
+            }
             liveDiameter = max(minDiameter, min(storedDiameter, maxDiameter))
             model.prepareCameraIfNeeded()
             updateWindowFrame(newDimensions: currentDimensions)

--- a/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
@@ -31,6 +31,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     private var startContinuation: CheckedContinuation<Date, Error>?
     private var finishContinuation: CheckedContinuation<URL?, Error>?
     private var finishResult: Result<URL?, Error>?
+    private var preparationGeneration = 0
 
     var isRecording: Bool {
         movieOutput?.isRecording == true
@@ -52,11 +53,20 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         }
 
         cleanup()
+        let generation = preparationGeneration
         let (session, output) = try buildSession(cameraDeviceID: cameraDeviceID)
 
         await Task.detached(priority: .userInitiated) {
             session.startRunning()
         }.value
+
+        guard generation == preparationGeneration else {
+            // A newer prepare()/cleanup() call superseded this one while we were
+            // suspended on startRunning() — stop the now-orphaned session instead of
+            // letting it silently overwrite (and outlive) the current one.
+            session.stopRunning()
+            return
+        }
 
         self.session = session
         self.movieOutput = output
@@ -221,6 +231,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     }
 
     private func cleanup(keepOutputURL: Bool = false) {
+        preparationGeneration += 1
         if let session, session.isRunning {
             session.stopRunning()
         }

--- a/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/FacecamRecorder.swift
@@ -1,5 +1,8 @@
 @preconcurrency import AVFoundation
 import Foundation
+import os
+
+let facecamLog = Logger(subsystem: "dev.openrecorder.app", category: "facecam")
 
 enum FacecamRecorderError: LocalizedError {
     case cameraUnavailable
@@ -55,6 +58,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         cleanup()
         let generation = preparationGeneration
         let (session, output) = try buildSession(cameraDeviceID: cameraDeviceID)
+        facecamLog.notice("prepare(gen=\(generation)) building session for device=\(cameraDeviceID ?? "default", privacy: .public)")
 
         await Task.detached(priority: .userInitiated) {
             session.startRunning()
@@ -64,6 +68,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
             // A newer prepare()/cleanup() call superseded this one while we were
             // suspended on startRunning() — stop the now-orphaned session instead of
             // letting it silently overwrite (and outlive) the current one.
+            facecamLog.notice("prepare(gen=\(generation)) superseded by gen=\(self.preparationGeneration); stopping orphaned session")
             session.stopRunning()
             return
         }
@@ -72,9 +77,11 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         self.movieOutput = output
         self.preparedCameraDeviceID = cameraDeviceID
         self.finishResult = nil
+        facecamLog.notice("prepare(gen=\(generation)) completed, session running=\(session.isRunning, privacy: .public)")
     }
 
     func start(outputURL: URL, cameraDeviceID: String?) async throws -> Date {
+        facecamLog.notice("start() requested for device=\(cameraDeviceID ?? "default", privacy: .public), isPrepared=\(self.isPrepared, privacy: .public)")
         if preparedCameraDeviceID != cameraDeviceID || session == nil || movieOutput == nil {
             try await prepare(cameraDeviceID: cameraDeviceID)
         } else if let session, !session.isRunning {
@@ -84,10 +91,12 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         }
 
         guard let output = movieOutput else {
+            facecamLog.error("start() aborting: movieOutput is nil after prepare()")
             throw FacecamRecorderError.cannotAddMovieOutput
         }
 
         if output.isRecording, let startedAt {
+            facecamLog.notice("start() already recording since \(startedAt.description, privacy: .public)")
             return startedAt
         }
 
@@ -131,6 +140,7 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
 
     func stop() async throws -> URL? {
         guard let output = movieOutput, output.isRecording else {
+            facecamLog.notice("stop() called while not recording (movieOutput=\(self.movieOutput != nil, privacy: .public)); returning outputURL=\(self.outputURL?.lastPathComponent ?? "nil", privacy: .public)")
             let url = outputURL
             cleanup()
             return url
@@ -202,6 +212,9 @@ final class FacecamRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         } else {
             result = .success(outputFileURL)
         }
+
+        let fileSize = (try? FileManager.default.attributesOfItem(atPath: outputFileURL.path)[.size] as? Int64) ?? -1
+        facecamLog.notice("finishRecording url=\(outputFileURL.lastPathComponent, privacy: .public) isSuccess=\(isSuccess, privacy: .public) fileSize=\(fileSize, privacy: .public) error=\(error?.localizedDescription ?? "none", privacy: .public)")
 
         finishResult = result
         switch result {

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -236,6 +236,13 @@ struct OpenRecorderApp: App {
                 }
                 .keyboardShortcut("2", modifiers: [.command])
             }
+
+            // Without this, SwiftUI auto-populates the "Window" menu with every declared
+            // Window scene by title, including internal tool windows like "Camera Bubble",
+            // "Select Area", and the capture selectors. Selecting one from that menu (or
+            // triggering it via Mission Control/window cycling) opens it directly, bypassing
+            // requestWindow()'s includeCamera gating entirely.
+            CommandGroup(replacing: .windowList) {}
         }
 
         Settings {

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -4,6 +4,17 @@ import SwiftUI
 
 private typealias CGWindowInfoDictionary = [String: Any]
 
+enum RecordingCountdownOverlayChrome {
+    // CGShieldingWindowLevel matches HUDWindowChrome/AreaSelectionOverlayChrome:
+    // .screenSaver sits too low to reliably beat another app's full-screen Space.
+    static let level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+    static let collectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .ignoresCycle
+    ]
+}
+
 struct RecordingOverlayScreen: Equatable {
     var frame: CGRect
     var displayID: UInt32?
@@ -139,12 +150,8 @@ final class RecordingCountdownOverlayController {
         window.hasShadow = false
         window.hidesOnDeactivate = false
         window.ignoresMouseEvents = true
-        window.level = .screenSaver
-        window.collectionBehavior = [
-            .canJoinAllSpaces,
-            .fullScreenAuxiliary,
-            .ignoresCycle
-        ]
+        window.level = RecordingCountdownOverlayChrome.level
+        window.collectionBehavior = RecordingCountdownOverlayChrome.collectionBehavior
         window.contentView = NSHostingView(rootView: RecordingCountdownOverlay(state: state))
         self.window = window
         window.setFrame(frame, display: true)

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -21,7 +21,9 @@ enum HUDWindowChrome {
         .fullScreenAuxiliary,
         .ignoresCycle
     ]
-    static let level: NSWindow.Level = .screenSaver
+    // CGShieldingWindowLevel matches AreaSelectionOverlayChrome/ScreenSelectionOverlayChrome:
+    // .screenSaver sits too low to reliably beat another app's full-screen Space.
+    static let level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
     static let activeSpaceSyncDelay: TimeInterval = 0.18
 }
 
@@ -216,11 +218,12 @@ final class WindowConfigurationView: NSView {
         window.isOpaque = true
         window.backgroundColor = NSColor(red: 0.055, green: 0.055, blue: 0.070, alpha: 1)
         window.hasShadow = true
-        // Use .screenSaver so the selector appears above the HUD (which also lives at
-        // .screenSaver). At .floating the HUD would intercept scroll and click events.
-        window.level = .screenSaver
+        // Match HUDWindowChrome.level so the selector appears above the HUD (which now
+        // lives at CGShieldingWindowLevel to beat other apps' full-screen Spaces). At
+        // .floating the HUD would intercept scroll and click events.
+        window.level = NSWindow.Level(rawValue: HUDWindowChrome.level.rawValue + 1)
         // .managed ensures macOS routes focus to this window in a production app bundle.
-        window.collectionBehavior = [.fullScreenAuxiliary, .managed]
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .managed]
         window.isMovableByWindowBackground = true
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
@@ -10,7 +10,7 @@ final class HUDWindowMetricsTests: XCTestCase {
         XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
         XCTAssertTrue(behavior.contains(.ignoresCycle))
         XCTAssertFalse(behavior.contains(.stationary))
-        XCTAssertEqual(HUDWindowChrome.level, .screenSaver)
+        XCTAssertGreaterThan(HUDWindowChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
     }
 
     func testScreenSelectionOverlayChromeCanCoverFullscreenSpaces() {
@@ -33,6 +33,16 @@ final class HUDWindowMetricsTests: XCTestCase {
         XCTAssertTrue(behavior.contains(.ignoresCycle))
         XCTAssertFalse(behavior.contains(.stationary))
         XCTAssertGreaterThan(AreaSelectionOverlayChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
+    }
+
+    func testRecordingCountdownOverlayChromeCanCoverFullscreenSpaces() {
+        let behavior = RecordingCountdownOverlayChrome.collectionBehavior
+
+        XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
+        XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.stationary))
+        XCTAssertGreaterThan(RecordingCountdownOverlayChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
     }
 
     func testDefaultWidthMatchesCondensedHUDLayout() {


### PR DESCRIPTION
## Summary
- Raise the HUD and recording countdown overlay to `CGShieldingWindowLevel()` (matching the already-fixed area/screen selectors from #1026), which were still stuck at `.screenSaver` and losing to other apps' full-screen Spaces.
- Fix a real async race in `FacecamRecorder.prepare()`: turning the camera toggle on kicks off a prewarm `Task` with an unavoidable suspension point; starting a recording immediately after cancelled that task but didn't wait for it, so two unsynchronized `prepare()` calls could race and orphan a still-running `AVCaptureSession`. Added a generation guard so a superseded `prepare()` call stops its own session instead of silently overwriting the current one.
- Stop leaking the camera bubble/session when `prepareFacecam()`/`startFacecam()` fails — `.cameraDisabledForCaptureFailure` only flipped a flag, it never tore down the session or closed the bubble.
- Fix the camera turning on during recording even when the HUD camera toggle was never enabled. Root cause: `NSApp.unhide(nil)` (called from several window-command handlers during the record flow) unhides the whole app, which can surface the camera-bubble window even though it was never opened via `requestWindow(.showCameraBubble)` — SwiftUI can instantiate a `Window(id:)` scene's content ahead of any explicit `openWindow` call, and `.defaultLaunchBehavior(.suppressed)` only suppresses the *initial* automatic show. `CameraBubbleWindowView`'s `onAppear` now checks `includeCamera` directly and self-closes instead of arming the camera, regardless of how the window became visible. Also removed the default SwiftUI "Window" menu listing for these internal tool windows, and added defensive pre/post-countdown checks as a backstop.
- Added lightweight `os.Logger` diagnostics (subsystem `dev.openrecorder.app`, category `facecam`) through the facecam prepare/start/stop path, since this subsystem turned out to have several non-obvious races.

## Test plan
- [x] `swift test` — 624/624 passing
- [x] `swift build` — clean
- [x] Manually verified on a real Mac: camera toggle stays untouched through record → countdown → recording → stop, with no camera light activation and no camera bubble appearance
- [x] Manually verified: facecam recording (toggle explicitly on) produces a valid, playable clip with real audio/video frames
- [ ] HUD/countdown appearing over a full-screen app on an external monitor — fix applied but not yet independently re-verified after the camera fixes landed
- [ ] Multi-monitor drag-area selection after a 3-finger swipe to a full-screen app

🤖 Generated with [Claude Code](https://claude.com/claude-code)