### PR TITLE
fix(macos): keep HUD and countdown over fullscreen apps

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -8,14 +8,17 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
     private weak var model: AppModel?
     private var pendingFileURLs: [URL] = []
     private let windowActions = AppWindowActions()
+    private let hudPanelController = HUDPanelController()
     private let statusItemController = OpenRecorderStatusItemController()
     private let hotKeyController = GlobalRecordingHotKeyController()
     private let updateChecker = UpdateChecker.shared
     private var terminationTask: Task<Void, Never>?
+    private var didBootstrapModel = false
 
     func attach(model: AppModel) {
         if self.model !== model {
             self.model = model
+            hudPanelController.attach(model: model)
             statusItemController.attach(model: model, windowActions: windowActions)
             hotKeyController.attach(model: model)
             model.installNativeWindowCommandHandler { [weak self] command in
@@ -23,10 +26,15 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
             }
         } else {
             self.model = model
+            hudPanelController.attach(model: model)
         }
         pendingFileURLs.append(contentsOf: launchArgumentFileURLs())
         flushPendingFileURLs()
         handleWindowCommand(model.windowCommand)
+        if !didBootstrapModel {
+            didBootstrapModel = true
+            model.bootstrap()
+        }
     }
 
     var isCameraEnabled: Bool {
@@ -41,9 +49,21 @@ final class OpenRecorderAppDelegate: NSObject, NSApplicationDelegate {
         shouldKeepCameraBubble: @escaping () -> Bool = { false }
     ) {
         windowActions.install(
-            openWindow: openWindow,
+            openWindow: { [weak self] id in
+                if id == "hud" {
+                    self?.hudPanelController.show()
+                } else {
+                    openWindow(id)
+                }
+            },
             openEditor: openEditor,
-            dismissWindow: dismissWindow,
+            dismissWindow: { [weak self] id in
+                if id == "hud" {
+                    self?.hudPanelController.hide()
+                } else {
+                    dismissWindow(id)
+                }
+            },
             shouldKeepCameraBubble: shouldKeepCameraBubble
         )
         handleWindowCommand(model?.windowCommand)
@@ -110,20 +130,18 @@ struct OpenRecorderApp: App {
     @StateObject private var model = AppModel(captureSetupPreferencesStore: .live)
 
     var body: some Scene {
-        Window("Open Recorder", id: "hud") {
-            ContentView(role: .hud)
-                .environmentObject(model)
-                .onAppear {
-                    appDelegate.attach(model: model)
-                }
+        let _ = appDelegate.attach(model: model)
+
+        WindowGroup("Open Recorder Host", id: "hud-host") {
+            Color.clear
+                .frame(width: 240, height: 120)
                 .background(AppWindowActionBridge(appDelegate: appDelegate))
-                .task {
-                    model.bootstrap()
-                }
+                .background(HUDHostWindowHider())
         }
         .windowStyle(.hiddenTitleBar)
-        .windowResizability(.contentMinSize)
-        .defaultSize(width: HUDWindowMetrics.defaultSize.width, height: HUDWindowMetrics.defaultSize.height)
+        .defaultLaunchBehavior(.presented)
+        .restorationBehavior(.disabled)
+        .defaultSize(width: 240, height: 120)
 
         Window("Open Recorder Setup", id: "onboarding") {
             ContentView(role: .onboarding)
@@ -338,7 +356,6 @@ final class AppWindowActions {
         case .showHUD:
             unhideApp()
             openWindow("hud")
-            activateApp()
         case .hideHUD:
             dismissWindow("hud")
         case .showOnboarding:
@@ -362,7 +379,6 @@ final class AppWindowActions {
             dismissWindow("source-selector")
             dismissWindow("area-selector")
             openWindow("hud")
-            activateApp()
         case .hideRecordingSetup:
             dismissCaptureWindows()
         case .hideAppWindowsForCapture:
@@ -571,7 +587,6 @@ private final class OpenRecorderStatusItemController: NSObject {
             model.showHUD()
             NSApp.unhide(nil)
             windowActions.open("hud")
-            NSApp.activate(ignoringOtherApps: true)
         }
     }
 
@@ -598,7 +613,6 @@ private final class OpenRecorderStatusItemController: NSObject {
         model.showHUD()
         NSApp.unhide(nil)
         windowActions.open("hud")
-        NSApp.activate(ignoringOtherApps: true)
     }
 }
 

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -4,20 +4,15 @@ import SwiftUI
 
 private typealias CGWindowInfoDictionary = [String: Any]
 
-enum RecordingCountdownOverlayChrome {
-    // CGShieldingWindowLevel matches HUDWindowChrome/AreaSelectionOverlayChrome:
-    // .screenSaver sits too low to reliably beat another app's full-screen Space.
-    static let level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
-    static let collectionBehavior: NSWindow.CollectionBehavior = [
-        .canJoinAllSpaces,
-        .fullScreenAuxiliary,
-        .ignoresCycle
-    ]
-}
-
 struct RecordingOverlayScreen: Equatable {
     var frame: CGRect
     var displayID: UInt32?
+}
+
+enum RecordingCountdownOverlayChrome {
+    static let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel]
+    static let collectionBehavior = CaptureOverlayWindowChrome.collectionBehavior
+    static let level = CaptureOverlayWindowChrome.level
 }
 
 enum RecordingCountdownTargetResolver {
@@ -109,7 +104,7 @@ enum RecordingCountdownTargetResolver {
 
 @MainActor
 final class RecordingCountdownOverlayController {
-    private var window: NSWindow?
+    private var window: RecordingCountdownOverlayPanel?
     private var state: RecordingCountdownState?
 
     func run(for source: CaptureSource) async throws {
@@ -138,9 +133,9 @@ final class RecordingCountdownOverlayController {
     private func showWindow(for source: CaptureSource, state: RecordingCountdownState) {
         dismiss()
         let frame = RecordingCountdownTargetResolver.currentFrame(for: source)
-        let window = NSWindow(
+        let window = RecordingCountdownOverlayPanel(
             contentRect: frame,
-            styleMask: [.borderless],
+            styleMask: RecordingCountdownOverlayChrome.styleMask,
             backing: .buffered,
             defer: false
         )
@@ -150,15 +145,19 @@ final class RecordingCountdownOverlayController {
         window.hasShadow = false
         window.hidesOnDeactivate = false
         window.ignoresMouseEvents = true
+        window.isFloatingPanel = true
         window.level = RecordingCountdownOverlayChrome.level
         window.collectionBehavior = RecordingCountdownOverlayChrome.collectionBehavior
         window.contentView = NSHostingView(rootView: RecordingCountdownOverlay(state: state))
         self.window = window
         window.setFrame(frame, display: true)
-        window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
-        NSApp.activate(ignoringOtherApps: true)
     }
+}
+
+final class RecordingCountdownOverlayPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
 }
 
 @MainActor

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import AppKit
-import CoreGraphics
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -15,16 +14,198 @@ enum NativeWindowRole {
     case studio
 }
 
-enum HUDWindowChrome {
+enum CaptureOverlayWindowChrome {
     static let collectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllApplications,
         .canJoinAllSpaces,
         .fullScreenAuxiliary,
         .ignoresCycle
     ]
-    // CGShieldingWindowLevel matches AreaSelectionOverlayChrome/ScreenSelectionOverlayChrome:
-    // .screenSaver sits too low to reliably beat another app's full-screen Space.
-    static let level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+    static let level: NSWindow.Level = .screenSaver
+}
+
+enum HUDWindowChrome {
+    static let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel]
+    static let collectionBehavior = CaptureOverlayWindowChrome.collectionBehavior
+    static let level = CaptureOverlayWindowChrome.level
     static let activeSpaceSyncDelay: TimeInterval = 0.18
+
+    @MainActor
+    static func apply(to window: NSWindow) {
+        if let panel = window as? NSPanel {
+            panel.isFloatingPanel = true
+            panel.becomesKeyOnlyIfNeeded = true
+        }
+
+        window.level = level
+        window.collectionBehavior = collectionBehavior
+        window.hidesOnDeactivate = false
+    }
+
+    @MainActor
+    static func prepareForActiveSpace(_ window: NSWindow) {
+        window.orderOut(nil)
+        apply(to: window)
+    }
+}
+
+final class HUDOverlayPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+final class HUDPanelController {
+    private var panel: HUDOverlayPanel?
+    private weak var model: AppModel?
+    private var isPresented = false
+    private var activeSpaceObserver: NSObjectProtocol?
+    private var pendingActiveSpaceSync: DispatchWorkItem?
+
+    init() {
+        activeSpaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.syncToActiveSpace()
+                self?.scheduleActiveSpaceSync()
+            }
+        }
+    }
+
+    func attach(model: AppModel) {
+        guard self.model !== model || panel == nil else {
+            if model.isHUDVisible {
+                show()
+            }
+            return
+        }
+
+        panel?.close()
+        self.model = model
+        panel = makePanel(model: model)
+        if model.isHUDVisible {
+            show()
+        }
+    }
+
+    func show() {
+        guard let panel else { return }
+        isPresented = true
+        HUDWindowChrome.apply(to: panel)
+        panel.orderFrontRegardless()
+    }
+
+    func hide() {
+        isPresented = false
+        pendingActiveSpaceSync?.cancel()
+        pendingActiveSpaceSync = nil
+        panel?.orderOut(nil)
+    }
+
+    private func makePanel(model: AppModel) -> HUDOverlayPanel {
+        let size = HUDWindowMetrics.defaultSize
+        let panel = HUDOverlayPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: HUDWindowChrome.styleMask,
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Open Recorder"
+        panel.identifier = NSUserInterfaceItemIdentifier("hud")
+        panel.isReleasedWhenClosed = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = false
+        panel.acceptsMouseMovedEvents = true
+        panel.isMovableByWindowBackground = true
+        panel.animationBehavior = .none
+        HUDWindowChrome.apply(to: panel)
+        let hostingView = NSHostingView(
+            rootView: HUDOverlayWindowView()
+                .environmentObject(model)
+                .preferredColorScheme(.dark)
+        )
+        hostingView.sizingOptions = []
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        panel.contentView = hostingView
+        panel.setContentSize(size)
+        positionBottomCenter(panel, contentSize: size)
+        return panel
+    }
+
+    private func syncToActiveSpace() {
+        guard isPresented, let panel else { return }
+        HUDWindowChrome.prepareForActiveSpace(panel)
+        if let screen = panel.screen ?? NSScreen.main {
+            let origin = HUDWindowMetrics.clampedOrigin(
+                for: panel.frame.size,
+                currentOrigin: panel.frame.origin,
+                visibleFrame: screen.visibleFrame
+            )
+            panel.setFrameOrigin(origin)
+        }
+        panel.orderFrontRegardless()
+    }
+
+    private func scheduleActiveSpaceSync() {
+        pendingActiveSpaceSync?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                self?.syncToActiveSpace()
+            }
+        }
+        pendingActiveSpaceSync = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + HUDWindowChrome.activeSpaceSyncDelay,
+            execute: workItem
+        )
+    }
+
+    private func positionBottomCenter(_ panel: NSPanel, contentSize: CGSize) {
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else { return }
+        let origin = HUDWindowMetrics.bottomCenterOrigin(
+            for: contentSize,
+            visibleFrame: screen.visibleFrame
+        )
+        panel.setFrame(NSRect(origin: origin, size: contentSize), display: false)
+    }
+}
+
+struct HUDHostWindowHider: NSViewRepresentable {
+    func makeNSView(context: Context) -> HUDHostWindowHidingView {
+        HUDHostWindowHidingView()
+    }
+
+    func updateNSView(_ nsView: HUDHostWindowHidingView, context: Context) {
+        nsView.hideHostWindow()
+    }
+}
+
+final class HUDHostWindowHidingView: NSView {
+    private var hasScheduledHide = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        hideHostWindow()
+    }
+
+    func hideHostWindow() {
+        guard let window, !hasScheduledHide else { return }
+        hasScheduledHide = true
+        window.alphaValue = 0
+        window.ignoresMouseEvents = true
+        window.isExcludedFromWindowsMenu = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak window] in
+            window?.isExcludedFromWindowsMenu = true
+            window?.orderOut(nil)
+        }
+    }
 }
 
 struct WindowConfigurator: NSViewRepresentable {
@@ -169,9 +350,7 @@ final class WindowConfigurationView: NSView {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
-        window.hidesOnDeactivate = false
-        window.level = HUDWindowChrome.level
-        window.collectionBehavior = HUDWindowChrome.collectionBehavior
+        HUDWindowChrome.prepareForActiveSpace(window)
         window.isMovableByWindowBackground = true
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
@@ -218,9 +397,8 @@ final class WindowConfigurationView: NSView {
         window.isOpaque = true
         window.backgroundColor = NSColor(red: 0.055, green: 0.055, blue: 0.070, alpha: 1)
         window.hasShadow = true
-        // Match HUDWindowChrome.level so the selector appears above the HUD (which now
-        // lives at CGShieldingWindowLevel to beat other apps' full-screen Spaces). At
-        // .floating the HUD would intercept scroll and click events.
+        // Keep the selector above the HUD so the HUD cannot intercept its scroll and
+        // click events while capture setup is open.
         window.level = NSWindow.Level(rawValue: HUDWindowChrome.level.rawValue + 1)
         // .managed ensures macOS routes focus to this window in a production app bundle.
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .managed]
@@ -368,11 +546,9 @@ final class WindowConfigurationView: NSView {
         )
     }
 
-    private func syncHUDToActiveSpace(_ window: NSWindow) {
-        guard role == .hud, window.isVisible else { return }
-        window.collectionBehavior = HUDWindowChrome.collectionBehavior
-        window.level = HUDWindowChrome.level
-        window.hidesOnDeactivate = false
+    func syncHUDToActiveSpace(_ window: NSWindow) {
+        guard role == .hud else { return }
+        HUDWindowChrome.prepareForActiveSpace(window)
         if let screen = window.screen ?? NSScreen.main {
             let clamped = HUDWindowMetrics.clampedOrigin(
                 for: window.frame.size,

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -2116,6 +2116,26 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertFalse(openedWindows.contains("source-selector"))
     }
 
+    func testAppWindowActionsShowHUDDoesNotActivateApplication() {
+        let actions = AppWindowActions()
+        var openedWindows: [String] = []
+        var didActivateApp = false
+        var didUnhideApp = false
+
+        actions.install(
+            openWindow: { openedWindows.append($0) },
+            openEditor: { _ in },
+            dismissWindow: { _ in },
+            activateApp: { didActivateApp = true },
+            unhideApp: { didUnhideApp = true }
+        )
+        actions.perform(NativeWindowCommand(action: .showHUD))
+
+        XCTAssertEqual(openedWindows, ["hud"])
+        XCTAssertTrue(didUnhideApp)
+        XCTAssertFalse(didActivateApp)
+    }
+
     func testAppWindowActionsCloseCaptureSetupClosesSelectorsWithoutHUD() {
         let actions = AppWindowActions()
         var openedWindows: [String] = []

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
@@ -6,11 +6,96 @@ final class HUDWindowMetricsTests: XCTestCase {
     func testHUDWindowBehaviorFollowsActiveMacOSSpace() {
         let behavior = HUDWindowChrome.collectionBehavior
 
+        XCTAssertTrue(behavior.contains(.canJoinAllApplications))
         XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
         XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
         XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.primary))
+        XCTAssertFalse(behavior.contains(.auxiliary))
         XCTAssertFalse(behavior.contains(.stationary))
-        XCTAssertGreaterThan(HUDWindowChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
+        XCTAssertEqual(HUDWindowChrome.level, .screenSaver)
+        XCTAssertEqual(behavior, CaptureOverlayWindowChrome.collectionBehavior)
+    }
+
+    @MainActor
+    func testHUDPanelFloatsAndRemainsVisibleWhenApplicationIsInactive() {
+        let panel = HUDOverlayPanel(
+            contentRect: .zero,
+            styleMask: HUDWindowChrome.styleMask,
+            backing: .buffered,
+            defer: false
+        )
+
+        HUDWindowChrome.apply(to: panel)
+
+        XCTAssertTrue(panel.isFloatingPanel)
+        XCTAssertTrue(panel.becomesKeyOnlyIfNeeded)
+        XCTAssertFalse(panel.hidesOnDeactivate)
+        XCTAssertTrue(HUDWindowChrome.styleMask.contains(.borderless))
+        XCTAssertTrue(panel.styleMask.contains(.nonactivatingPanel))
+        XCTAssertFalse(panel.canBecomeKey)
+        XCTAssertFalse(panel.canBecomeMain)
+        XCTAssertEqual(panel.level, HUDWindowChrome.level)
+        XCTAssertEqual(panel.collectionBehavior, HUDWindowChrome.collectionBehavior)
+    }
+
+    @MainActor
+    func testHUDHostWindowIsMadeInvisibleBeforeItIsOrderedOut() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let hider = HUDHostWindowHidingView()
+        window.contentView = hider
+
+        hider.hideHostWindow()
+
+        XCTAssertEqual(window.alphaValue, 0)
+        XCTAssertTrue(window.ignoresMouseEvents)
+        XCTAssertTrue(window.isExcludedFromWindowsMenu)
+    }
+
+    @MainActor
+    func testHUDIsReorderedWhenItIsNotVisibleAfterActiveSpaceChanges() {
+        let configurator = WindowConfigurationView()
+        configurator.role = .hud
+        let window = HUDOrderTrackingWindow(
+            contentRect: NSRect(origin: .zero, size: HUDWindowMetrics.defaultSize),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        XCTAssertFalse(window.isVisible)
+
+        configurator.syncHUDToActiveSpace(window)
+
+        XCTAssertEqual(window.orderingActions, [.out, .frontRegardless])
+    }
+
+    @MainActor
+    func testRecordingCountdownUsesNonactivatingFullscreenOverlayPanel() {
+        let behavior = RecordingCountdownOverlayChrome.collectionBehavior
+        let panel = RecordingCountdownOverlayPanel(
+            contentRect: .zero,
+            styleMask: RecordingCountdownOverlayChrome.styleMask,
+            backing: .buffered,
+            defer: false
+        )
+
+        XCTAssertTrue(RecordingCountdownOverlayChrome.styleMask.contains(.nonactivatingPanel))
+        XCTAssertTrue(behavior.contains(.canJoinAllApplications))
+        XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
+        XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.primary))
+        XCTAssertFalse(behavior.contains(.auxiliary))
+        XCTAssertFalse(behavior.contains(.stationary))
+        XCTAssertEqual(RecordingCountdownOverlayChrome.level, .screenSaver)
+        XCTAssertEqual(behavior, CaptureOverlayWindowChrome.collectionBehavior)
+        XCTAssertFalse(panel.canBecomeKey)
+        XCTAssertFalse(panel.canBecomeMain)
     }
 
     func testScreenSelectionOverlayChromeCanCoverFullscreenSpaces() {
@@ -38,11 +123,15 @@ final class HUDWindowMetricsTests: XCTestCase {
     func testRecordingCountdownOverlayChromeCanCoverFullscreenSpaces() {
         let behavior = RecordingCountdownOverlayChrome.collectionBehavior
 
+        XCTAssertTrue(behavior.contains(.canJoinAllApplications))
         XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
         XCTAssertTrue(behavior.contains(.fullScreenAuxiliary))
         XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.primary))
+        XCTAssertFalse(behavior.contains(.auxiliary))
         XCTAssertFalse(behavior.contains(.stationary))
-        XCTAssertGreaterThan(RecordingCountdownOverlayChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
+        XCTAssertEqual(RecordingCountdownOverlayChrome.level, .screenSaver)
+        XCTAssertEqual(behavior, CaptureOverlayWindowChrome.collectionBehavior)
     }
 
     func testDefaultWidthMatchesCondensedHUDLayout() {
@@ -121,5 +210,22 @@ final class HUDWindowMetricsTests: XCTestCase {
             bottomMargin: 26
         )
         XCTAssertEqual(clampedLeft.x, HUDWindowMetrics.horizontalScreenMargin)
+    }
+}
+
+private final class HUDOrderTrackingWindow: NSWindow {
+    enum OrderingAction: Equatable {
+        case out
+        case frontRegardless
+    }
+
+    private(set) var orderingActions: [OrderingAction] = []
+
+    override func orderOut(_ sender: Any?) {
+        orderingActions.append(.out)
+    }
+
+    override func orderFrontRegardless() {
+        orderingActions.append(.frontRegardless)
     }
 }


### PR DESCRIPTION
## Summary

- move the HUD to a nonactivating AppKit panel that joins every application and Space
- share fullscreen-safe window chrome between the HUD and recording countdown without using the shielding window level
- resync the HUD after active Space changes without activating Open Recorder or stealing focus

This follows up on #1039 by replacing the shielding-level workaround with the documented fullscreen application membership behavior and fixes the HUD remaining on the previous Space after a three-finger swipe.

## Testing

- `make test-macos` — 31 Rust tests and 629 macOS tests passed
- `make build-macos`
- `git diff --check`
- native: HUD above Chrome and ChatGPT fullscreen, HUD followed a real Space change and remained interactive, fullscreen enter/exit, countdown above a full-display capture without switching focus, recording start/stop, source-picker cancellation
- second-monitor native coverage was unavailable because only one display was connected