### PR TITLE
Enable cursor-activity auto-zoom for all presets; add more gradients/colors

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AutoZoomGenerator.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AutoZoomGenerator.swift
@@ -44,8 +44,7 @@ enum AutoZoomGenerator {
             samples: sortedSamples,
             clicks: sortedClicks,
             telemetry: telemetry,
-            config: config,
-            preset: preset
+            config: config
         )
         let candidates = (clickCandidates + cursorCandidates)
             .filter { $0.confidence >= config.minimumConfidence }
@@ -155,10 +154,9 @@ enum AutoZoomGenerator {
         samples: [CursorTelemetrySample],
         clicks: [CursorTelemetryClick],
         telemetry: CursorTelemetryPayload,
-        config: TimelineZoomAnimationConfiguration,
-        preset: TimelineZoomAnimationPreset
+        config: TimelineZoomAnimationConfiguration
     ) -> [ZoomCandidate] {
-        guard preset == .guided, samples.count >= 8 else { return [] }
+        guard samples.count >= 8 else { return [] }
 
         let width = Double(max(telemetry.width, 1))
         let height = Double(max(telemetry.height, 1))

--- a/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
+++ b/apps/macos/Sources/OpenRecorderMac/BackgroundPresets.swift
@@ -126,7 +126,13 @@ enum BackgroundPresets {
         SerializableColor(hex: "#16A34A"), // Emerald
         SerializableColor(hex: "#0D9488"), // Teal
         SerializableColor(hex: "#FFFFFF"), // Pure White
-        SerializableColor(hex: "#64748B")  // Muted Slate
+        SerializableColor(hex: "#64748B"), // Muted Slate
+        SerializableColor(hex: "#B91C1C"), // Crimson
+        SerializableColor(hex: "#CA8A04"), // Amber Gold
+        SerializableColor(hex: "#0369A1"), // Ocean Blue
+        SerializableColor(hex: "#4D7C0F"), // Olive Green
+        SerializableColor(hex: "#9D174D"), // Magenta Wine
+        SerializableColor(hex: "#292524")  // Espresso Brown
     ]
 
     static let gradients: [GradientPreset] = [
@@ -368,6 +374,107 @@ enum BackgroundPresets {
             stops: [
                 GradientStop(color: SerializableColor(hex: "#0acffe"), position: 0),
                 GradientStop(color: SerializableColor(hex: "#495aff"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "graphite-fade",
+            kind: .linear(angleDegrees: 135),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#3A3A3C"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#0B0B0D"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "champagne-gold",
+            kind: .linear(angleDegrees: 120),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#F7E7CE"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#C08A3E"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "arctic-frost",
+            kind: .linear(angleDegrees: 100),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#E0EAFC"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#CFDEF3"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "wine-dusk",
+            kind: .linear(angleDegrees: 140),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#3A0519"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#7A0C2E"), position: 0.55),
+                GradientStop(color: SerializableColor(hex: "#1A0308"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "cyber-fade",
+            kind: .linear(angleDegrees: 105),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#00F5FF"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#8A2BE2"), position: 0.55),
+                GradientStop(color: SerializableColor(hex: "#0A0014"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "sunset-boulevard",
+            kind: .linear(angleDegrees: 100),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#FF6B6B"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#C44FDB"), position: 0.5),
+                GradientStop(color: SerializableColor(hex: "#3A1C71"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "espresso",
+            kind: .linear(angleDegrees: 135),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#4E342E"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#1B0F0C"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "steel-blue",
+            kind: .linear(angleDegrees: 115),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#334155"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#0F1B2D"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "lilac-mist",
+            kind: .linear(angleDegrees: 100),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#E6D6FF"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#C3AEEB"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "volcanic-glow",
+            kind: .radial(centerX: 0.5, centerY: 0.85),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#FF4500"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#3A0A02"), position: 0.55),
+                GradientStop(color: SerializableColor(hex: "#050101"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "emerald-noir",
+            kind: .linear(angleDegrees: 135),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#0F3D2E"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#020705"), position: 1)
+            ]
+        ),
+        GradientPreset(
+            id: "aurora-teal",
+            kind: .radial(centerX: 0.22, centerY: 0.15),
+            stops: [
+                GradientStop(color: SerializableColor(hex: "#7CF9D6"), position: 0),
+                GradientStop(color: SerializableColor(hex: "#1B7A6E"), position: 0.5),
+                GradientStop(color: SerializableColor(hex: "#031315"), position: 1)
             ]
         )
     ]

--- a/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AutoZoomGeneratorTests.swift
@@ -215,7 +215,11 @@ final class AutoZoomGeneratorTests: XCTestCase {
         XCTAssertGreaterThan(zooms[0].span.duration, 3.0)
     }
 
-    func testGuidedPresetCreatesCursorOnlyDwellRegion() {
+    func testCursorOnlyDwellRegionIsNotLimitedToGuidedPreset() {
+        // Cursor-activity (hover/dropdown) detection used to be gated to the .guided
+        // preset only; every other preset only zoomed on clicks. It's now evaluated for
+        // every preset and gated purely by each preset's own minimumConfidence, same as
+        // click-based candidates already were.
         let payload = CursorTelemetryPayload(
             width: 1000,
             height: 1000,
@@ -234,13 +238,22 @@ final class AutoZoomGeneratorTests: XCTestCase {
 
         let guided = AutoZoomGenerator.generate(from: payload, duration: 5, preset: .guided)
         let balanced = AutoZoomGenerator.generate(from: payload, duration: 5, preset: .balanced)
+        let subtle = AutoZoomGenerator.generate(from: payload, duration: 5, preset: .subtle)
 
         XCTAssertEqual(guided.count, 1)
         XCTAssertEqual(guided[0].animationPreset, .guided)
         XCTAssertNil(guided[0].sourceClickTimestamp)
         XCTAssertEqual(guided[0].focusX, 0.509, accuracy: 0.001)
         XCTAssertEqual(guided[0].focusY, 0.590, accuracy: 0.001)
-        XCTAssertTrue(balanced.isEmpty)
+
+        XCTAssertEqual(balanced.count, 1)
+        XCTAssertEqual(balanced[0].animationPreset, .balanced)
+        XCTAssertNil(balanced[0].sourceClickTimestamp)
+
+        // subtle's minimumConfidence (0.72) is stricter than this dwell's confidence
+        // (~0.665), so it should still filter it out — confirming the behavior change
+        // is "no longer guided-only" and not "no longer gated at all".
+        XCTAssertTrue(subtle.isEmpty)
     }
 
     func testGuidedPresetSkipsIdleCursorOnlySamples() {


### PR DESCRIPTION
## Summary
- Cursor-activity (hover/dropdown) auto-zoom detection was gated to the `.guided` preset only — every other preset could only ever zoom in response to a click. Now it's evaluated for every preset, gated purely by each preset's own `minimumConfidence` (same mechanism click-based candidates already use).
- Added 12 new gradients and 6 new solid colors to the background picker, filling in color families not already covered (gold, wine, steel blue, espresso, volcanic, aurora teal, etc). Code-only — no new image/video assets.

## Test plan
- [x] `swift test` — 629/629 passing
- [x] `swift build` — clean
- [x] Added a test confirming `.balanced` now produces a cursor-activity zoom where it previously produced none, and that `.subtle` (stricter `minimumConfidence`) still correctly filters the same candidate out — confirms the change is "no longer guided-only," not "no longer gated at all"

🤖 Generated with [Claude Code](https://claude.com/claude-code)