### PR TITLE
fix(macos): cancel recording countdown with Escape

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -231,7 +231,7 @@ final class AppModel: ObservableObject {
     @Published private(set) var shortcutPreferences: ShortcutPreferences = .defaultPreferences
     @Published private(set) var isDragRecordingPending = false
     private var displayFlashWindows: [NSWindow] = []
-    private let countdownOverlayController = RecordingCountdownOverlayController()
+    private let countdownOverlayController: RecordingCountdownOverlayController
     private let captureUIHideDelayNanoseconds: UInt64
 
     let service: RustServiceClient
@@ -310,6 +310,7 @@ final class AppModel: ObservableObject {
         self.areaSelectionPresenter = areaSelectionPresenter
         self.captureUIHideDelayNanoseconds = captureUIHideDelayNanoseconds
         self.capture = capture
+        self.countdownOverlayController = RecordingCountdownOverlayController()
         self.screenshotCapture = screenshotCapture ?? { source, outputURL in
             try capture.takeScreenshot(source: source, outputURL: outputURL)
         }
@@ -410,6 +411,9 @@ final class AppModel: ObservableObject {
         }
         self.runRecordingCountdown = runRecordingCountdown ?? { [countdownOverlayController] source in
             try await countdownOverlayController.run(for: source)
+        }
+        self.countdownOverlayController.onCancel = { [weak self] in
+            self?.cancelCountdownRecording()
         }
         appShell.configure(
             refreshBackend: { [weak self] in

--- a/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RecordingCountdownOverlay.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import CoreGraphics
 import SwiftUI
 
@@ -13,6 +14,76 @@ enum RecordingCountdownOverlayChrome {
     static let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel]
     static let collectionBehavior = CaptureOverlayWindowChrome.collectionBehavior
     static let level = CaptureOverlayWindowChrome.level
+}
+
+@MainActor
+struct RecordingCountdownEventMonitorClient {
+    var addLocalKeyDownMonitor: (@escaping (NSEvent) -> NSEvent?) -> Any?
+    var addGlobalKeyDownMonitor: (@escaping (NSEvent) -> Void) -> Any?
+    var removeMonitor: (Any) -> Void
+
+    static let live = RecordingCountdownEventMonitorClient(
+        addLocalKeyDownMonitor: { handler in
+            NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+        },
+        addGlobalKeyDownMonitor: { handler in
+            NSEvent.addGlobalMonitorForEvents(matching: .keyDown, handler: handler)
+        },
+        removeMonitor: { monitor in
+            NSEvent.removeMonitor(monitor)
+        }
+    )
+}
+
+@MainActor
+final class RecordingCountdownEscapeMonitor {
+    private let eventMonitorClient: RecordingCountdownEventMonitorClient
+    private var localKeyMonitor: Any?
+    private var globalKeyMonitor: Any?
+    private var onEscape: (() -> Void)?
+
+    init(eventMonitorClient: RecordingCountdownEventMonitorClient = .live) {
+        self.eventMonitorClient = eventMonitorClient
+    }
+
+    func install(onEscape: @escaping () -> Void) {
+        remove()
+        self.onEscape = onEscape
+
+        localKeyMonitor = eventMonitorClient.addLocalKeyDownMonitor { [weak self] event in
+            guard Self.isEscapeKey(event) else { return event }
+            self?.handleEscape()
+            return nil
+        }
+        globalKeyMonitor = eventMonitorClient.addGlobalKeyDownMonitor { [weak self] event in
+            guard Self.isEscapeKey(event) else { return }
+            Task { @MainActor [weak self] in
+                self?.handleEscape()
+            }
+        }
+    }
+
+    func remove() {
+        if let localKeyMonitor {
+            eventMonitorClient.removeMonitor(localKeyMonitor)
+        }
+        if let globalKeyMonitor {
+            eventMonitorClient.removeMonitor(globalKeyMonitor)
+        }
+        localKeyMonitor = nil
+        globalKeyMonitor = nil
+        onEscape = nil
+    }
+
+    private func handleEscape() {
+        guard let onEscape else { return }
+        remove()
+        onEscape()
+    }
+
+    private static func isEscapeKey(_ event: NSEvent) -> Bool {
+        event.keyCode == UInt16(kVK_Escape) || event.charactersIgnoringModifiers == "\u{1B}"
+    }
 }
 
 enum RecordingCountdownTargetResolver {
@@ -106,11 +177,19 @@ enum RecordingCountdownTargetResolver {
 final class RecordingCountdownOverlayController {
     private var window: RecordingCountdownOverlayPanel?
     private var state: RecordingCountdownState?
+    private let escapeMonitor: RecordingCountdownEscapeMonitor
+    var onCancel: () -> Void = {}
+
+    init(eventMonitorClient: RecordingCountdownEventMonitorClient = .live) {
+        escapeMonitor = RecordingCountdownEscapeMonitor(eventMonitorClient: eventMonitorClient)
+    }
 
     func run(for source: CaptureSource) async throws {
         let state = RecordingCountdownState(sourceName: source.name)
-        self.state = state
         showWindow(for: source, state: state)
+        escapeMonitor.install { [weak self] in
+            self?.onCancel()
+        }
 
         defer {
             dismiss()
@@ -125,6 +204,7 @@ final class RecordingCountdownOverlayController {
     }
 
     func dismiss() {
+        escapeMonitor.remove()
         window?.close()
         window = nil
         state = nil
@@ -132,6 +212,7 @@ final class RecordingCountdownOverlayController {
 
     private func showWindow(for source: CaptureSource, state: RecordingCountdownState) {
         dismiss()
+        self.state = state
         let frame = RecordingCountdownTargetResolver.currentFrame(for: source)
         let window = RecordingCountdownOverlayPanel(
             contentRect: frame,

--- a/apps/macos/Tests/OpenRecorderMacTests/RecordingCountdownOverlayTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/RecordingCountdownOverlayTests.swift
@@ -1,8 +1,100 @@
+import AppKit
 import CoreGraphics
 import XCTest
 @testable import OpenRecorderMac
 
 final class RecordingCountdownOverlayTests: XCTestCase {
+    @MainActor
+    func testLocalEscapeCancelsCountdownOnceAndConsumesEvent() throws {
+        var localHandler: ((NSEvent) -> NSEvent?)?
+        var globalHandler: ((NSEvent) -> Void)?
+        var removedMonitorCount = 0
+        var cancelCount = 0
+        let monitor = RecordingCountdownEscapeMonitor(
+            eventMonitorClient: RecordingCountdownEventMonitorClient(
+                addLocalKeyDownMonitor: { handler in
+                    localHandler = handler
+                    return NSObject()
+                },
+                addGlobalKeyDownMonitor: { handler in
+                    globalHandler = handler
+                    return NSObject()
+                },
+                removeMonitor: { _ in
+                    removedMonitorCount += 1
+                }
+            )
+        )
+        monitor.install {
+            cancelCount += 1
+        }
+        let escapeEvent = try makeKeyEvent(keyCode: 53, characters: "\u{1B}")
+        let handler = try XCTUnwrap(localHandler)
+
+        XCTAssertNil(handler(escapeEvent))
+        XCTAssertEqual(cancelCount, 1)
+        XCTAssertEqual(removedMonitorCount, 2)
+
+        globalHandler?(escapeEvent)
+        XCTAssertEqual(cancelCount, 1)
+    }
+
+    @MainActor
+    func testNonEscapeKeyPassesThroughWithoutCancelingCountdown() throws {
+        var localHandler: ((NSEvent) -> NSEvent?)?
+        var cancelCount = 0
+        let monitor = RecordingCountdownEscapeMonitor(
+            eventMonitorClient: RecordingCountdownEventMonitorClient(
+                addLocalKeyDownMonitor: { handler in
+                    localHandler = handler
+                    return NSObject()
+                },
+                addGlobalKeyDownMonitor: { _ in NSObject() },
+                removeMonitor: { _ in }
+            )
+        )
+        monitor.install {
+            cancelCount += 1
+        }
+        defer { monitor.remove() }
+        let letterEvent = try makeKeyEvent(keyCode: 0, characters: "a")
+        let handler = try XCTUnwrap(localHandler)
+
+        XCTAssertTrue(handler(letterEvent) === letterEvent)
+        XCTAssertEqual(cancelCount, 0)
+    }
+
+    @MainActor
+    func testGlobalEscapeCancelsCountdownWhenAnotherAppIsActive() async throws {
+        var globalHandler: ((NSEvent) -> Void)?
+        var removedMonitorCount = 0
+        var cancelCount = 0
+        let canceled = expectation(description: "Countdown canceled")
+        let monitor = RecordingCountdownEscapeMonitor(
+            eventMonitorClient: RecordingCountdownEventMonitorClient(
+                addLocalKeyDownMonitor: { _ in NSObject() },
+                addGlobalKeyDownMonitor: { handler in
+                    globalHandler = handler
+                    return NSObject()
+                },
+                removeMonitor: { _ in
+                    removedMonitorCount += 1
+                }
+            )
+        )
+        monitor.install {
+            cancelCount += 1
+            canceled.fulfill()
+        }
+        let escapeEvent = try makeKeyEvent(keyCode: 53, characters: "\u{1B}")
+
+        globalHandler?(escapeEvent)
+        await fulfillment(of: [canceled], timeout: 1)
+
+        XCTAssertEqual(cancelCount, 1)
+        XCTAssertEqual(removedMonitorCount, 2)
+    }
+
     func testDisplaySourceUsesMatchingDisplayFrame() {
         let source = CaptureSource(
             id: "display:42",
@@ -178,5 +270,20 @@ final class RecordingCountdownOverlayTests: XCTestCase {
         let frame = RecordingCountdownTargetResolver.frame(for: source, screens: [])
 
         XCTAssertEqual(frame, CGRect(x: 0, y: 0, width: 900, height: 600))
+    }
+
+    private func makeKeyEvent(keyCode: UInt16, characters: String) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        ))
     }
 }


### PR DESCRIPTION
## Summary

- listen for Escape locally and globally while the nonactivating recording countdown overlay is visible
- route Escape through the existing countdown cancellation state transition and remove both event monitors after cancellation or dismissal
- cover active-app, background-app, non-Escape, and one-shot monitor behavior

## Verification

- `swift test --package-path apps/macos --filter RecordingCountdownOverlayTests` (11 passed)
- `make test-macos` (31 Rust tests and 632 macOS tests passed)
- `make build-macos`
- native packaged app: Escape during the recording start flow returned the HUD to ready state with `Recording canceled.` and capture did not start
- `git diff --check`