### PR TITLE
fix(macos): prevent duplicate area selection overlay

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -446,9 +446,6 @@ final class AppModel: ObservableObject {
                 showSourceSelector: { [weak self] in
                     self?.requestWindow(.showSourceSelector)
                 },
-                showAreaSelector: { [weak self] in
-                    self?.requestWindow(.showAreaSelector)
-                },
                 showRecordingSetup: { [weak self] kind in
                     self?.requestWindow(kind == .display ? .showScreenRecordingSetup : .showRecordingSetup)
                 },
@@ -738,10 +735,6 @@ final class AppModel: ObservableObject {
 
     var recordingPhase: RecordingPhase {
         captureState.recordingPhase
-    }
-
-    var isAreaSelectionActive: Bool {
-        captureState.isAreaSelectionActive
     }
 
     func setCaptureStateForTesting(_ state: CaptureState) {
@@ -1370,7 +1363,7 @@ final class AppModel: ObservableObject {
                 requestWindow(.showSourceSelector)
             }
         case .areaSelecting:
-            requestWindow(.showAreaSelector)
+            areaSelectionPresenter.focus()
         case .choosingSourceType:
             showHUD()
         case .screenSelecting:

--- a/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
@@ -22,6 +22,7 @@ protocol AreaSelectionPresenting: AnyObject {
         onSelect: @escaping (CaptureArea) -> Void,
         onCancel: @escaping () -> Void
     )
+    func focus()
     func dismiss()
 }
 
@@ -35,6 +36,12 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
     private var onSelect: ((CaptureArea) -> Void)?
     private var onCancel: (() -> Void)?
     private var mode: CaptureMode = .recording
+    private var presentationGeneration = 0
+
+#if DEBUG
+    var presentedWindowCountForTesting: Int { windows.count }
+    var presentedWindowsForTesting: [NSWindow] { windows }
+#endif
 
     func present(
         mode: CaptureMode,
@@ -47,11 +54,20 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
         self.onCancel = onCancel
 
         installKeyMonitor()
-        installSpaceAndScreenObservers()
+        installSpaceAndScreenObservers(generation: presentationGeneration)
         rebuildWindows()
     }
 
+    func focus() {
+        NSApp.activate(ignoringOtherApps: true)
+        windows.forEach { $0.orderFrontRegardless() }
+        if let mainScreenWindow = windows.first(where: { $0.screen == NSScreen.main }) ?? windows.first {
+            mainScreenWindow.makeKeyAndOrderFront(nil)
+        }
+    }
+
     func dismiss() {
+        presentationGeneration += 1
         if let keyMonitor {
             NSEvent.removeMonitor(keyMonitor)
         }
@@ -114,10 +130,7 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
             window.orderFrontRegardless()
         }
 
-        if let mainScreenWindow = windows.first(where: { $0.screen == NSScreen.main }) ?? windows.first {
-            mainScreenWindow.makeKeyAndOrderFront(nil)
-        }
-        NSApp.activate(ignoringOtherApps: true)
+        focus()
     }
 
     private func handleSelect(_ area: CaptureArea) {
@@ -132,13 +145,14 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
         callback?()
     }
 
-    private func installSpaceAndScreenObservers() {
+    private func installSpaceAndScreenObservers(generation: Int) {
         spaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.activeSpaceDidChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                guard self?.presentationGeneration == generation else { return }
                 self?.windows.forEach { $0.orderFrontRegardless() }
             }
         }
@@ -148,6 +162,7 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                guard self?.presentationGeneration == generation else { return }
                 self?.rebuildWindows()
             }
         }
@@ -339,44 +354,5 @@ struct AreaSelectionScreenOverlayView: View {
             on: screenFrame,
             displayID: displayID
         )
-    }
-}
-
-struct AreaSelectionWindowView: View {
-    @EnvironmentObject private var model: AppModel
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.dismissWindow) private var dismissWindow
-    @State private var dragStart: CGPoint?
-    @State private var dragCurrent: CGPoint?
-    @State private var isFinishingSelection = false
-    @FocusState private var selectionHasFocus: Bool
-
-    var body: some View {
-        AreaSelectionScreenOverlayView(
-            screen: NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first ?? NSScreen(),
-            mode: model.captureMode,
-            onSelect: { area in
-                dismiss()
-                dismissWindow(id: "area-selector")
-                model.completeInteractiveAreaSelection(area)
-            },
-            onCancel: {
-                model.cancelInteractiveAreaSelection()
-                dismiss()
-                dismissWindow(id: "area-selector")
-            }
-        )
-        .focusedValue(\.areaSelectionIsFocused, true)
-    }
-}
-
-struct AreaSelectionFocusKey: FocusedValueKey {
-    typealias Value = Bool
-}
-
-extension FocusedValues {
-    var areaSelectionIsFocused: Bool? {
-        get { self[AreaSelectionFocusKey.self] }
-        set { self[AreaSelectionFocusKey.self] = newValue }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/CaptureDriver.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureDriver.swift
@@ -6,7 +6,6 @@ struct CaptureEffectHandlers {
     var hideHUD: () -> Void = {}
     var closeCaptureSetup: () -> Void = {}
     var showSourceSelector: () -> Void = {}
-    var showAreaSelector: () -> Void = {}
     var showRecordingSetup: (CaptureSourceKind) -> Void = { _ in }
     var dismissScreenSelection: () -> Void = {}
     var dismissCaptureWindows: () -> Void = {}
@@ -74,8 +73,6 @@ final class CaptureDriver {
                 effectHandlers.closeCaptureSetup()
             case .showSourceSelector:
                 effectHandlers.showSourceSelector()
-            case .showAreaSelector:
-                effectHandlers.showAreaSelector()
             case .showRecordingSetup(let kind):
                 effectHandlers.showRecordingSetup(kind)
             case .dismissScreenSelection:

--- a/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
@@ -250,7 +250,6 @@ enum CaptureEffect: Hashable {
     case hideHUD
     case closeCaptureSetup
     case showSourceSelector
-    case showAreaSelector
     case showRecordingSetup(CaptureSourceKind)
     case dismissScreenSelection
     case dismissCaptureWindows
@@ -685,7 +684,7 @@ struct CaptureState: Hashable {
             next.setPhase(.areaSelecting(modeForSelection()), clearSource: false)
             next.preferredSourceKind = .area
             statusMessage = "Draw an area to capture."
-            effects.append(.showAreaSelector)
+            // AppModel owns the multi-screen overlay presentation directly.
 
         case .completeInteractiveAreaSelection(let source):
             next.selectedSource = source

--- a/apps/macos/Sources/OpenRecorderMac/ContentView.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ContentView.swift
@@ -10,7 +10,6 @@ enum AppWindowRole {
     case microphoneSelector
     case cameraSelector
     case cameraBubble
-    case areaSelector
     case studio
 }
 
@@ -44,9 +43,6 @@ struct ContentView: View {
             case .cameraBubble:
                 CameraBubbleWindowView()
                     .background(WindowConfigurator(role: .cameraBubble))
-            case .areaSelector:
-                AreaSelectionWindowView()
-                    .background(WindowConfigurator(role: .areaSelector, isPresented: model.isAreaSelectionActive))
             case .studio:
                 StudioWindowView(editorSession: editorSession)
                     .background(WindowConfigurator(role: .studio))

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -929,7 +929,6 @@ enum NativeWindowCommandAction: Equatable {
     case showSourceSelector
     case showMicrophoneSelector
     case showCameraSelector
-    case showAreaSelector
     case showCameraBubble
     case closeCameraBubble
     case showStudio
@@ -937,7 +936,6 @@ enum NativeWindowCommandAction: Equatable {
     case closeSourceSelector
     case closeMicrophoneSelector
     case closeCameraSelector
-    case closeAreaSelector
 }
 
 struct NativeWindowCommand: Identifiable {

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -197,16 +197,6 @@ struct OpenRecorderApp: App {
         .defaultLaunchBehavior(.suppressed)
         .restorationBehavior(.disabled)
 
-        Window("Select Area", id: "area-selector") {
-            ContentView(role: .areaSelector)
-                .environmentObject(model)
-                .background(AppWindowActionBridge(appDelegate: appDelegate))
-        }
-        .windowStyle(.hiddenTitleBar)
-        .defaultLaunchBehavior(.suppressed)
-        .restorationBehavior(.disabled)
-        .defaultSize(width: 900, height: 600)
-
         Window("Open Recorder Editor", id: "studio") {
             ContentView(role: .studio)
                 .environmentObject(model)
@@ -261,8 +251,8 @@ struct OpenRecorderApp: App {
             }
 
             // Without this, SwiftUI auto-populates the "Window" menu with every declared
-            // Window scene by title, including internal tool windows like "Camera Bubble",
-            // "Select Area", and the capture selectors. Selecting one from that menu (or
+            // Window scene by title, including internal tool windows like "Camera Bubble"
+            // and the capture selectors. Selecting one from that menu (or
             // triggering it via Mission Control/window cycling) opens it directly, bypassing
             // requestWindow()'s includeCamera gating entirely.
             CommandGroup(replacing: .windowList) {}
@@ -393,7 +383,6 @@ final class AppWindowActions {
         case .showScreenRecordingSetup:
             unhideApp()
             dismissWindow("source-selector")
-            dismissWindow("area-selector")
             openWindow("hud")
         case .hideRecordingSetup:
             dismissCaptureWindows()
@@ -412,9 +401,6 @@ final class AppWindowActions {
             openWindow("camera-bubble")
         case .closeCameraBubble:
             dismissWindow("camera-bubble")
-        case .showAreaSelector:
-            unhideApp()
-            openWindow("area-selector")
         case .showStudio:
             facecamLog.notice("AppWindowActions.perform(.showStudio) hasSession=\(command.editorSession != nil, privacy: .public)")
             unhideApp()
@@ -428,15 +414,12 @@ final class AppWindowActions {
             activateApp()
         case .closeCaptureSetup:
             dismissWindow("source-selector")
-            dismissWindow("area-selector")
         case .closeSourceSelector:
             dismissWindow("source-selector")
         case .closeMicrophoneSelector:
             dismissWindow("microphone-selector")
         case .closeCameraSelector:
             dismissWindow("camera-selector")
-        case .closeAreaSelector:
-            dismissWindow("area-selector")
         }
     }
 
@@ -448,7 +431,6 @@ final class AppWindowActions {
         // Callers that genuinely need the HUD gone (e.g. .showStudio, once recording is
         // fully over) dismiss it explicitly themselves.
         dismissWindow("source-selector")
-        dismissWindow("area-selector")
         dismissWindow("microphone-selector")
         dismissWindow("camera-selector")
         if alwaysDismissCameraBubble || !shouldKeepCameraBubble() {

--- a/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
+++ b/apps/macos/Sources/OpenRecorderMac/WindowChrome.swift
@@ -10,7 +10,6 @@ enum NativeWindowRole {
     case microphoneSelector
     case cameraSelector
     case cameraBubble
-    case areaSelector
     case studio
 }
 
@@ -211,20 +210,17 @@ final class HUDHostWindowHidingView: NSView {
 struct WindowConfigurator: NSViewRepresentable {
     var role: NativeWindowRole
     var preferredSize: CGSize?
-    var isPresented = true
 
     func makeNSView(context: Context) -> WindowConfigurationView {
         let view = WindowConfigurationView()
         view.role = role
         view.preferredSize = preferredSize
-        view.isPresented = isPresented
         return view
     }
 
     func updateNSView(_ nsView: WindowConfigurationView, context: Context) {
         nsView.role = role
         nsView.preferredSize = preferredSize
-        nsView.isPresented = isPresented
         nsView.configureWindow()
     }
 }
@@ -246,8 +242,6 @@ final class WindowConfigurationView: NSView {
             }
         }
     }
-    var isPresented = true
-
     private var configuredRole: NativeWindowRole?
     private weak var configuredWindow: NSWindow?
     private weak var hudSpaceSyncWindow: NSWindow?
@@ -272,17 +266,6 @@ final class WindowConfigurationView: NSView {
             stopSyncingHUDToActiveSpace()
             return
         }
-        if role == .areaSelector {
-            guard isPresented else {
-                window.close()
-                return
-            }
-            configuredRole = role
-            configuredWindow = window
-            stopSyncingHUDToActiveSpace()
-            configureAreaSelector(window)
-            return
-        }
         guard configuredRole != role || configuredWindow !== window else { return }
         configuredRole = role
         configuredWindow = window
@@ -304,8 +287,6 @@ final class WindowConfigurationView: NSView {
             configureCameraSelector(window)
         case .cameraBubble:
             configureCameraBubble(window)
-        case .areaSelector:
-            configureAreaSelector(window)
         case .studio:
             configureStudio(window)
         }
@@ -453,29 +434,6 @@ final class WindowConfigurationView: NSView {
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
         window.standardWindowButton(.zoomButton)?.isHidden = true
         window.center()
-    }
-
-    private func configureAreaSelector(_ window: NSWindow) {
-        let screenFrame = (window.screen ?? NSScreen.main ?? NSScreen.screens.first)?.frame ?? NSRect(x: 0, y: 0, width: 900, height: 600)
-        window.title = "Select Area"
-        window.setFrame(screenFrame, display: true)
-        window.minSize = screenFrame.size
-        window.maxSize = screenFrame.size
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.hasShadow = false
-        window.level = .screenSaver
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        window.isMovableByWindowBackground = false
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-        window.styleMask = [.titled, .fullSizeContentView]
-        [.closeButton, .miniaturizeButton, .zoomButton].forEach { button in
-            window.standardWindowButton(button)?.isHidden = true
-        }
-        window.makeKeyAndOrderFront(nil)
-        window.orderFrontRegardless()
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func configureStudio(_ window: NSWindow) {
@@ -686,7 +644,6 @@ struct WindowCommandBridge: View {
         case .showScreenRecordingSetup:
             NSApp.unhide(nil)
             dismissWindow(id: "source-selector")
-            dismissWindow(id: "area-selector")
             openWindow(id: "hud")
             NSApp.activate(ignoringOtherApps: true)
         case .hideRecordingSetup:
@@ -706,9 +663,6 @@ struct WindowCommandBridge: View {
             openWindow(id: "camera-bubble")
         case .closeCameraBubble:
             dismissWindow(id: "camera-bubble")
-        case .showAreaSelector:
-            NSApp.unhide(nil)
-            openWindow(id: "area-selector")
         case .showStudio:
             facecamLog.notice("WindowCommandBridge.handle(.showStudio) hasSession=\(command.editorSession != nil, privacy: .public)")
             NSApp.unhide(nil)
@@ -722,15 +676,12 @@ struct WindowCommandBridge: View {
             NSApp.activate(ignoringOtherApps: true)
         case .closeCaptureSetup:
             dismissWindow(id: "source-selector")
-            dismissWindow(id: "area-selector")
         case .closeSourceSelector:
             dismissWindow(id: "source-selector")
         case .closeMicrophoneSelector:
             dismissWindow(id: "microphone-selector")
         case .closeCameraSelector:
             dismissWindow(id: "camera-selector")
-        case .closeAreaSelector:
-            dismissWindow(id: "area-selector")
         }
     }
 
@@ -742,7 +693,6 @@ struct WindowCommandBridge: View {
         // Callers that genuinely need the HUD gone (e.g. .showStudio, once recording is
         // fully over) dismiss it explicitly themselves.
         dismissWindow(id: "source-selector")
-        dismissWindow(id: "area-selector")
         dismissWindow(id: "microphone-selector")
         dismissWindow(id: "camera-selector")
         if alwaysDismissCameraBubble || !isCameraEnabled() {

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -238,7 +238,7 @@ final class AppModelStateTests: XCTestCase {
         model.requestInteractiveAreaSelection()
 
         XCTAssertEqual(model.hudState, .setup(.screenshot))
-        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertFalse(model.captureState.isAreaSelectionActive)
         XCTAssertEqual(model.statusMessage, CaptureBlocker.screenRecordingPermissionNeedsRestart.message)
         XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
@@ -345,7 +345,7 @@ final class AppModelStateTests: XCTestCase {
 
         XCTAssertEqual(model.hudState, .setup(.recording))
         XCTAssertEqual(model.captureFlow, .recordingSetup)
-        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertFalse(model.captureState.isAreaSelectionActive)
         XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
@@ -357,11 +357,11 @@ final class AppModelStateTests: XCTestCase {
 
         XCTAssertEqual(model.hudState, .setup(.screenshot))
         XCTAssertEqual(model.captureFlow, .screenshotSetup)
-        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertFalse(model.captureState.isAreaSelectionActive)
         XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
-    func testCancelReadySetupDoesNotLeaveSelectorOrAreaCloseCommand() {
+    func testCancelReadySetupDoesNotLeaveSelectorCloseCommand() {
         let model = AppModel()
         let source = makeSource()
         model.setCaptureStateForTesting(CaptureState(phase: .choosingMode, selectedSource: source))
@@ -372,7 +372,6 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(model.hudState, .setup(.recording, source: source))
         XCTAssertEqual(model.captureFlow, .recordingSetup)
         XCTAssertNotEqual(model.windowCommand?.action, .showSourceSelector)
-        XCTAssertNotEqual(model.windowCommand?.action, .closeAreaSelector)
         XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 
@@ -704,7 +703,7 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(presenter.dismissCallCount, 1)
     }
 
-    func testRequestingInteractiveAreaSelectionPresentsMultiScreenAreaPresenter() {
+    func testInteractiveAreaSelectionUsesOnlyMultiScreenPresenterAndRefocusesIt() {
         let presenter = AreaSelectionPresenterSpy()
         let model = AppModel(areaSelectionPresenter: presenter)
 
@@ -714,7 +713,15 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertEqual(presenter.presentCallCount, 1)
         XCTAssertEqual(presenter.presentedMode, .recording)
         XCTAssertEqual(model.hudState.phase, .areaSelecting(.recording))
-        XCTAssertTrue(model.isAreaSelectionActive)
+        XCTAssertTrue(model.captureState.isAreaSelectionActive)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+
+        let windowCommandID = model.windowCommand?.id
+        model.beginCapture(.screenshot)
+
+        XCTAssertEqual(presenter.focusCallCount, 1)
+        XCTAssertEqual(model.windowCommand?.id, windowCommandID)
+        XCTAssertEqual(model.hudState.phase, .areaSelecting(.recording))
     }
 
     func testCompletingInteractiveAreaSelectionDismissesAreaPresenter() {
@@ -729,7 +736,7 @@ final class AppModelStateTests: XCTestCase {
         model.completeInteractiveAreaSelection(area)
 
         XCTAssertEqual(presenter.dismissCallCount, 1)
-        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertFalse(model.captureState.isAreaSelectionActive)
         XCTAssertEqual(model.selectedSource?.area, area)
     }
 
@@ -744,7 +751,7 @@ final class AppModelStateTests: XCTestCase {
         model.cancelInteractiveAreaSelection()
 
         XCTAssertEqual(presenter.dismissCallCount, 1)
-        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertFalse(model.captureState.isAreaSelectionActive)
     }
 
     func testScreenshotEditorReleasesCaptureSlot() {
@@ -2063,7 +2070,7 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertTrue(actions.isInstalled)
         XCTAssertEqual(openedEditorSession, session)
         XCTAssertTrue(openedWindows.isEmpty)
-        XCTAssertEqual(dismissedWindows, ["hud", "source-selector", "area-selector", "microphone-selector", "camera-selector", "camera-bubble"])
+        XCTAssertEqual(dismissedWindows, ["hud", "source-selector", "microphone-selector", "camera-selector", "camera-bubble"])
         XCTAssertTrue(didUnhideApp)
     }
 
@@ -2164,7 +2171,7 @@ final class AppModelStateTests: XCTestCase {
 
         XCTAssertTrue(openedWindows.isEmpty)
         XCTAssertFalse(dismissedWindows.contains("hud"))
-        XCTAssertEqual(dismissedWindows, ["source-selector", "area-selector", "microphone-selector", "camera-selector", "camera-bubble"])
+        XCTAssertEqual(dismissedWindows, ["source-selector", "microphone-selector", "camera-selector", "camera-bubble"])
     }
 
     func testAppWindowActionsHideAppWindowsForCaptureDoesNotHideTheWholeAppOrTheHUD() {
@@ -2200,7 +2207,6 @@ final class AppModelStateTests: XCTestCase {
         XCTAssertFalse(dismissedWindows.contains("hud"))
         XCTAssertEqual(dismissedWindows, [
             "source-selector",
-            "area-selector",
             "microphone-selector",
             "camera-selector",
             "camera-bubble"
@@ -2222,7 +2228,7 @@ final class AppModelStateTests: XCTestCase {
         actions.perform(NativeWindowCommand(action: .showScreenRecordingSetup))
 
         XCTAssertEqual(openedWindows, ["hud"])
-        XCTAssertEqual(dismissedWindows, ["source-selector", "area-selector"])
+        XCTAssertEqual(dismissedWindows, ["source-selector"])
         XCTAssertFalse(openedWindows.contains("source-selector"))
     }
 
@@ -2260,7 +2266,7 @@ final class AppModelStateTests: XCTestCase {
         actions.perform(NativeWindowCommand(action: .closeCaptureSetup))
 
         XCTAssertTrue(openedWindows.isEmpty)
-        XCTAssertEqual(dismissedWindows, ["source-selector", "area-selector"])
+        XCTAssertEqual(dismissedWindows, ["source-selector"])
         XCTAssertFalse(dismissedWindows.contains("hud"))
     }
 
@@ -2402,6 +2408,7 @@ private final class ScreenSelectionPresenterSpy: ScreenSelectionPresenting {
 private final class AreaSelectionPresenterSpy: AreaSelectionPresenting {
     var presentedMode: CaptureMode?
     var presentCallCount = 0
+    var focusCallCount = 0
     var dismissCallCount = 0
     var onSelect: ((CaptureArea) -> Void)?
     var onCancel: (() -> Void)?
@@ -2415,6 +2422,10 @@ private final class AreaSelectionPresenterSpy: AreaSelectionPresenting {
         presentedMode = mode
         self.onSelect = onSelect
         self.onCancel = onCancel
+    }
+
+    func focus() {
+        focusCallCount += 1
     }
 
     func dismiss() {

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
@@ -219,7 +219,7 @@ final class CaptureStateReducerTests: XCTestCase {
 
         XCTAssertEqual(requested.state.phase, .areaSelecting(.screenshot))
         XCTAssertTrue(requested.state.isAreaSelectionActive)
-        XCTAssertEqual(requested.effects, [.showAreaSelector])
+        XCTAssertTrue(requested.effects.isEmpty)
 
         let completed = requested.state.applying(.completeInteractiveAreaSelection(areaSource))
         XCTAssertEqual(completed.state.phase, .setup(.screenshot))

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
@@ -215,7 +215,7 @@ final class HUDStateMachineTests: XCTestCase {
 
         XCTAssertEqual(model.hudState.phase, .areaSelecting(.screenshot))
         XCTAssertNil(model.selectedSource)
-        XCTAssertTrue(model.isAreaSelectionActive)
+        XCTAssertTrue(model.captureState.isAreaSelectionActive)
         XCTAssertFalse(model.canStartNewCapture)
 
         model.beginCapture(.recording)
@@ -223,15 +223,14 @@ final class HUDStateMachineTests: XCTestCase {
         XCTAssertEqual(model.hudState.phase, .areaSelecting(.screenshot))
         XCTAssertNil(model.selectedSource)
         XCTAssertEqual(model.captureMode, .screenshot)
-        XCTAssertEqual(model.windowCommand?.action, .showAreaSelector)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
 
         model.cancelInteractiveAreaSelection()
 
         XCTAssertEqual(model.hudState, .setup(.screenshot, preferredSourceKind: .area))
-        XCTAssertFalse(model.isAreaSelectionActive)
+        XCTAssertFalse(model.captureState.isAreaSelectionActive)
         XCTAssertTrue(model.canStartNewCapture)
         XCTAssertNotEqual(model.windowCommand?.action, .showSourceSelector)
-        XCTAssertNotEqual(model.windowCommand?.action, .closeAreaSelector)
         XCTAssertEqual(model.windowCommand?.action, .showHUD)
     }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
@@ -120,6 +120,43 @@ final class HUDWindowMetricsTests: XCTestCase {
         XCTAssertGreaterThan(AreaSelectionOverlayChrome.level.rawValue, NSWindow.Level.screenSaver.rawValue)
     }
 
+    @MainActor
+    func testDismissedAreaSelectionIgnoresQueuedScreenRebuild() async throws {
+        guard !NSScreen.screens.isEmpty else {
+            throw XCTSkip("Area overlay lifecycle requires an attached display.")
+        }
+        let controller = AreaSelectionOverlayController()
+        defer { controller.dismiss() }
+
+        controller.present(mode: .screenshot, onSelect: { _ in }, onCancel: {})
+        XCTAssertGreaterThan(controller.presentedWindowCountForTesting, 0)
+
+        NotificationCenter.default.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+        controller.dismiss()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(controller.presentedWindowCountForTesting, 0)
+    }
+
+    @MainActor
+    func testAreaSelectionFocusRestoresEveryOverlay() throws {
+        guard !NSScreen.screens.isEmpty else {
+            throw XCTSkip("Area overlay focus requires an attached display.")
+        }
+        let controller = AreaSelectionOverlayController()
+        defer { controller.dismiss() }
+
+        controller.present(mode: .screenshot, onSelect: { _ in }, onCancel: {})
+        let windows = controller.presentedWindowsForTesting
+        windows.forEach { $0.orderOut(nil) }
+        XCTAssertTrue(windows.allSatisfy { !$0.isVisible })
+
+        controller.focus()
+
+        XCTAssertTrue(windows.allSatisfy(\.isVisible))
+    }
+
     func testRecordingCountdownOverlayChromeCanCoverFullscreenSpaces() {
         let behavior = RecordingCountdownOverlayChrome.collectionBehavior
 


### PR DESCRIPTION
## Summary
- remove the legacy SwiftUI area-selector window so the multi-screen AppKit overlay is the only presentation path
- refocus the active area-selection overlay instead of opening another window
- prevent queued display-change callbacks from recreating dismissed overlays
- add regression coverage for single-path presentation, refocusing, and dismissal races

## Verification
- `make test-macos` — 31 Rust tests and 642 macOS tests passed
- `swift test --filter AreaSelection` — 17 focused tests passed
- `make build-macos`
- packaged Open Recorder Dev app — area selection showed one prompt and Escape returned to the HUD
- `git diff --check origin/main`