### PR TITLE
feat(macos): add native shortcut recorder

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -229,7 +229,9 @@ final class AppModel: ObservableObject {
     @Published private(set) var isTerminationPending = false
     @Published private(set) var activeRecordingStartDate: Date? = nil
     @Published private(set) var shortcutPreferences: ShortcutPreferences = .defaultPreferences
+    @Published private(set) var isShortcutRecorderActive = false
     @Published private(set) var isDragRecordingPending = false
+    private var shortcutRecorderActivationCount = 0
     private var displayFlashWindows: [NSWindow] = []
     private let countdownOverlayController: RecordingCountdownOverlayController
     private let captureUIHideDelayNanoseconds: UInt64
@@ -559,6 +561,9 @@ final class AppModel: ObservableObject {
                 self?.recordingPreferences.setShortcuts(shortcuts)
                 self?.shortcutPreferences = shortcuts
                 self?.objectWillChange.send()
+            },
+            setShortcutRecorderActive: { [weak self] isActive in
+                self?.setShortcutRecorderActive(isActive)
             },
             openFolder: { [weak self] path in
                 self?.openPath(path)
@@ -1305,6 +1310,17 @@ final class AppModel: ObservableObject {
         self.shortcutPreferences = shortcuts
         self.recordingPreferences.setShortcuts(shortcuts)
         self.appShell.settings.send(.shortcutsSynced(shortcuts))
+    }
+
+    func setShortcutRecorderActive(_ isActive: Bool) {
+        if isActive {
+            shortcutRecorderActivationCount += 1
+        } else {
+            shortcutRecorderActivationCount = max(0, shortcutRecorderActivationCount - 1)
+        }
+        let nextIsActive = shortcutRecorderActivationCount > 0
+        guard isShortcutRecorderActive != nextIsActive else { return }
+        isShortcutRecorderActive = nextIsActive
     }
 
     func requestWindow(_ action: NativeWindowCommandAction, editorSession: EditorSession? = nil) {

--- a/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppPresentationStateMachines.swift
@@ -786,6 +786,7 @@ final class SettingsDriver {
     @ObservationIgnored private var persistAutoZoomPreference: (Bool) -> Void = { _ in }
     @ObservationIgnored private var persistAutoZoomAnimationPreset: (TimelineZoomAnimationPreset) -> Void = { _ in }
     @ObservationIgnored private var persistShortcuts: (ShortcutPreferences) -> Void = { _ in }
+    @ObservationIgnored private var setShortcutRecorderActive: (Bool) -> Void = { _ in }
     @ObservationIgnored private var openFolder: (String) -> Void = { _ in }
     @ObservationIgnored private var openScreenRecordingSettings: () -> Void = {}
     @ObservationIgnored private var openAccessibilitySettings: () -> Void = {}
@@ -809,6 +810,7 @@ final class SettingsDriver {
         persistAutoZoomPreference: @escaping (Bool) -> Void = { _ in },
         persistAutoZoomAnimationPreset: @escaping (TimelineZoomAnimationPreset) -> Void = { _ in },
         persistShortcuts: @escaping (ShortcutPreferences) -> Void = { _ in },
+        setShortcutRecorderActive: @escaping (Bool) -> Void = { _ in },
         openFolder: @escaping (String) -> Void = { _ in },
         openScreenRecordingSettings: @escaping () -> Void = {},
         openAccessibilitySettings: @escaping () -> Void = {},
@@ -819,6 +821,7 @@ final class SettingsDriver {
         self.persistAutoZoomPreference = persistAutoZoomPreference
         self.persistAutoZoomAnimationPreset = persistAutoZoomAnimationPreset
         self.persistShortcuts = persistShortcuts
+        self.setShortcutRecorderActive = setShortcutRecorderActive
         self.openFolder = openFolder
         self.openScreenRecordingSettings = openScreenRecordingSettings
         self.openAccessibilitySettings = openAccessibilitySettings
@@ -855,6 +858,10 @@ final class SettingsDriver {
             get: { self.state.shortcuts.item(for: action) },
             set: { self.send(.shortcutItemChanged($0)) }
         )
+    }
+
+    func shortcutRecorderActive(_ isActive: Bool) {
+        setShortcutRecorderActive(isActive)
     }
 
     private func perform(_ effects: [SettingsEffect]) {

--- a/apps/macos/Sources/OpenRecorderMac/CaptureShortcuts.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureShortcuts.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon
 import Foundation
 
@@ -44,46 +45,6 @@ public enum CaptureShortcutAction: String, CaseIterable, Identifiable, Codable, 
             return KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option, .shift])
         }
     }
-
-    public var availablePresets: [KeyCombination] {
-        switch self {
-        case .deviceScreenshot:
-            return [
-                KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.option, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.command, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_3), modifiers: [.control, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_S), modifiers: [.option, .shift])
-            ]
-        case .dragScreenshot:
-            return [
-                KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.option, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.command, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_4), modifiers: [.control, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_A), modifiers: [.option, .shift])
-            ]
-        case .deviceScreenRecord:
-            return [
-                KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.option, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.command, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_5), modifiers: [.control, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option, .shift])
-            ]
-        case .dragScreenRecord:
-            return [
-                KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.option, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.command, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_6), modifiers: [.control, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_D), modifiers: [.option, .shift])
-            ]
-        case .toggleRecording:
-            return [
-                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.command]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.command, .shift]),
-                KeyCombination(keyCode: UInt32(kVK_ANSI_R), modifiers: [.option])
-            ]
-        }
-    }
 }
 
 public struct ShortcutModifiers: OptionSet, Codable, Equatable, Hashable, Sendable {
@@ -105,6 +66,24 @@ public struct ShortcutModifiers: OptionSet, Codable, Equatable, Hashable, Sendab
         if contains(.shift) { s += "⇧" }
         if contains(.command) { s += "⌘" }
         return s
+    }
+
+    init(eventModifierFlags: NSEvent.ModifierFlags) {
+        var modifiers: ShortcutModifiers = []
+        if eventModifierFlags.contains(.command) { modifiers.insert(.command) }
+        if eventModifierFlags.contains(.shift) { modifiers.insert(.shift) }
+        if eventModifierFlags.contains(.option) { modifiers.insert(.option) }
+        if eventModifierFlags.contains(.control) { modifiers.insert(.control) }
+        self = modifiers
+    }
+
+    var eventModifierFlags: NSEvent.ModifierFlags {
+        var flags: NSEvent.ModifierFlags = []
+        if contains(.command) { flags.insert(.command) }
+        if contains(.shift) { flags.insert(.shift) }
+        if contains(.option) { flags.insert(.option) }
+        if contains(.control) { flags.insert(.control) }
+        return flags
     }
 }
 
@@ -135,6 +114,10 @@ public struct KeyCombination: Codable, Equatable, Hashable, Identifiable, Sendab
     }
 
     public static func keyString(for keyCode: UInt32) -> String {
+        keyLabel(for: keyCode) ?? "Key(\(keyCode))"
+    }
+
+    static func keyLabel(for keyCode: UInt32) -> String? {
         switch Int(keyCode) {
         case kVK_ANSI_0: return "0"
         case kVK_ANSI_1: return "1"
@@ -172,10 +155,216 @@ public struct KeyCombination: Codable, Equatable, Hashable, Identifiable, Sendab
         case kVK_ANSI_X: return "X"
         case kVK_ANSI_Y: return "Y"
         case kVK_ANSI_Z: return "Z"
+        case kVK_ANSI_Equal: return "="
+        case kVK_ANSI_Minus: return "-"
+        case kVK_ANSI_RightBracket: return "]"
+        case kVK_ANSI_LeftBracket: return "["
+        case kVK_ANSI_Quote: return "'"
+        case kVK_ANSI_Semicolon: return ";"
+        case kVK_ANSI_Backslash: return "\\"
+        case kVK_ANSI_Comma: return ","
+        case kVK_ANSI_Slash: return "/"
+        case kVK_ANSI_Period: return "."
+        case kVK_ANSI_Grave: return "`"
+        case kVK_ANSI_KeypadDecimal: return "⌨."
+        case kVK_ANSI_KeypadMultiply: return "⌨×"
+        case kVK_ANSI_KeypadPlus: return "⌨+"
+        case kVK_ANSI_KeypadClear: return "⌨Clear"
+        case kVK_ANSI_KeypadDivide: return "⌨÷"
+        case kVK_ANSI_KeypadEnter: return "⌨↩"
+        case kVK_ANSI_KeypadMinus: return "⌨−"
+        case kVK_ANSI_KeypadEquals: return "⌨="
+        case kVK_ANSI_Keypad0: return "⌨0"
+        case kVK_ANSI_Keypad1: return "⌨1"
+        case kVK_ANSI_Keypad2: return "⌨2"
+        case kVK_ANSI_Keypad3: return "⌨3"
+        case kVK_ANSI_Keypad4: return "⌨4"
+        case kVK_ANSI_Keypad5: return "⌨5"
+        case kVK_ANSI_Keypad6: return "⌨6"
+        case kVK_ANSI_Keypad7: return "⌨7"
+        case kVK_ANSI_Keypad8: return "⌨8"
+        case kVK_ANSI_Keypad9: return "⌨9"
         case kVK_Space: return "Space"
         case kVK_Return: return "↩"
-        default: return "Key(\(keyCode))"
+        case kVK_Tab: return "⇥"
+        case kVK_Delete: return "⌫"
+        case kVK_Escape: return "⎋"
+        case kVK_ForwardDelete: return "⌦"
+        case kVK_Help: return "Help"
+        case kVK_Home: return "↖"
+        case kVK_End: return "↘"
+        case kVK_PageUp: return "⇞"
+        case kVK_PageDown: return "⇟"
+        case kVK_LeftArrow: return "←"
+        case kVK_RightArrow: return "→"
+        case kVK_DownArrow: return "↓"
+        case kVK_UpArrow: return "↑"
+        case kVK_F1: return "F1"
+        case kVK_F2: return "F2"
+        case kVK_F3: return "F3"
+        case kVK_F4: return "F4"
+        case kVK_F5: return "F5"
+        case kVK_F6: return "F6"
+        case kVK_F7: return "F7"
+        case kVK_F8: return "F8"
+        case kVK_F9: return "F9"
+        case kVK_F10: return "F10"
+        case kVK_F11: return "F11"
+        case kVK_F12: return "F12"
+        case kVK_F13: return "F13"
+        case kVK_F14: return "F14"
+        case kVK_F15: return "F15"
+        case kVK_F16: return "F16"
+        case kVK_F17: return "F17"
+        case kVK_F18: return "F18"
+        case kVK_F19: return "F19"
+        case kVK_F20: return "F20"
+        default: return nil
         }
+    }
+
+    static func isFunctionKey(_ keyCode: UInt32) -> Bool {
+        switch Int(keyCode) {
+        case kVK_F1, kVK_F2, kVK_F3, kVK_F4, kVK_F5,
+             kVK_F6, kVK_F7, kVK_F8, kVK_F9, kVK_F10,
+             kVK_F11, kVK_F12, kVK_F13, kVK_F14, kVK_F15,
+             kVK_F16, kVK_F17, kVK_F18, kVK_F19, kVK_F20:
+            true
+        default:
+            false
+        }
+    }
+}
+
+struct ShortcutCapturedKey: Equatable {
+    var combination: KeyCombination
+    var charactersIgnoringModifiers: String
+
+    init(combination: KeyCombination, charactersIgnoringModifiers: String) {
+        self.combination = combination
+        self.charactersIgnoringModifiers = charactersIgnoringModifiers
+    }
+
+    init(event: NSEvent) {
+        combination = KeyCombination(
+            keyCode: UInt32(event.keyCode),
+            modifiers: ShortcutModifiers(eventModifierFlags: event.modifierFlags)
+        )
+        charactersIgnoringModifiers = event.charactersIgnoringModifiers ?? event.characters ?? ""
+    }
+}
+
+enum ShortcutCaptureValidationError: Equatable {
+    case unsupportedKey
+    case missingRequiredModifier
+    case duplicate(CaptureShortcutAction)
+    case applicationMenu(String)
+    case unavailable
+
+    var message: String {
+        switch self {
+        case .unsupportedKey:
+            "That key cannot be used as a global shortcut."
+        case .missingRequiredModifier:
+            "Add Command, Control, or Option. Function keys can be used on their own."
+        case .duplicate(let action):
+            "Already used by \(action.title)."
+        case .applicationMenu(let title):
+            "Already used by the \(title) menu command."
+        case .unavailable:
+            "That shortcut is reserved by macOS or another application."
+        }
+    }
+}
+
+enum ShortcutCapturePolicy {
+    static func isCancelKey(_ keyCode: UInt32) -> Bool {
+        keyCode == UInt32(kVK_Escape)
+    }
+
+    static func validationError(for combination: KeyCombination) -> ShortcutCaptureValidationError? {
+        guard !isCancelKey(combination.keyCode),
+              KeyCombination.keyLabel(for: combination.keyCode) != nil else {
+            return .unsupportedKey
+        }
+
+        if KeyCombination.isFunctionKey(combination.keyCode) {
+            return nil
+        }
+
+        let requiredModifiers: ShortcutModifiers = [.command, .control, .option]
+        guard !combination.modifiers.intersection(requiredModifiers).isEmpty else {
+            return .missingRequiredModifier
+        }
+        return nil
+    }
+}
+
+struct ShortcutRecorderSession: Equatable {
+    enum Phase: Equatable {
+        case idle
+        case recording(CaptureShortcutAction)
+        case awaitingRelease(CaptureShortcutAction, keyCode: UInt32)
+    }
+
+    private(set) var phase: Phase = .idle
+    private(set) var previewModifiers: ShortcutModifiers = []
+    private(set) var errorMessage: String?
+
+    var activeAction: CaptureShortcutAction? {
+        switch phase {
+        case .idle: nil
+        case .recording(let action), .awaitingRelease(let action, _): action
+        }
+    }
+
+    var isActive: Bool { activeAction != nil }
+
+    func isRecording(_ action: CaptureShortcutAction) -> Bool {
+        activeAction == action
+    }
+
+    func isAwaitingRelease(_ action: CaptureShortcutAction) -> Bool {
+        guard case .awaitingRelease(let activeAction, _) = phase else { return false }
+        return activeAction == action
+    }
+
+    mutating func begin(_ action: CaptureShortcutAction) {
+        phase = .recording(action)
+        previewModifiers = []
+        errorMessage = nil
+    }
+
+    mutating func updateModifiers(_ modifiers: ShortcutModifiers) {
+        guard case .recording = phase else { return }
+        previewModifiers = modifiers
+    }
+
+    mutating func reject(_ error: ShortcutCaptureValidationError) {
+        guard case .recording = phase else { return }
+        errorMessage = error.message
+    }
+
+    mutating func accept(_ combination: KeyCombination) {
+        guard case .recording(let action) = phase else { return }
+        phase = .awaitingRelease(action, keyCode: combination.keyCode)
+        previewModifiers = combination.modifiers
+        errorMessage = nil
+    }
+
+    mutating func completeKeyRelease(_ keyCode: UInt32) -> Bool {
+        guard case .awaitingRelease(_, let expectedKeyCode) = phase,
+              expectedKeyCode == keyCode else {
+            return false
+        }
+        cancel()
+        return true
+    }
+
+    mutating func cancel() {
+        phase = .idle
+        previewModifiers = []
+        errorMessage = nil
     }
 }
 
@@ -212,5 +401,109 @@ public struct ShortcutPreferences: Codable, Equatable, Sendable {
 
     public mutating func setItem(_ item: ShortcutItem) {
         shortcuts[item.id] = item
+    }
+
+    func conflictingAction(
+        for combination: KeyCombination,
+        excluding action: CaptureShortcutAction
+    ) -> CaptureShortcutAction? {
+        CaptureShortcutAction.allCases.first { candidateAction in
+            guard candidateAction != action else { return false }
+            let candidate = item(for: candidateAction)
+            return candidate.keyCombination == combination
+        }
+    }
+}
+
+@MainActor
+struct ShortcutAvailabilityValidator {
+    var canRegister: @MainActor (KeyCombination) -> Bool
+
+    init(canRegister: @escaping @MainActor (KeyCombination) -> Bool = GlobalShortcutAvailability.canRegister) {
+        self.canRegister = canRegister
+    }
+
+    func validationError(
+        for capturedKey: ShortcutCapturedKey,
+        editing action: CaptureShortcutAction,
+        preferences: ShortcutPreferences,
+        applicationMenu: NSMenu? = NSApp.mainMenu
+    ) -> ShortcutCaptureValidationError? {
+        let combination = capturedKey.combination
+        if let error = ShortcutCapturePolicy.validationError(for: combination) {
+            return error
+        }
+        if let conflictingAction = preferences.conflictingAction(for: combination, excluding: action) {
+            return .duplicate(conflictingAction)
+        }
+        if let item = matchingMenuItem(
+            in: applicationMenu,
+            charactersIgnoringModifiers: capturedKey.charactersIgnoringModifiers,
+            modifiers: combination.modifiers.eventModifierFlags
+        ) {
+            return .applicationMenu(item.title)
+        }
+        guard canRegister(combination) else {
+            return .unavailable
+        }
+        return nil
+    }
+
+    private func matchingMenuItem(
+        in menu: NSMenu?,
+        charactersIgnoringModifiers: String,
+        modifiers: NSEvent.ModifierFlags
+    ) -> NSMenuItem? {
+        guard let menu else { return nil }
+        let relevantFlags: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+        let normalizedCharacters = charactersIgnoringModifiers.lowercased()
+
+        for item in menu.items {
+            if let match = matchingMenuItem(
+                in: item.submenu,
+                charactersIgnoringModifiers: charactersIgnoringModifiers,
+                modifiers: modifiers
+            ) {
+                return match
+            }
+
+            guard item.isEnabled,
+                  !item.isHidden,
+                  !item.keyEquivalent.isEmpty,
+                  item.keyEquivalent.lowercased() == normalizedCharacters,
+                  item.keyEquivalentModifierMask.intersection(relevantFlags)
+                    == modifiers.intersection(relevantFlags) else {
+                continue
+            }
+            return item
+        }
+        return nil
+    }
+}
+
+@MainActor
+private enum GlobalShortcutAvailability {
+    static func canRegister(_ combination: KeyCombination) -> Bool {
+        var hotKeyRef: EventHotKeyRef?
+        let hotKeyID = EventHotKeyID(signature: fourCharCode("ORvr"), id: UInt32.max)
+        let status = RegisterEventHotKey(
+            combination.keyCode,
+            combination.carbonModifiers,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        return status == noErr
+    }
+
+    private static func fourCharCode(_ string: String) -> OSType {
+        string.utf8.reduce(0) { result, character in
+            (result << 8) + OSType(character)
+        }
     }
 }

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderApp.swift
@@ -648,6 +648,20 @@ final class OpenRecorderStatusItemController: NSObject {
     }
 }
 
+enum GlobalRecordingHotKeyRegistrationPolicy {
+    static func shouldRegister(
+        action: CaptureShortcutAction,
+        item: ShortcutItem,
+        captureState: CaptureState,
+        runtimeIsRecording: Bool,
+        shortcutRecorderIsActive: Bool
+    ) -> Bool {
+        guard item.isEnabled, !shortcutRecorderIsActive else { return false }
+        guard action == .toggleRecording else { return true }
+        return captureState.shouldRegisterRecordingHotKey(runtimeIsRecording: runtimeIsRecording)
+    }
+}
+
 @MainActor
 private final class GlobalRecordingHotKeyController {
     private weak var model: AppModel?
@@ -661,7 +675,8 @@ private final class GlobalRecordingHotKeyController {
             syncRegistration(
                 captureState: model.captureState,
                 runtimeIsRecording: model.capture.isRecording,
-                shortcuts: model.shortcutPreferences
+                shortcuts: model.shortcutPreferences,
+                shortcutRecorderIsActive: model.isShortcutRecorderActive
             )
             return
         }
@@ -676,7 +691,8 @@ private final class GlobalRecordingHotKeyController {
                 self?.syncRegistration(
                     captureState: state,
                     runtimeIsRecording: model.capture.isRecording,
-                    shortcuts: model.shortcutPreferences
+                    shortcuts: model.shortcutPreferences,
+                    shortcutRecorderIsActive: model.isShortcutRecorderActive
                 )
             }
             .store(in: &cancellables)
@@ -687,7 +703,8 @@ private final class GlobalRecordingHotKeyController {
                 self?.syncRegistration(
                     captureState: model.captureState,
                     runtimeIsRecording: isRecording,
-                    shortcuts: model.shortcutPreferences
+                    shortcuts: model.shortcutPreferences,
+                    shortcutRecorderIsActive: model.isShortcutRecorderActive
                 )
             }
             .store(in: &cancellables)
@@ -698,7 +715,20 @@ private final class GlobalRecordingHotKeyController {
                 self?.syncRegistration(
                     captureState: model.captureState,
                     runtimeIsRecording: model.capture.isRecording,
-                    shortcuts: shortcuts
+                    shortcuts: shortcuts,
+                    shortcutRecorderIsActive: model.isShortcutRecorderActive
+                )
+            }
+            .store(in: &cancellables)
+
+        model.$isShortcutRecorderActive
+            .sink { [weak self, weak model] isActive in
+                guard let model else { return }
+                self?.syncRegistration(
+                    captureState: model.captureState,
+                    runtimeIsRecording: model.capture.isRecording,
+                    shortcuts: model.shortcutPreferences,
+                    shortcutRecorderIsActive: isActive
                 )
             }
             .store(in: &cancellables)
@@ -706,14 +736,16 @@ private final class GlobalRecordingHotKeyController {
         syncRegistration(
             captureState: model.captureState,
             runtimeIsRecording: model.capture.isRecording,
-            shortcuts: model.shortcutPreferences
+            shortcuts: model.shortcutPreferences,
+            shortcutRecorderIsActive: model.isShortcutRecorderActive
         )
     }
 
     private func syncRegistration(
         captureState: CaptureState,
         runtimeIsRecording: Bool,
-        shortcuts: ShortcutPreferences
+        shortcuts: ShortcutPreferences,
+        shortcutRecorderIsActive: Bool
     ) {
         guard installEventHandlerIfNeeded() else { return }
 
@@ -727,14 +759,13 @@ private final class GlobalRecordingHotKeyController {
 
         for (id, action) in actionMap {
             let item = shortcuts.item(for: action)
-            let isAllowedByCaptureState: Bool
-            if action == .toggleRecording {
-                isAllowedByCaptureState = captureState.shouldRegisterRecordingHotKey(runtimeIsRecording: runtimeIsRecording)
-            } else {
-                isAllowedByCaptureState = true
-            }
-
-            if item.isEnabled && isAllowedByCaptureState {
+            if GlobalRecordingHotKeyRegistrationPolicy.shouldRegister(
+                action: action,
+                item: item,
+                captureState: captureState,
+                runtimeIsRecording: runtimeIsRecording,
+                shortcutRecorderIsActive: shortcutRecorderIsActive
+            ) {
                 registerIfNeeded(id: id, combination: item.keyCombination)
             } else {
                 unregister(id: id)
@@ -818,7 +849,7 @@ private final class GlobalRecordingHotKeyController {
     }
 
     private func handleHotKey(id: UInt32) {
-        guard let model else { return }
+        guard let model, !model.isShortcutRecorderActive else { return }
         switch id {
         case 1:
             model.toggleRecordingShortcut()

--- a/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SettingsStudioViews.swift
@@ -159,50 +159,119 @@ private struct SettingsGeneralPane: View {
 }
 
 private struct SettingsShortcutsPane: View {
+    @State private var recorderSession = ShortcutRecorderSession()
+
     var driver: SettingsDriver
 
     var body: some View {
         SettingsSection(title: "Global Shortcuts") {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text("Use Open Recorder's quick shortcuts from any application to capture screens and recordings.")
                     .font(.system(size: 12))
                     .foregroundStyle(Theme.fgMuted)
-                    .padding(.bottom, 4)
+                    .padding(.bottom, 10)
 
-                SettingsShortcutRow(
-                    action: .deviceScreenshot,
-                    item: driver.shortcutBinding(for: .deviceScreenshot)
-                )
-                Divider().overlay(Color.white.opacity(0.06))
-                SettingsShortcutRow(
-                    action: .dragScreenshot,
-                    item: driver.shortcutBinding(for: .dragScreenshot)
-                )
-                Divider().overlay(Color.white.opacity(0.06))
-                SettingsShortcutRow(
-                    action: .deviceScreenRecord,
-                    item: driver.shortcutBinding(for: .deviceScreenRecord)
-                )
-                Divider().overlay(Color.white.opacity(0.06))
-                SettingsShortcutRow(
-                    action: .dragScreenRecord,
-                    item: driver.shortcutBinding(for: .dragScreenRecord)
-                )
-                Divider().overlay(Color.white.opacity(0.06))
-                SettingsShortcutRow(
-                    action: .toggleRecording,
-                    item: driver.shortcutBinding(for: .toggleRecording)
-                )
+                ForEach(CaptureShortcutAction.allCases) { action in
+                    if action != CaptureShortcutAction.allCases.first {
+                        Divider().overlay(Color.white.opacity(0.06))
+                    }
+
+                    SettingsShortcutRow(
+                        action: action,
+                        item: driver.shortcutBinding(for: action),
+                        isRecording: recorderSession.isRecording(action),
+                        isAwaitingRelease: recorderSession.isAwaitingRelease(action),
+                        previewModifiers: recorderSession.previewModifiers,
+                        errorMessage: recorderSession.isRecording(action) ? recorderSession.errorMessage : nil,
+                        onRecordRequested: { toggleRecording(for: action) },
+                        onRecordingCancelled: cancelRecording
+                    )
+                }
 
                 Button("Restore Default Shortcuts") {
+                    cancelRecording()
                     driver.send(.shortcutsResetToDefaults)
                 }
                 .buttonStyle(.borderless)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(Theme.accent)
                 .frame(maxWidth: .infinity, alignment: .trailing)
-                .padding(.top, 4)
+                .padding(.top, 10)
             }
+        }
+        .background {
+            SettingsShortcutEventMonitor(
+                isEnabled: recorderSession.isActive,
+                handler: handleRecorderEvent,
+                windowDidResignKey: cancelRecording
+            )
+            .frame(width: 0, height: 0)
+        }
+        .onDisappear(perform: cancelRecording)
+    }
+
+    private func toggleRecording(for action: CaptureShortcutAction) {
+        if recorderSession.isRecording(action) {
+            cancelRecording()
+            return
+        }
+
+        let wasActive = recorderSession.isActive
+        recorderSession.begin(action)
+        if !wasActive {
+            driver.shortcutRecorderActive(true)
+        }
+    }
+
+    private func cancelRecording() {
+        guard recorderSession.isActive else { return }
+        recorderSession.cancel()
+        driver.shortcutRecorderActive(false)
+    }
+
+    private func handleRecorderEvent(_ event: NSEvent) -> Bool {
+        guard recorderSession.isActive else { return false }
+
+        switch event.type {
+        case .flagsChanged:
+            recorderSession.updateModifiers(ShortcutModifiers(eventModifierFlags: event.modifierFlags))
+            return true
+
+        case .keyDown:
+            if ShortcutCapturePolicy.isCancelKey(UInt32(event.keyCode)) {
+                cancelRecording()
+                return true
+            }
+            guard !event.isARepeat,
+                  case .recording(let action) = recorderSession.phase else {
+                return true
+            }
+
+            let capturedKey = ShortcutCapturedKey(event: event)
+            let validator = ShortcutAvailabilityValidator()
+            if let error = validator.validationError(
+                for: capturedKey,
+                editing: action,
+                preferences: driver.state.shortcuts
+            ) {
+                recorderSession.reject(error)
+                return true
+            }
+
+            var updatedItem = driver.state.shortcuts.item(for: action)
+            updatedItem.keyCombination = capturedKey.combination
+            recorderSession.accept(capturedKey.combination)
+            driver.send(.shortcutItemChanged(updatedItem))
+            return true
+
+        case .keyUp:
+            if recorderSession.completeKeyRelease(UInt32(event.keyCode)) {
+                driver.shortcutRecorderActive(false)
+            }
+            return true
+
+        default:
+            return false
         }
     }
 }
@@ -261,62 +330,205 @@ private struct SettingsSystemPane: View {
 private struct SettingsShortcutRow: View {
     var action: CaptureShortcutAction
     @Binding var item: ShortcutItem
+    var isRecording: Bool
+    var isAwaitingRelease: Bool
+    var previewModifiers: ShortcutModifiers
+    var errorMessage: String?
+    var onRecordRequested: () -> Void
+    var onRecordingCancelled: () -> Void
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(alignment: .top, spacing: 18) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(action.title)
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(item.isEnabled ? Theme.fg : Theme.fgMuted)
                 Text(action.subtitle)
                     .font(.system(size: 11))
                     .foregroundStyle(Theme.fgMuted.opacity(0.8))
+                    .fixedSize(horizontal: false, vertical: true)
             }
+            .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
 
-            Spacer(minLength: 8)
-
-            Menu {
-                ForEach(action.availablePresets) { preset in
-                    Button {
-                        item.keyCombination = preset
-                        item.isEnabled = true
-                    } label: {
-                        HStack {
-                            Text(preset.displayString)
-                            if item.keyCombination == preset {
-                                Image(systemName: "checkmark")
-                            }
+            VStack(alignment: .leading, spacing: 5) {
+                Button(action: onRecordRequested) {
+                    HStack(spacing: 7) {
+                        Image(systemName: isRecording ? "record.circle.fill" : "keyboard")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(isRecording ? Theme.accent : Theme.fgMuted)
+                            .accessibilityHidden(true)
+                        Text(recorderLabel)
+                            .font(.system(size: 12, weight: .bold, design: .monospaced))
+                            .foregroundStyle(item.isEnabled ? Color.white : Theme.fgMuted)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                        if !isRecording {
+                            Image(systemName: "pencil")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(Theme.fgMuted)
+                                .accessibilityHidden(true)
                         }
                     }
+                    .padding(.horizontal, 11)
+                    .frame(height: 34)
+                    .background(recorderBackground, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .stroke(recorderBorder, lineWidth: isRecording ? 1.5 : 1)
+                    }
                 }
-            } label: {
-                HStack(spacing: 5) {
-                    Text(item.keyCombination.displayString)
-                        .font(.system(size: 12, weight: .bold, design: .monospaced))
-                        .foregroundStyle(item.isEnabled ? Color.white : Theme.fgMuted)
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(Theme.fgMuted)
-                }
-                .padding(.horizontal, 9)
-                .padding(.vertical, 4)
-                .background(item.isEnabled ? Color.white.opacity(0.12) : Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .stroke(item.isEnabled ? Color.white.opacity(0.22) : Color.white.opacity(0.08), lineWidth: 1)
+                .buttonStyle(.plain)
+                .disabled(!item.isEnabled)
+                .accessibilityLabel("Change shortcut for \(action.title)")
+                .accessibilityValue(isRecording ? recorderLabel : item.keyCombination.displayString)
+                .accessibilityHint(isRecording ? "Press a shortcut. Press Escape to cancel." : "Press to record a new shortcut.")
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(Color.red.opacity(0.9))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityLabel("Shortcut error: \(errorMessage)")
                 }
             }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            .disabled(!item.isEnabled)
+            .frame(width: 210, alignment: .leading)
 
-            Toggle("", isOn: $item.isEnabled)
+            Toggle("", isOn: enabledBinding)
                 .toggleStyle(.switch)
                 .tint(Theme.accent)
                 .labelsHidden()
                 .controlSize(.small)
+                .padding(.top, 7)
+                .accessibilityLabel("Enable \(action.title) shortcut")
         }
-        .padding(.vertical, 3)
+        .padding(.vertical, 9)
+    }
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { item.isEnabled },
+            set: { isEnabled in
+                item.isEnabled = isEnabled
+                if !isEnabled && isRecording {
+                    onRecordingCancelled()
+                }
+            }
+        )
+    }
+
+    private var recorderLabel: String {
+        guard isRecording else { return item.keyCombination.displayString }
+        if isAwaitingRelease {
+            return item.keyCombination.displayString
+        }
+        let modifiers = previewModifiers.displayString
+        return modifiers.isEmpty ? "Press shortcut…" : "\(modifiers)…"
+    }
+
+    private var recorderBackground: Color {
+        if isRecording {
+            return Theme.accent.opacity(0.16)
+        }
+        return item.isEnabled ? Color.white.opacity(0.10) : Color.white.opacity(0.04)
+    }
+
+    private var recorderBorder: Color {
+        if isRecording {
+            return Theme.accent.opacity(0.9)
+        }
+        return item.isEnabled ? Color.white.opacity(0.20) : Color.white.opacity(0.07)
+    }
+}
+
+private struct SettingsShortcutEventMonitor: NSViewRepresentable {
+    var isEnabled: Bool
+    var handler: (NSEvent) -> Bool
+    var windowDidResignKey: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(handler: handler, windowDidResignKey: windowDidResignKey)
+    }
+
+    func makeNSView(context: Context) -> StudioKeyMonitorAttachmentView {
+        let view = StudioKeyMonitorAttachmentView(frame: .zero)
+        context.coordinator.view = view
+        context.coordinator.handler = handler
+        context.coordinator.windowDidResignKey = windowDidResignKey
+        context.coordinator.isEnabled = isEnabled
+        context.coordinator.install()
+        return view
+    }
+
+    func updateNSView(_ nsView: StudioKeyMonitorAttachmentView, context: Context) {
+        context.coordinator.view = nsView
+        context.coordinator.handler = handler
+        context.coordinator.windowDidResignKey = windowDidResignKey
+        context.coordinator.isEnabled = isEnabled
+        context.coordinator.install()
+    }
+
+    static func dismantleNSView(_ nsView: StudioKeyMonitorAttachmentView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    final class Coordinator: NSObject {
+        weak var view: StudioKeyMonitorAttachmentView?
+        var handler: (NSEvent) -> Bool
+        var windowDidResignKey: () -> Void
+        var isEnabled = false
+        private var monitor: Any?
+
+        init(handler: @escaping (NSEvent) -> Bool, windowDidResignKey: @escaping () -> Void) {
+            self.handler = handler
+            self.windowDidResignKey = windowDidResignKey
+        }
+
+        func install() {
+            guard monitor == nil else { return }
+            let mask: NSEvent.EventTypeMask = [.keyDown, .keyUp, .flagsChanged]
+            monitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+                guard let self,
+                      let view = self.view,
+                      let windowScope = view.windowScope.snapshot(),
+                      StudioKeyEventScope.shouldHandle(
+                          isEnabled: self.isEnabled,
+                          ownerWindowNumber: windowScope.windowNumber,
+                          eventWindowNumber: event.windowNumber,
+                          ownerWindowIsKey: windowScope.isKey
+                      ) else {
+                    return event
+                }
+                return self.handler(event) ? nil : event
+            }
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(ownerWindowDidResignKey(_:)),
+                name: NSWindow.didResignKeyNotification,
+                object: nil
+            )
+        }
+
+        func uninstall() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            monitor = nil
+            NotificationCenter.default.removeObserver(self)
+        }
+
+        @MainActor @objc private func ownerWindowDidResignKey(_ notification: Notification) {
+            guard isEnabled,
+                  let ownerWindow = view?.window,
+                  let resignedWindow = notification.object as? NSWindow,
+                  ownerWindow === resignedWindow else {
+                return
+            }
+            windowDidResignKey()
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
     }
 }
 

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureShortcutsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureShortcutsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon
 import XCTest
 @testable import OpenRecorderMac
@@ -37,6 +38,181 @@ final class CaptureShortcutsTests: XCTestCase {
         XCTAssertEqual(combo.carbonModifiers, expectedCarbon)
     }
 
+    func testKeyCombinationDisplaysSpecialAndKeypadKeys() {
+        XCTAssertEqual(KeyCombination(keyCode: UInt32(kVK_F12), modifiers: []).displayString, "F12")
+        XCTAssertEqual(KeyCombination(keyCode: UInt32(kVK_LeftArrow), modifiers: [.control]).displayString, "⌃←")
+        XCTAssertEqual(KeyCombination(keyCode: UInt32(kVK_ANSI_Slash), modifiers: [.command]).displayString, "⌘/")
+        XCTAssertEqual(KeyCombination(keyCode: UInt32(kVK_ANSI_Keypad7), modifiers: [.option]).displayString, "⌥⌨7")
+    }
+
+    func testShortcutCapturePolicyAcceptsSafeGlobalChords() {
+        XCTAssertNil(ShortcutCapturePolicy.validationError(for: KeyCombination(
+            keyCode: UInt32(kVK_ANSI_K),
+            modifiers: [.command]
+        )))
+        XCTAssertNil(ShortcutCapturePolicy.validationError(for: KeyCombination(
+            keyCode: UInt32(kVK_ANSI_3),
+            modifiers: [.option, .shift]
+        )))
+        XCTAssertNil(ShortcutCapturePolicy.validationError(for: KeyCombination(
+            keyCode: UInt32(kVK_F12),
+            modifiers: []
+        )))
+    }
+
+    func testShortcutCapturePolicyRejectsUnsafeOrUnsupportedChords() {
+        XCTAssertEqual(
+            ShortcutCapturePolicy.validationError(for: KeyCombination(
+                keyCode: UInt32(kVK_ANSI_K),
+                modifiers: []
+            )),
+            .missingRequiredModifier
+        )
+        XCTAssertEqual(
+            ShortcutCapturePolicy.validationError(for: KeyCombination(
+                keyCode: UInt32(kVK_ANSI_K),
+                modifiers: [.shift]
+            )),
+            .missingRequiredModifier
+        )
+        XCTAssertEqual(
+            ShortcutCapturePolicy.validationError(for: KeyCombination(
+                keyCode: UInt32(kVK_Command),
+                modifiers: [.command]
+            )),
+            .unsupportedKey
+        )
+        XCTAssertTrue(ShortcutCapturePolicy.isCancelKey(UInt32(kVK_Escape)))
+    }
+
+    func testShortcutModifierFlagsNormalizeToSupportedModifiers() {
+        let modifiers = ShortcutModifiers(eventModifierFlags: [.capsLock, .command, .shift, .numericPad])
+
+        XCTAssertEqual(modifiers, [.command, .shift])
+        XCTAssertEqual(modifiers.eventModifierFlags, [.command, .shift])
+    }
+
+    func testShortcutPreferencesDetectConflictIncludingDisabledActions() {
+        var preferences = ShortcutPreferences.defaultPreferences
+        let combination = preferences.item(for: .deviceScreenshot).keyCombination
+        var dragItem = preferences.item(for: .dragScreenshot)
+        dragItem.keyCombination = combination
+        dragItem.isEnabled = false
+        preferences.setItem(dragItem)
+
+        XCTAssertEqual(
+            preferences.conflictingAction(for: combination, excluding: .deviceScreenshot),
+            .dragScreenshot
+        )
+        XCTAssertNil(preferences.conflictingAction(
+            for: CaptureShortcutAction.toggleRecording.defaultKeyCombination,
+            excluding: .toggleRecording
+        ))
+    }
+
+    func testShortcutAvailabilityValidatorBlocksDuplicatesBeforeRegistrationProbe() {
+        let preferences = ShortcutPreferences.defaultPreferences
+        let combination = preferences.item(for: .deviceScreenshot).keyCombination
+        let capturedKey = ShortcutCapturedKey(combination: combination, charactersIgnoringModifiers: "3")
+        var didProbeRegistration = false
+        let validator = ShortcutAvailabilityValidator { _ in
+            didProbeRegistration = true
+            return true
+        }
+
+        XCTAssertEqual(
+            validator.validationError(
+                for: capturedKey,
+                editing: .dragScreenshot,
+                preferences: preferences,
+                applicationMenu: NSMenu()
+            ),
+            .duplicate(.deviceScreenshot)
+        )
+        XCTAssertFalse(didProbeRegistration)
+    }
+
+    func testShortcutAvailabilityValidatorBlocksApplicationMenuCommands() {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let menuItem = NSMenuItem(title: "Show Shortcuts", action: nil, keyEquivalent: "k")
+        menuItem.keyEquivalentModifierMask = [.command]
+        menuItem.isEnabled = true
+        menu.addItem(menuItem)
+        let capturedKey = ShortcutCapturedKey(
+            combination: KeyCombination(keyCode: UInt32(kVK_ANSI_K), modifiers: [.command]),
+            charactersIgnoringModifiers: "k"
+        )
+        let validator = ShortcutAvailabilityValidator { _ in true }
+
+        XCTAssertEqual(
+            validator.validationError(
+                for: capturedKey,
+                editing: .deviceScreenshot,
+                preferences: .defaultPreferences,
+                applicationMenu: menu
+            ),
+            .applicationMenu("Show Shortcuts")
+        )
+    }
+
+    func testShortcutAvailabilityValidatorReportsRegistrationFailure() {
+        let capturedKey = ShortcutCapturedKey(
+            combination: KeyCombination(keyCode: UInt32(kVK_ANSI_K), modifiers: [.control, .option]),
+            charactersIgnoringModifiers: "k"
+        )
+        let validator = ShortcutAvailabilityValidator { _ in false }
+
+        XCTAssertEqual(
+            validator.validationError(
+                for: capturedKey,
+                editing: .deviceScreenshot,
+                preferences: .defaultPreferences,
+                applicationMenu: NSMenu()
+            ),
+            .unavailable
+        )
+    }
+
+    func testShortcutRecorderSessionTracksPreviewRejectionAndKeyRelease() {
+        var session = ShortcutRecorderSession()
+        session.begin(.deviceScreenshot)
+        session.updateModifiers([.option, .shift])
+
+        XCTAssertTrue(session.isRecording(.deviceScreenshot))
+        XCTAssertEqual(session.previewModifiers, [.option, .shift])
+
+        session.reject(.missingRequiredModifier)
+        XCTAssertEqual(session.errorMessage, ShortcutCaptureValidationError.missingRequiredModifier.message)
+
+        let combination = KeyCombination(keyCode: UInt32(kVK_ANSI_7), modifiers: [.option, .shift])
+        session.accept(combination)
+        XCTAssertTrue(session.isAwaitingRelease(.deviceScreenshot))
+        XCTAssertNil(session.errorMessage)
+        XCTAssertFalse(session.completeKeyRelease(UInt32(kVK_ANSI_8)))
+        XCTAssertTrue(session.completeKeyRelease(UInt32(kVK_ANSI_7)))
+        XCTAssertFalse(session.isActive)
+    }
+
+    func testGlobalHotKeyRegistrationPolicySuspendsWhileRecordingShortcut() {
+        let item = ShortcutPreferences.defaultPreferences.item(for: .deviceScreenshot)
+
+        XCTAssertTrue(GlobalRecordingHotKeyRegistrationPolicy.shouldRegister(
+            action: .deviceScreenshot,
+            item: item,
+            captureState: .choosingMode,
+            runtimeIsRecording: false,
+            shortcutRecorderIsActive: false
+        ))
+        XCTAssertFalse(GlobalRecordingHotKeyRegistrationPolicy.shouldRegister(
+            action: .deviceScreenshot,
+            item: item,
+            captureState: .choosingMode,
+            runtimeIsRecording: false,
+            shortcutRecorderIsActive: true
+        ))
+    }
+
     func testShortcutPreferencesRoundTripPersistence() throws {
         let suiteName = "CaptureShortcutsTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -60,10 +236,14 @@ final class CaptureShortcutsTests: XCTestCase {
 
     func testSettingsDriverShortcutUpdates() {
         var persistedShortcuts: ShortcutPreferences?
+        var recorderStates: [Bool] = []
         let driver = SettingsDriver(createZoomsAutomatically: true)
         driver.configure(
             persistShortcuts: { shortcuts in
                 persistedShortcuts = shortcuts
+            },
+            setShortcutRecorderActive: { isActive in
+                recorderStates.append(isActive)
             }
         )
 
@@ -76,6 +256,10 @@ final class CaptureShortcutsTests: XCTestCase {
 
         driver.send(.shortcutsResetToDefaults)
         XCTAssertTrue(driver.state.shortcuts.item(for: .dragScreenshot).isEnabled)
+
+        driver.shortcutRecorderActive(true)
+        driver.shortcutRecorderActive(false)
+        XCTAssertEqual(recorderStates, [true, false])
     }
 
     func testAppModelShortcutTriggers() async {
@@ -84,6 +268,13 @@ final class CaptureShortcutsTests: XCTestCase {
             startRecordingCapture: { _, _, _ in Date() },
             stopRecording: { URL(fileURLWithPath: "/tmp/test.mp4") }
         )
+
+        model.setShortcutRecorderActive(true)
+        model.setShortcutRecorderActive(true)
+        model.setShortcutRecorderActive(false)
+        XCTAssertTrue(model.isShortcutRecorderActive)
+        model.setShortcutRecorderActive(false)
+        XCTAssertFalse(model.isShortcutRecorderActive)
 
         model.cancelCapture()
         model.triggerDeviceScreenshot()


### PR DESCRIPTION
## Summary
- replace shortcut preset dropdowns with spacious keyboard-driven recorder controls
- validate unsafe, duplicate, menu, and system-reserved combinations while suspending global hotkeys during capture
- expand special-key labels and cover recorder lifecycle, validation, and registration behavior

## Testing
- `make test-macos` (31 Rust tests and 654 macOS tests passed)
- `make build-macos`
- native QA: record, duplicate/menu conflict feedback, Escape/tab cancellation, and default reset