### PR TITLE
Fix Mintlify typography leaking from landing app

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,2 @@
+# Application source is deployed separately and must not be processed as docs assets.
+apps/


### PR DESCRIPTION
## Summary

- exclude the separately deployed apps directory from Mintlify processing
- stop landing-site global CSS from overriding Mintlify headings, colors, and fonts
- restore the changelog heading from 88px to Mintlify’s native 36px styling

## Root cause

Mintlify processes repository CSS as global documentation styles. The landing app’s apps/landing/src/app/globals.css includes an unscoped h1 rule with clamp(3rem, 8vw, 5.5rem), which overrode Mintlify’s built-in page-title class on every docs page.

## Validation

- mint validate (Node 24): passed
- local Mintlify preview: changelog returns 200
- local computed H1: 36px font size, 40px line height
- leaked application styles detected in preview: 0
- docs.json parses with jq
- git diff --check