### PR TITLE
feat(macos): add delete-all menu to zoom inspector

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineEditing.swift
@@ -561,6 +561,7 @@ enum TimelineEditEvent: Equatable {
     case select(TimelineRegionKind?, TimelineRegionID?)
     case selectClip(index: Int)
     case clearSelection
+    case deleteAllZooms
     case deleteSelection(duration: Double?)
     case updateSpan(kind: TimelineRegionKind, id: TimelineRegionID, span: TimelineSpan, duration: Double)
     case cycleClipSpeed(index: Int)
@@ -650,6 +651,10 @@ extension TimelineEditState {
 
         case .clearSelection:
             clearSelection()
+            return []
+
+        case .deleteAllZooms:
+            deleteAllZooms()
             return []
 
         case .deleteSelection(let duration):
@@ -892,6 +897,15 @@ extension TimelineEditState {
         selectedID = nil
         selectedClipIndex = nil
         selectedCameraClipID = nil
+    }
+
+    private mutating func deleteAllZooms() {
+        guard !snapshot.zoomRegions.isEmpty else { return }
+        snapshot.zoomRegions.removeAll()
+        if selectedKind == .zoom {
+            clearSelection()
+        }
+        statusMessage = "Deleted all zoom levels."
     }
 
     private mutating func deleteSelection(duration: Double? = nil) {
@@ -1376,6 +1390,10 @@ final class TimelineEditDriver {
 
     func clearSelection() {
         send(.clearSelection, recordsUndo: false)
+    }
+
+    func deleteAllZooms() {
+        send(.deleteAllZooms)
     }
 
     func deleteSelection() {

--- a/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
+++ b/apps/macos/Sources/OpenRecorderMac/TimelineSelectionSidebar.swift
@@ -86,6 +86,11 @@ struct TimelineSelectionSidebar: View {
                 ) {
                     edits.deleteSelection(duration: playback.duration)
                 }
+            } else if edits.selectedKind == .zoom {
+                TimelineZoomDeleteButton(
+                    deleteSelected: { edits.deleteSelection(duration: playback.duration) },
+                    deleteAll: { edits.deleteAllZooms() }
+                )
             } else if edits.selectedKind != nil {
                 TimelineSelectionActionButton(title: "Delete", symbolName: "trash", isDestructive: true) {
                     edits.deleteSelection(duration: playback.duration)
@@ -430,6 +435,45 @@ private struct TimelineSelectionInfoRow: View {
         .overlay {
             Rectangle()
                 .stroke(Theme.borderSubtle, lineWidth: 1)
+        }
+    }
+}
+
+private struct TimelineZoomDeleteButton: View {
+    var deleteSelected: () -> Void
+    var deleteAll: () -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            StudioButton(help: "Delete selected zoom", action: deleteSelected) {
+                Label("Delete", systemImage: "trash")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: Theme.btnHeightSm)
+            }
+
+            Rectangle()
+                .fill(Color.red.opacity(0.30))
+                .frame(width: 1, height: Theme.btnHeightSm)
+                .accessibilityHidden(true)
+
+            StudioMenu(help: "Zoom delete options") {
+                Button("Delete All Zoom Levels", role: .destructive, action: deleteAll)
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .frame(width: Theme.btnHeightSm, height: Theme.btnHeightSm)
+            }
+            .fixedSize()
+            .accessibilityLabel("Zoom delete options")
+        }
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(Color.red.opacity(0.95))
+        .background(Color.red.opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: Theme.radiusMd, style: .continuous)
+                .stroke(Color.red.opacity(0.30), lineWidth: 1)
+                .allowsHitTesting(false)
         }
     }
 }

--- a/apps/macos/Tests/OpenRecorderMacTests/TimelineZoomDeletionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/TimelineZoomDeletionTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import OpenRecorderMac
+
+final class TimelineZoomDeletionTests: XCTestCase {
+    private func fixture() -> TimelineEditSnapshot {
+        TimelineEditSnapshot(
+            zoomRegions: [
+                TimelineZoomRegion(span: TimelineSpan(start: 1, end: 2), mode: .manual),
+                TimelineZoomRegion(span: TimelineSpan(start: 3, end: 4), mode: .auto)
+            ],
+            trimRegions: [TimelineTrimRegion(span: TimelineSpan(start: 8, end: 9))],
+            annotationRegions: [TimelineAnnotationRegion(span: TimelineSpan(start: 5, end: 6))],
+            clipSplitTimes: [5],
+            clipSpeeds: [0: 1.5],
+            cameraClips: [TimelineCameraClip(span: TimelineSpan(start: 0, end: 10), settings: FacecamSettings(enabled: true, shape: "circle", size: 20, cornerRadius: 20, borderWidth: 0, borderColor: "#ffffff", margin: 4, anchor: "bottomRight"))]
+        )
+    }
+
+    @MainActor
+    func testDeleteAllZoomsIsOneUndoableEditAndPreservesOtherContent() throws {
+        let edits = TimelineEditDriver()
+        let original = fixture()
+        edits.applySnapshot(original)
+        let selectedID = original.zoomRegions[1].id
+        edits.select(.zoom, id: selectedID)
+        var expected = original
+        expected.zoomRegions = []
+
+        edits.deleteAllZooms()
+
+        XCTAssertEqual(edits.snapshot, expected)
+        XCTAssertFalse(edits.hasSelection)
+        XCTAssertEqual(edits.statusMessage, "Deleted all zoom levels.")
+        XCTAssertTrue(edits.canUndo)
+        let saved = try JSONEncoder().encode(edits.snapshot)
+        XCTAssertEqual(try JSONDecoder().decode(TimelineEditSnapshot.self, from: saved), expected)
+
+        edits.undo()
+        XCTAssertEqual(edits.snapshot, original)
+        XCTAssertEqual(edits.selectedKind, .zoom)
+        XCTAssertEqual(edits.selectedID, selectedID)
+        XCTAssertFalse(edits.canUndo)
+
+        edits.redo()
+        XCTAssertEqual(edits.snapshot, expected)
+        XCTAssertFalse(edits.hasSelection)
+        XCTAssertFalse(edits.canRedo)
+    }
+
+    @MainActor
+    func testDeleteAllZoomsPreservesUnrelatedSelections() {
+        let original = fixture()
+        for selection in 0..<4 {
+            let edits = TimelineEditDriver()
+            edits.applySnapshot(original)
+            switch selection {
+            case 0: edits.select(.trim, id: original.trimRegions[0].id)
+            case 1: edits.select(.annotation, id: original.annotationRegions[0].id)
+            case 2: edits.selectClip(index: 0)
+            default: edits.selectCameraClip(id: original.cameraClips[0].id)
+            }
+            let before = edits.state
+            edits.deleteAllZooms()
+            XCTAssertTrue(edits.zoomRegions.isEmpty)
+            XCTAssertEqual(edits.selectedKind, before.selectedKind)
+            XCTAssertEqual(edits.selectedID, before.selectedID)
+            XCTAssertEqual(edits.selectedClipIndex, before.selectedClipIndex)
+            XCTAssertEqual(edits.selectedCameraClipID, before.selectedCameraClipID)
+        }
+    }
+
+    @MainActor
+    func testDeletingEmptyZoomListIsNoOpAndPreservesRedo() {
+        let edits = TimelineEditDriver()
+        edits.add(.zoom, at: 1, duration: 10)
+        edits.undo()
+        let before = edits.state
+        edits.deleteAllZooms()
+        XCTAssertEqual(edits.state, before)
+        XCTAssertFalse(edits.canUndo)
+        XCTAssertTrue(edits.canRedo)
+    }
+
+    @MainActor
+    func testDefaultDeletionOnlyDeletesSelectedZoom() {
+        let edits = TimelineEditDriver()
+        let original = fixture()
+        edits.applySnapshot(original)
+        edits.select(.zoom, id: original.zoomRegions[0].id)
+        edits.deleteSelection(duration: 10)
+        var expected = original
+        expected.zoomRegions.removeFirst()
+        XCTAssertEqual(edits.snapshot, expected)
+        XCTAssertFalse(edits.hasSelection)
+    }
+}


### PR DESCRIPTION
## Description
The selected zoom inspector now has a split Delete button. Clicking Delete removes the selected zoom; clicking its downward caret opens a native menu with **Delete All Zoom Levels**, which removes all manual and automatic zooms in the current recording.

Bulk deletion is one undoable edit. Undo restores zooms and selection; other timeline content and unrelated selections are preserved. An empty zoom list is a no-op.

## Motivation
Make it possible to clear the zoom track from the inspector without deleting each zoom individually.

## Type of Change
- [x] New Feature

## Testing Guide
- `make test-macos`: 31 Rust tests and 658 macOS tests passed, including four new zoom-deletion tests covering single/bulk deletion, unrelated content and selections, empty-list behavior, Undo/Redo, and snapshot serialization.
- `make package-macos-dev`: passed.
- `git diff --check`: passed.
- Native validation attempted with a disposable MP4 and a project containing manual and automatic zooms. The packaged editor repeatedly timed out during accessibility queries and screenshot capture before zoom selection. The menu screenshot, native hit-target/Undo/Redo checks, and reopen persistence check remain unverified; serialization is covered by an automated test.

Manual verification: open a recording with multiple zooms, select one, check that Delete removes only it, Undo, open the caret menu, choose Delete All Zoom Levels, Undo/Redo, then reopen the project and verify the zooms remain deleted.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] Native screenshot and interaction verification (blocked by editor timeouts).
