### PR TITLE
Add Quit Open Recorder to the HUD right-click menu

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureHUDViews.swift
@@ -21,6 +21,12 @@ struct CaptureHUD: View {
                 idleControls
             }
         }
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button("Quit Open Recorder") {
+                NSApp.terminate(nil)
+            }
+        }
         .animation(.spring(response: 0.35, dampingFraction: 0.82), value: model.captureMode)
         .animation(.spring(response: 0.35, dampingFraction: 0.82), value: isRecordingActive)
         .environment(\.layoutDirection, .leftToRight)


### PR DESCRIPTION
Right-clicking the capture HUD now offers **Quit Open Recorder**, in both idle and recording states. The action uses the existing AppKit termination flow so pending saves and active capture handling remain in effect.

Validation: `make test-macos` passes after rebasing onto current main; packaged development build passed. Interactive menu verification remains blocked by the locked Mac.
