### PR TITLE
fix(macos): align dragged area captures

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AreaSelectionGeometry.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AreaSelectionGeometry.swift
@@ -1,0 +1,36 @@
+import CoreGraphics
+
+enum AreaSelectionGeometry {
+    static func alignedSelectionRect(between start: CGPoint, and current: CGPoint) -> CGRect {
+        let minX = min(start.x, current.x).rounded()
+        let maxX = max(start.x, current.x).rounded()
+        let minY = min(start.y, current.y).rounded()
+        let maxY = max(start.y, current.y).rounded()
+
+        return CGRect(
+            x: minX,
+            y: minY,
+            width: max(0, maxX - minX),
+            height: max(0, maxY - minY)
+        )
+    }
+
+    static func captureArea(
+        for selectionRect: CGRect,
+        on screenFrame: CGRect,
+        displayID: UInt32?
+    ) -> CaptureArea {
+        let minX = Int((screenFrame.minX + selectionRect.minX).rounded())
+        let maxX = Int((screenFrame.minX + selectionRect.maxX).rounded())
+        let minY = Int((screenFrame.maxY - selectionRect.maxY).rounded())
+        let maxY = Int((screenFrame.maxY - selectionRect.minY).rounded())
+
+        return CaptureArea(
+            x: minX,
+            y: minY,
+            width: max(maxX - minX, 1),
+            height: max(maxY - minY, 1),
+            displayID: displayID
+        )
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
@@ -218,7 +218,7 @@ struct AreaSelectionScreenOverlayView: View {
                         .fill(Color.clear)
                         .overlay {
                             Rectangle()
-                                .stroke(Color.white, lineWidth: 2)
+                                .strokeBorder(Color.white, lineWidth: 2)
                                 .shadow(color: Color.black.opacity(0.4), radius: 2)
                         }
                         .background(Theme.border.opacity(0.12))
@@ -271,12 +271,7 @@ struct AreaSelectionScreenOverlayView: View {
 
     private var selectionRect: CGRect? {
         guard let dragStart, let dragCurrent else { return nil }
-        return CGRect(
-            x: min(dragStart.x, dragCurrent.x),
-            y: min(dragStart.y, dragCurrent.y),
-            width: abs(dragCurrent.x - dragStart.x),
-            height: abs(dragCurrent.y - dragStart.y)
-        )
+        return AreaSelectionGeometry.alignedSelectionRect(between: dragStart, and: dragCurrent)
     }
 
     @ViewBuilder
@@ -339,11 +334,9 @@ struct AreaSelectionScreenOverlayView: View {
     private func captureArea(for rect: CGRect) -> CaptureArea {
         let screenFrame = screen.frame
         let displayID = (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
-        return CaptureArea(
-            x: Int((screenFrame.minX + rect.minX).rounded()),
-            y: Int((screenFrame.maxY - rect.maxY).rounded()),
-            width: max(Int(rect.width.rounded()), 1),
-            height: max(Int(rect.height.rounded()), 1),
+        return AreaSelectionGeometry.captureArea(
+            for: rect,
+            on: screenFrame,
             displayID: displayID
         )
     }

--- a/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
+++ b/apps/macos/Sources/OpenRecorderMac/NativeScreenRecorder.swift
@@ -86,8 +86,8 @@ final class NativeScreenRecorder: NSObject {
         options: RecordingCaptureOptions
     ) -> SCStreamConfiguration {
         let configuration = SCStreamConfiguration()
-        configuration.width = width
-        configuration.height = height
+        configuration.width = evenVideoDimension(width)
+        configuration.height = evenVideoDimension(height)
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 60)
         configuration.queueDepth = 8
         // Record without cursor capture here; playback and export reapply the saved cursor preference after capture.
@@ -107,6 +107,11 @@ final class NativeScreenRecorder: NSObject {
             configuration.sourceRect = sourceRect
         }
         return configuration
+    }
+
+    private static func evenVideoDimension(_ value: Int) -> Int {
+        let clamped = max(value, 2)
+        return clamped.isMultiple(of: 2) ? clamped : clamped + 1
     }
 
     func stop() async throws {

--- a/apps/macos/Tests/OpenRecorderMacTests/AreaSelectionGeometryTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AreaSelectionGeometryTests.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+import XCTest
+@testable import OpenRecorderMac
+
+final class AreaSelectionGeometryTests: XCTestCase {
+    func testAlignsEachSelectionEdgeToTheCaptureGrid() {
+        let rect = AreaSelectionGeometry.alignedSelectionRect(
+            between: CGPoint(x: 300.4, y: 350.4),
+            and: CGPoint(x: 100.6, y: 200.6)
+        )
+
+        XCTAssertEqual(rect, CGRect(x: 101, y: 201, width: 199, height: 149))
+    }
+
+    func testRoundsOpposingSelectionEdgesBeforeDerivingSize() {
+        let area = AreaSelectionGeometry.captureArea(
+            for: CGRect(x: 100.6, y: 200.6, width: 199.8, height: 149.8),
+            on: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            displayID: 7
+        )
+
+        XCTAssertEqual(
+            area,
+            CaptureArea(x: 101, y: 767, width: 199, height: 149, displayID: 7)
+        )
+        XCTAssertEqual(area.x + area.width, 300)
+        XCTAssertEqual(area.y + area.height, 916)
+    }
+
+    func testPreservesIntegralSelectionEdges() {
+        let area = AreaSelectionGeometry.captureArea(
+            for: CGRect(x: 120, y: 230, width: 640, height: 360),
+            on: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            displayID: 11
+        )
+
+        XCTAssertEqual(
+            area,
+            CaptureArea(x: 120, y: 527, width: 640, height: 360, displayID: 11)
+        )
+    }
+
+    func testMapsSelectionOnOffsetDisplay() {
+        let area = AreaSelectionGeometry.captureArea(
+            for: CGRect(x: 20.4, y: 30.4, width: 300.2, height: 200.2),
+            on: CGRect(x: -1512, y: -85, width: 1512, height: 982),
+            displayID: 19
+        )
+
+        XCTAssertEqual(
+            area,
+            CaptureArea(x: -1492, y: 666, width: 301, height: 201, displayID: 19)
+        )
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/NativeScreenRecorderConfigurationTests.swift
@@ -5,6 +5,27 @@ import XCTest
 
 @MainActor
 final class NativeScreenRecorderConfigurationTests: XCTestCase {
+    func testStreamConfigurationRoundsOddVideoDimensionsUpToEvenValues() {
+        let configuration = NativeScreenRecorder.makeStreamConfiguration(
+            width: 873,
+            height: 581,
+            sourceRect: CGRect(x: 436, y: 364, width: 873, height: 581),
+            options: RecordingCaptureOptions(
+                includeMicrophone: false,
+                microphoneDeviceID: nil,
+                includeSystemAudio: false,
+                includeCamera: false,
+                cameraDeviceID: nil,
+                showCursor: false,
+                showClicks: false
+            )
+        )
+
+        XCTAssertEqual(configuration.width, 874)
+        XCTAssertEqual(configuration.height, 582)
+        XCTAssertEqual(configuration.sourceRect, CGRect(x: 436, y: 364, width: 873, height: 581))
+    }
+
     func testStreamConfigurationCapturesSystemAudioWhenEnabled() {
         let configuration = NativeScreenRecorder.makeStreamConfiguration(
             width: 1920,


### PR DESCRIPTION
## Summary
- snap the two dragged selection edges before deriving the capture rectangle, keeping screenshot and recording geometry on the same logical-point grid
- draw the selection border inside the selected bounds so the visible outline matches the captured region
- request even recording output dimensions while preserving the exact ScreenCaptureKit source rectangle, avoiding H.264 padding shifts for odd-sized selections

## Verification
- `make test-macos` — 31 Rust tests and 637 macOS tests passed
- focused geometry tests — 4 passed
- focused recorder configuration tests — 6 passed
- native Retina verification: screenshot output matched the 873×581 logical-point selection at 1746×1162 pixels; the recorded frame aligned with the matching screenshot at zero x/y offset after the fix