### PR TITLE
fix: redesign update changelog content

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run tests
         run: make test-macos
+
+      - name: Test release-note rendering and appcast updates
+        run: node --test scripts/render-release-notes.test.mjs

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -939,11 +939,38 @@
             <sparkle:shortVersionString>0.2.47</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[
-## Commits since v0.2.46
-
-- de8bafb Merge pull request #1080 from imbhargav5/codex/native-shortcut-recorder
-- 7729870 feat(macos): add native shortcut recorder
-- 12dcd2d Update appcast for v0.2.46
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>What’s New · 0.2.47</title>
+<style>
+:root { color-scheme: light dark; --text: #242426; --muted: #66666e; --line: #e1e1e6; --link: #305dc8; --background: #fff; }
+@media (prefers-color-scheme: dark) { :root { --text: #ededf0; --muted: #aaaab3; --line: #414146; --link: #9cbaff; --background: #242426; } }
+* { box-sizing: border-box; }
+body { margin: 0; padding: 24px; background: var(--background); color: var(--text); font: 13px/1.6 -apple-system, BlinkMacSystemFont, sans-serif; overflow-wrap: anywhere; }
+header { margin-bottom: 24px; }
+.version { margin: 0 0 4px; color: var(--muted); font-size: 11px; }
+h1 { margin: 0; font-size: 24px; line-height: 1.25; font-weight: 650; letter-spacing: -.5px; }
+h2 { margin: 22px 0 8px; font-size: 14px; line-height: 1.4; font-weight: 600; }
+p { margin: 8px 0; }
+ul { padding-left: 18px; margin: 8px 0; }
+li { padding-left: 3px; margin: 6px 0; }
+li::marker { color: var(--muted); }
+a:any-link { color: var(--link); text-underline-offset: 3px; }
+a:focus-visible { outline: 2px solid var(--link); outline-offset: 3px; }
+footer { margin-top: 24px; padding-top: 14px; border-top: 1px solid var(--line); font-size: 12px; }
+</style>
+</head>
+<body>
+<header><p class="version">Version 0.2.47</p><h1>What’s New</h1></header>
+<main><h2>New</h2>
+<ul><li>Record keyboard shortcuts directly in Settings by pressing your preferred key combination.</li></ul></main>
+<footer><a href="https://github.com/imbhargav5/open-recorder/releases/tag/v0.2.47">Full release details</a></footer>
+</body>
+</html>
 ]]></description>
             <enclosure url="https://github.com/imbhargav5/open-recorder/releases/download/v0.2.47/open-recorder-macos.zip" sparkle:edSignature="ImQPpdc6mwy2InOwCigSi80Zsu6LCq3QxAYddQWXS9HLyY8l1j77QKgycbLOWG4vtO5wjuUbaz3BBDp02BjAAQ==" length="73249459" type="application/octet-stream"/>
         </item>

--- a/scripts/render-release-notes.mjs
+++ b/scripts/render-release-notes.mjs
@@ -1,0 +1,103 @@
+export function escapeHtml(value) {
+	return String(value).replace(/[&<>"']/g, (char) => ({
+		"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+	})[char]);
+}
+
+function inline(text) {
+	// Only explicit HTTP(S) links become markup. Everything else remains text.
+	return text.split(/(\[[^\]\n]+\]\([^\s)]+\))/g).map((part) => {
+		const link = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(part);
+		if (link) {
+			try {
+				const url = new URL(link[2]);
+				if (["https:", "http:"].includes(url.protocol)) {
+					return `<a href="${escapeHtml(url.href)}">${escapeHtml(link[1])}</a>`;
+				}
+			} catch { /* Render malformed links as text. */ }
+		}
+		return escapeHtml(part);
+	}).join("");
+}
+
+function generatedNotes(notes) {
+	const groups = { New: [], Improved: [], Fixed: [] };
+	for (const line of notes.split(/\r?\n/)) {
+		const match = /^\s*-\s+[a-f0-9]{7,40}\s+(.+)$/i.exec(line);
+		if (!match) continue;
+		let subject = match[1];
+		if (/^(Merge\b|Update appcast\b|(?:chore|ci|build|docs|test)(?:\([^)]*\))?!?:|(?:chore:\s*)?release\b|bump version\b)/i.test(subject)) continue;
+		const conventional = /^(\w+)(?:\([^)]*\))?!?:\s*(.+)$/.exec(subject);
+		const group = conventional?.[1] === "feat" ? "New" : conventional?.[1] === "fix" ? "Fixed" : "Improved";
+		subject = (conventional?.[2] ?? subject).replace(/\s+\(#\d+\)$/, "").trim();
+		if (subject && !groups[group].includes(subject)) groups[group].push(subject);
+	}
+	return Object.entries(groups).filter(([, items]) => items.length).map(([title, items]) =>
+		`## ${title}\n\n${items.map((item) => `- ${item[0].toUpperCase()}${item.slice(1)}`).join("\n")}`
+	).join("\n\n");
+}
+
+function blocks(notes) {
+	const result = [];
+	let paragraph = [];
+	let bullets = [];
+	let heading = null;
+	const flushHeading = () => {
+		if (heading !== null) { result.push(`<h2>${inline(heading)}</h2>`); heading = null; }
+	};
+	const flush = () => {
+		if (paragraph.length) { flushHeading(); result.push(`<p>${inline(paragraph.join(" "))}</p>`); paragraph = []; }
+		if (bullets.length) { flushHeading(); result.push(`<ul>${bullets.map((item) => `<li>${inline(item)}</li>`).join("")}</ul>`); bullets = []; }
+	};
+	for (const line of notes.split(/\r?\n/)) {
+		const title = /^#{1,6}\s+(.+)$/.exec(line);
+		const bullet = /^\s*[-*+]\s+(.+)$/.exec(line);
+		if (title) { flush(); heading = title[1]; }
+		else if (bullet) { if (paragraph.length) flush(); bullets.push(bullet[1]); }
+		else if (!line.trim()) flush();
+		else { if (bullets.length) flush(); paragraph.push(line.trim()); }
+	}
+	flush();
+	return result.join("\n");
+}
+
+export function renderReleaseNotes({ version, releaseNotes = "" }) {
+	const generated = /^## Commits(?: since [^\n]+)?\s*(?:\n|$)/.test(releaseNotes.trim());
+	const content = blocks(generated ? generatedNotes(releaseNotes) : releaseNotes);
+	const releaseURL = `https://github.com/imbhargav5/open-recorder/releases/tag/v${encodeURIComponent(version)}`;
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>What’s New · ${escapeHtml(version)}</title>
+<style>
+:root { color-scheme: light dark; --text: #242426; --muted: #66666e; --line: #e1e1e6; --link: #305dc8; --background: #fff; }
+@media (prefers-color-scheme: dark) { :root { --text: #ededf0; --muted: #aaaab3; --line: #414146; --link: #9cbaff; --background: #242426; } }
+* { box-sizing: border-box; }
+body { margin: 0; padding: 24px; background: var(--background); color: var(--text); font: 13px/1.6 -apple-system, BlinkMacSystemFont, sans-serif; overflow-wrap: anywhere; }
+header { margin-bottom: 24px; }
+.version { margin: 0 0 4px; color: var(--muted); font-size: 11px; }
+h1 { margin: 0; font-size: 24px; line-height: 1.25; font-weight: 650; letter-spacing: -.5px; }
+h2 { margin: 22px 0 8px; font-size: 14px; line-height: 1.4; font-weight: 600; }
+p { margin: 8px 0; }
+ul { padding-left: 18px; margin: 8px 0; }
+li { padding-left: 3px; margin: 6px 0; }
+li::marker { color: var(--muted); }
+a:any-link { color: var(--link); text-underline-offset: 3px; }
+a:focus-visible { outline: 2px solid var(--link); outline-offset: 3px; }
+footer { margin-top: 24px; padding-top: 14px; border-top: 1px solid var(--line); font-size: 12px; }
+</style>
+</head>
+<body>
+<header><p class="version">Version ${escapeHtml(version)}</p><h1>What’s New</h1></header>
+<main>${content || "<p>See full release details for this update.</p>"}</main>
+<footer><a href="${escapeHtml(releaseURL)}">Full release details</a></footer>
+</body>
+</html>`;
+}
+
+export function releaseNotesDescription(options) {
+	return `<description><![CDATA[\n${renderReleaseNotes(options).replace(/\]\]>/g, "]]]]><![CDATA[>")}\n]]></description>`;
+}

--- a/scripts/render-release-notes.test.mjs
+++ b/scripts/render-release-notes.test.mjs
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { renderReleaseNotes, releaseNotesDescription } from "./render-release-notes.mjs";
+
+test("generated commits become grouped notes without release noise", () => {
+	const html = renderReleaseNotes({ version: "1.2.3", releaseNotes: `## Commits since v1.2.2
+- abc1234 Merge pull request #12
+- abc1235 feat(macos): record shortcuts (#12)
+- abc1236 fix: preserve selection
+- abc1237 perf: reduce export allocations
+- abc1238 docs: update instructions
+- abc1239 Update appcast for v1.2.2
+- abc1240 feat(macos): record shortcuts (#12)` });
+	assert.match(html, /<h2>New<\/h2>/);
+	assert.match(html, /<h2>Improved<\/h2>/);
+	assert.match(html, /<h2>Fixed<\/h2>/);
+	assert.equal(html.split("Record shortcuts").length, 2);
+	assert.doesNotMatch(html, /abc123|Merge pull|appcast|feat\(macos\)|update instructions/);
+});
+
+test("supplied copy, links and paragraphs are escaped and empty sections omitted", () => {
+	const html = renderReleaseNotes({ version: '1<&"', releaseNotes: '## New\n\nYour wording stays.\n\n- <script>alert(1)</script> & ]]>\n- [Guide](https://example.com/?a=1&b=2)\n- [Bad](javascript:alert)\n\n## Fixed' });
+	assert.match(html, /Your wording stays\./);
+	assert.match(html, /&lt;script&gt;/);
+	assert.match(html, /href="https:\/\/example.com\/\?a=1&amp;b=2"/);
+	assert.doesNotMatch(html, /<script>|href="javascript:|<h2>Fixed/);
+	assert.match(html, /\]\]&gt;/);
+	assert.match(releaseNotesDescription({ version: "1", releaseNotes: "]]>" }), /^<description><!\[CDATA\[/);
+});
+
+test("empty and long notes remain useful", () => {
+	for (const releaseNotes of ["", "## Commits\n\n- abc1234 ci: update workflow", "## New"]) {
+		const html = renderReleaseNotes({ version: "1", releaseNotes });
+		assert.match(html, /See full release details for this update/);
+		assert.doesNotMatch(html, /<h2>/);
+	}
+	const html = renderReleaseNotes({ version: "1", releaseNotes: Array.from({ length: 100 }, (_, i) => `- Change ${i}`).join("\n") });
+	assert.equal((html.match(/<li>/g) || []).length, 100);
+	assert.match(html, /prefers-color-scheme: dark/);
+});
+
+test("CLI replacement preserves every unrelated release and enclosure metadata", () => {
+	const root = mkdtempSync(join(tmpdir(), "release-notes-test-"));
+	try {
+		mkdirSync(join(root, "scripts")); mkdirSync(join(root, "docs"));
+		for (const name of ["update-production-appcast.mjs", "render-release-notes.mjs"]) copyFileSync(new URL(name, import.meta.url), join(root, "scripts", name));
+		const original = readFileSync(new URL("../docs/appcast.xml", import.meta.url), "utf8");
+		const items = original.match(/<item>[\s\S]*?<\/item>/g);
+		const target = items.at(-1);
+		const version = /<sparkle:version>(.*?)<\/sparkle:version>/.exec(target)[1];
+		const enclosure = /<enclosure[^>]+\/>/.exec(target)[0];
+		const attr = (name) => new RegExp(`${name}="([^"]+)"`).exec(enclosure)[1];
+		writeFileSync(join(root, "docs/appcast.xml"), original);
+		const args = [join(root, "scripts/update-production-appcast.mjs"), "--version", version, "--url", attr("url"), "--signature", attr("sparkle:edSignature"), "--length", attr("length"), "--min-system-version", "15.0", "--release-notes", "## Fixed\n\n- A & B"];
+		for (let run = 0; run < 2; run++) {
+			execFileSync(process.execPath, args);
+			const output = readFileSync(join(root, "docs/appcast.xml"), "utf8");
+			const updated = output.match(/<item>[\s\S]*?<\/item>/g);
+			assert.equal(updated.length, items.length);
+			assert.deepEqual(updated.slice(0, -1), items.slice(0, -1));
+			assert.ok(updated.at(-1).includes(enclosure));
+			assert.match(updated.at(-1), /A &amp; B/);
+		}
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/scripts/update-production-appcast.mjs
+++ b/scripts/update-production-appcast.mjs
@@ -3,6 +3,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { releaseNotesDescription } from "./render-release-notes.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
@@ -40,9 +41,7 @@ function escapeXml(value) {
 
 function buildItem({ version, url, signature, length, minSystemVersion, releaseNotes }) {
 	const pubDate = new Date().toUTCString();
-	const notesBlock = releaseNotes
-		? `            <description><![CDATA[\n${releaseNotes}\n]]></description>\n`
-		: "";
+	const notesBlock = `            ${releaseNotesDescription({ version, releaseNotes })}\n`;
 	return `        <item>
             <title>Version ${escapeXml(version)}</title>
             <pubDate>${pubDate}</pubDate>
@@ -94,11 +93,11 @@ if (!existsSync(appcastPath)) {
 
 let content = readFileSync(appcastPath, "utf8");
 
-const versionPattern = new RegExp(
-	`\\s*<item>[\\s\\S]*?<sparkle:version>${args.version.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}<\\/sparkle:version>[\\s\\S]*?<\\/item>`,
-	"g",
-);
-content = content.replace(versionPattern, "");
+// Match each item independently: a cross-item regex can delete older releases.
+content = content.replace(/<item>[\s\S]*?<\/item>/g, (existingItem) => {
+	const version = /<sparkle:version>([^<]*)<\/sparkle:version>/.exec(existingItem)?.[1];
+	return version === escapeXml(args.version) ? "" : existingItem;
+});
 
 if (!content.includes("</channel>")) {
 	die("appcast.xml is malformed: missing </channel>");


### PR DESCRIPTION
## Description
The update dialog currently displays raw commit lists with hashes and merge housekeeping. Render the appcast notes as a styled “What’s New” document with grouped changes, readable spacing, system typography, and light/dark colors. Refresh the latest entry with concise shortcut-recorder copy while retaining Sparkle’s native controls and GitHub release notes.

Also fix appcast entry replacement so updating one version cannot remove earlier releases. Add renderer and appcast regression tests to CI.

## Motivation
Make update notes readable and useful without changing the update installation flow.

## Type of Change
- [x] Bug Fix

## Testing Guide
- `node --test scripts/render-release-notes.test.mjs` — all 4 tests pass, including generated/supplied copy, escaping, empty/long content, and repeated appcast replacement.
- XML comparison verified all 36 existing releases retain their metadata and older entries remain unchanged.
- Native Sparkle preview verified short and long notes in light and dark mode using an isolated local feed. Verified scrolling to the footer; no update downloaded or installed.
- `git diff --check` passes.

## Checklist
- [x] I have performed a self-review of my code.
- [x] Updated the latest appcast changelog entry.
