### PR TITLE
perf(macos): cache static video export backgrounds

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -199,6 +199,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     private let renderingQueueKey = DispatchSpecificKey<Bool>()
     private let renderingQueue = DispatchQueue(label: "com.openrecorder.video.compositor", qos: .userInitiated)
     private let ciContext: CIContext
+    private let backgroundCache: VideoStaticBackgroundCache
     private var renderContext: AVVideoCompositionRenderContext?
     private let renderContextLock = NSLock()
     private var annotationCache: [String: CIImage] = [:]
@@ -218,6 +219,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         } else {
             ciContext = CIContext(options: Self.ciContextOptions())
         }
+        backgroundCache = VideoStaticBackgroundCache(context: ciContext)
         super.init()
         renderingQueue.setSpecific(key: renderingQueueKey, value: true)
     }
@@ -234,6 +236,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         renderContextLock.lock()
         renderContext = newRenderContext
         renderContextLock.unlock()
+        backgroundCache.invalidate()
     }
 
     func startRequest(_ request: AVAsynchronousVideoCompositionRequest) {
@@ -262,6 +265,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     }
 
     func cancelAllPendingVideoCompositionRequests() {
+        defer { backgroundCache.invalidate() }
         if DispatchQueue.getSpecific(key: renderingQueueKey) == true {
             return
         }
@@ -358,10 +362,17 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         let cornerRadius = instruction.styling.borderRadiusRatio * minDim
         let maskedSource = applyRoundedMask(positionedImage, cornerRadius: cornerRadius, in: placedRect)
 
-        var background = makeBackground(instruction.styling.background, extent: renderRect)
-        if instruction.styling.backgroundBlurRatio > 0, !instruction.styling.background.isTransparent {
-            let blurRadius = instruction.styling.backgroundBlurRatio * minDim
-            background = applyGaussianBlur(background, radius: blurRadius).cropped(to: renderRect)
+        let blurRadius = instruction.styling.backgroundBlurRatio * minDim
+        let background = backgroundCache.image(
+            style: instruction.styling.background,
+            extent: renderRect,
+            blurRadius: blurRadius
+        ) {
+            var image = makeBackground(instruction.styling.background, extent: renderRect)
+            if blurRadius > 0, !instruction.styling.background.isTransparent {
+                image = applyGaussianBlur(image, radius: blurRadius).cropped(to: renderRect)
+            }
+            return image
         }
 
         var composed = background

--- a/apps/macos/Sources/OpenRecorderMac/VideoStaticBackgroundCache.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoStaticBackgroundCache.swift
@@ -1,0 +1,73 @@
+import CoreImage
+import CoreVideo
+import Foundation
+
+/// Keeps at most one rendered background. Dynamic source frames, shadows and overlays
+/// never enter this cache. A separate IOSurface avoids rebuilding static CI graphs
+/// without enabling unbounded intermediate caching for the video itself.
+final class VideoStaticBackgroundCache {
+    private struct Key: Equatable {
+        let style: BackgroundStyle
+        let extent: CGRect
+        let blurRadius: Double
+    }
+
+    private let context: CIContext
+    private let lock = NSLock()
+    private var entry: (key: Key, image: CIImage)?
+
+    init(context: CIContext) {
+        self.context = context
+    }
+
+    func invalidate() {
+        lock.lock()
+        defer { lock.unlock() }
+        entry = nil
+    }
+
+    func image(style: BackgroundStyle, extent: CGRect, blurRadius: Double, makeImage: () -> CIImage) -> CIImage {
+        // Context changes/cancellation can arrive off the compositor's rendering queue.
+        lock.lock()
+        defer { lock.unlock() }
+
+        switch style {
+        case .solid, .transparent:
+            // Constant colors are cheaper as CI generators than as uploaded bitmaps.
+            entry = nil
+            return makeImage()
+        case .gradient, .wallpaper:
+            break
+        }
+
+        let key = Key(style: style, extent: extent, blurRadius: blurRadius)
+        if let entry, entry.key == key { return entry.image }
+        entry = nil
+        let source = makeImage()
+        guard extent.width.isFinite, extent.height.isFinite,
+              extent.width > 0, extent.height > 0,
+              extent.width <= CGFloat(Int32.max), extent.height <= CGFloat(Int32.max) else { return source }
+
+        var buffer: CVPixelBuffer?
+        let attributes: [String: Any] = [
+            kCVPixelBufferIOSurfacePropertiesKey as String: [String: Any](),
+            kCVPixelBufferMetalCompatibilityKey as String: true
+        ]
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, Int(ceil(extent.width)), Int(ceil(extent.height)),
+            kCVPixelFormatType_32BGRA, attributes as CFDictionary, &buffer
+        )
+        guard status == kCVReturnSuccess, let buffer else { return source }
+        let bounds = CGRect(origin: .zero, size: extent.size)
+        context.render(
+            source.transformed(by: CGAffineTransform(translationX: -extent.minX, y: -extent.minY)),
+            to: buffer, bounds: bounds, colorSpace: CGColorSpace(name: CGColorSpace.sRGB)
+        )
+        // CIImage retains its pixel buffer; replacing the sole entry releases the old surface.
+        let image = CIImage(cvPixelBuffer: buffer)
+            .cropped(to: bounds)
+            .transformed(by: CGAffineTransform(translationX: extent.minX, y: extent.minY))
+        entry = (key, image)
+        return image
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/AdaptiveZoomRenderTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AdaptiveZoomRenderTests.swift
@@ -11,7 +11,7 @@ import XCTest
 /// OPEN_RECORDER_ZOOM_RENDER_CHECK=1 swift test --filter AdaptiveZoomRenderTests
 final class AdaptiveZoomRenderTests: XCTestCase {
     @MainActor
-    func testEightRepresentativeExports() async throws {
+    func testRepresentativeExports() async throws {
         guard ProcessInfo.processInfo.environment["OPEN_RECORDER_ZOOM_RENDER_CHECK"] == "1" else {
             throw XCTSkip("Opt-in video encoding and visual artifacts")
         }
@@ -27,16 +27,27 @@ final class AdaptiveZoomRenderTests: XCTestCase {
         var padded = plain
         padded.styling.background = .solid(SerializableColor(hex: "172033"))
         padded.styling.paddingRatio = 0.1
-        var cropped = padded
+        var wallpaper = padded
+        wallpaper.styling.background = BackgroundPresets.default
+        wallpaper.styling.shadowIntensity = 0.35
+        var blurredGradient = padded
+        blurredGradient.styling.background = .gradient(GradientPreset(
+            id: "export-validation", kind: .linear(angleDegrees: 45), stops: [
+                GradientStop(color: SerializableColor(hex: "172033"), position: 0),
+                GradientStop(color: SerializableColor(hex: "6388AA"), position: 1)
+            ]))
+        blurredGradient.styling.backgroundBlurRatio = 0.04
+        blurredGradient.styling.borderRadiusRatio = 0.04
+        var cropped = wallpaper
         cropped.cropSelection = VideoCropSelection(normalizedRect: CGRect(x: 0.15, y: 0.1, width: 0.7, height: 0.8))
         var portrait = cropped
         portrait.aspectPreset = .vertical
         var square = padded
         square.aspectPreset = .square
-        var inset = padded
+        var inset = wallpaper
         inset.styling.inset = VideoInsetStyling(amountRatio: 0.15, color: SerializableColor(hex: "EFEFEF"), opacity: 1,
                                               balance: VideoInsetBalance(left: 0.2, top: 0.8))
-        var camera = padded
+        var camera = wallpaper
         camera.facecamVideoURL = source
         camera.facecamFallbackSettings = defaultFacecamSettings(enabled: true)
         camera.facecamFallbackSettings?.fixedDuringZoom = true
@@ -45,6 +56,8 @@ final class AdaptiveZoomRenderTests: XCTestCase {
         let scenarios: [(String, VideoExportOptions, [CursorTelemetryClick])] = [
             ("plain", plain, [click(220, 180, 1000)]),
             ("padded", padded, [click(220, 180, 1000)]),
+            ("wallpaper", wallpaper, [click(220, 180, 1000)]),
+            ("blurred-gradient", blurredGradient, [click(220, 180, 1000)]),
             ("cropped", cropped, [click(320, 120, 1000)]),
             ("portrait", portrait, [click(320, 120, 1000)]),
             ("square", square, [click(320, 120, 1000)]),

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoStaticBackgroundCacheTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoStaticBackgroundCacheTests.swift
@@ -1,0 +1,124 @@
+import CoreImage
+import XCTest
+@testable import OpenRecorderMac
+
+final class VideoStaticBackgroundCacheTests: XCTestCase {
+    private let context = CIContext(options: [.cacheIntermediates: false])
+    private let extent = CGRect(x: 0, y: 0, width: 64, height: 36)
+    private var style: BackgroundStyle {
+        .gradient(GradientPreset(id: "test", kind: .linear(angleDegrees: 0), stops: [
+            GradientStop(color: SerializableColor(hex: "336699"), position: 0),
+            GradientStop(color: SerializableColor(hex: "FF8800"), position: 1)
+        ]))
+    }
+
+    func testRepeatedFramesReuseOneRenderedBackground() {
+        let cache = VideoStaticBackgroundCache(context: context)
+        var builds = 0
+        var first: CIImage?
+        for _ in 0..<120 {
+            let image = cache.image(style: style, extent: extent, blurRadius: 0) {
+                builds += 1
+                return CIImage(color: .red).cropped(to: extent)
+            }
+            if let first { XCTAssertTrue(image === first) } else { first = image }
+        }
+        XCTAssertEqual(builds, 1)
+    }
+
+    func testStyleSizeBlurAndInvalidationRebuildWithoutKeepingOldEntries() {
+        let cache = VideoStaticBackgroundCache(context: context)
+        var builds = 0
+        func read(_ style: BackgroundStyle, _ rect: CGRect, _ blur: Double) {
+            _ = cache.image(style: style, extent: rect, blurRadius: blur) {
+                builds += 1
+                return CIImage(color: .red).cropped(to: rect)
+            }
+        }
+        read(style, extent, 0)
+        read(style, extent, 0)
+        XCTAssertEqual(builds, 1)
+        read(style, extent, 2)
+        read(style, CGRect(x: 0, y: 0, width: 80, height: 40), 2)
+        let wallpaper = BackgroundPresets.default
+        read(wallpaper, extent, 2)
+        read(style, extent, 0)
+        XCTAssertEqual(builds, 5, "Returning to an old key must rebuild: cache capacity is one")
+        cache.invalidate()
+        read(style, extent, 0)
+        XCTAssertEqual(builds, 6)
+    }
+
+    func testReplacingOrInvalidatingCacheReleasesPreviousImage() {
+        let cache = VideoStaticBackgroundCache(context: context)
+        weak var previous: CIImage?
+        autoreleasepool {
+            previous = cache.image(style: style, extent: extent, blurRadius: 0) {
+                CIImage(color: .red).cropped(to: extent)
+            }
+        }
+        XCTAssertNotNil(previous)
+        autoreleasepool {
+            _ = cache.image(style: style, extent: extent, blurRadius: 1) {
+                CIImage(color: .blue).cropped(to: extent)
+            }
+        }
+        XCTAssertNil(previous, "Changing keys must release the previous cached image")
+        autoreleasepool {
+            previous = cache.image(style: style, extent: extent, blurRadius: 1) {
+                XCTFail("The replacement should already be cached")
+                return CIImage.empty()
+            }
+        }
+        cache.invalidate()
+        XCTAssertNil(previous)
+    }
+
+    func testConstantColorsBypassCacheAndReleaseOldBackground() {
+        let cache = VideoStaticBackgroundCache(context: context)
+        var builds = 0
+        weak var previous: CIImage?
+        autoreleasepool {
+            previous = cache.image(style: style, extent: extent, blurRadius: 0) {
+                CIImage(color: .red).cropped(to: extent)
+            }
+        }
+        for constant in [BackgroundStyle.transparent, .solid(SerializableColor(hex: "123456"))] {
+            for _ in 0..<2 {
+                _ = cache.image(style: constant, extent: extent, blurRadius: 0) {
+                    builds += 1
+                    return CIImage(color: .clear).cropped(to: extent)
+                }
+            }
+        }
+        XCTAssertEqual(builds, 4)
+        XCTAssertNil(previous)
+    }
+
+    func testCachedPixelsPreserveGradientBlurAlphaAndExtent() {
+        let cache = VideoStaticBackgroundCache(context: context)
+        let rect = extent.offsetBy(dx: 11, dy: 7)
+        let source = CIFilter(name: "CILinearGradient", parameters: [
+            "inputPoint0": CIVector(x: rect.minX, y: rect.minY),
+            "inputPoint1": CIVector(x: rect.maxX, y: rect.maxY),
+            "inputColor0": CIColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 0.3),
+            "inputColor1": CIColor(red: 0.9, green: 0.6, blue: 0.1, alpha: 0.9)
+        ])!.outputImage!.cropped(to: rect).clampedToExtent()
+            .applyingFilter("CIGaussianBlur", parameters: [kCIInputRadiusKey: 3]).cropped(to: rect)
+        let cached = cache.image(style: style, extent: rect, blurRadius: 3) { source }
+        XCTAssertEqual(cached.extent, rect)
+        let expected = pixels(source, bounds: rect)
+        let actual = pixels(cached, bounds: rect)
+        let maximumDifference = zip(expected, actual).map { abs(Int($0) - Int($1)) }.max() ?? 0
+        XCTAssertLessThanOrEqual(maximumDifference, 2, "Only 8-bit intermediate rounding is expected")
+    }
+
+    private func pixels(_ image: CIImage, bounds: CGRect) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: Int(bounds.width * bounds.height) * 4)
+        bytes.withUnsafeMutableBytes { pointer in
+            context.render(image, toBitmap: pointer.baseAddress!, rowBytes: Int(bounds.width) * 4,
+                           bounds: bounds, format: .RGBA8, colorSpace: CGColorSpace(name: CGColorSpace.sRGB))
+        }
+        return bytes
+    }
+}

--- a/docs/video-export-performance-investigation-2026-09-07.md
+++ b/docs/video-export-performance-investigation-2026-09-07.md
@@ -1,0 +1,97 @@
+# Video export performance investigation — 2026-09-07
+
+## Conclusion
+
+Default styled export repeatedly renders an unchanged wallpaper/background. Materializing that background once into an IOSurface-backed CVPixelBuffer reduced export time from 2.915s to 1.406s (2.07x throughput, 51.8% less elapsed time) in a controlled synthetic probe. The encoder, output quality setting, and serial compositor scheduling were unchanged. This identifies avoidable composition work as a major cost for this scenario; it does not profile an unspecified user recording.
+
+The previous investigation's prototypes were removed at its conclusion. Inspection of the current checkout confirms that the repeated work remains. The initial experiments were reverted, then the bounded background cache described below was implemented and verified for the follow-up PR.
+
+## Fresh measurements
+
+Open Recorder commit: `897e2b2`. Machine: Apple M1 Max. SwiftPM debug test invoking the real `VideoExportRenderer.export` API. Existing synthetic H.264 fixture independently checked with ffprobe: 1920x1080, 60 fps, 8 seconds. Output: MOV/H.264, 1920x1080, 30 fps, high-source quality, 240 frames. No audio, cursor telemetry, facecam, or timeline edits were supplied. Default editor appearance: default wallpaper, padding ratio 0.036, radius 0, shadow 0.35, no background blur or inset. Three runs per case; table reports medians including the first run. Build time excluded. These are short synthetic measurements, not packaged-app or production performance guarantees.
+
+| Appearance | Current code | CGImage background cache | CVPixelBuffer background cache |
+| --- | ---: | ---: | ---: |
+| Plain, no styling | 0.889s | 0.876s | 0.884s |
+| Default wallpaper styling | 2.915s | 1.862s | 1.406s |
+| Same layout, solid background | 1.308s | 1.637s | 1.262s |
+| Wallpaper styling, shadow disabled | 2.576s | 1.482s | 1.127s |
+
+Removing shadows alone yields a much smaller change than eliminating repeated background rendering. Blindly rasterizing cheap solid colors into CGImages can make them slower. Retain a simple path for solid/transparent backgrounds.
+
+The pixel-buffer prototype output was checked with ffprobe and all 240 decoded frames compared using FFmpeg SSIM: overall 0.999428 versus baseline. This is high similarity, not pixel identity or comprehensive color/alpha validation.
+
+## Current pipeline findings
+
+- `apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift:198`: already creates a reusable Metal-backed CIContext when Metal is available. Enabling GPU rendering is not a missing first step.
+- `VideoBackgroundCompositor.swift:239`: synchronous serial rendering deliberately applies backpressure; the comment documents decoded-buffer retention from a backlog. Do not replace it with unbounded asynchronous requests.
+- `VideoBackgroundCompositor.swift:361`: builds the background graph for every frame, including blur when enabled. Wallpaper source images are already cached by `WallpaperImageCache`; the missing cache is the rendered background at output dimensions, not the image file decode.
+- `VideoBackgroundCompositor.swift:785`: gradients allocate and draw a full-size CGContext on each call.
+- `VideoBackgroundCompositor.swift:857`: rounded masks allocate a new bitmap on every call, even for radius zero. Source layout/mask geometry is usually invariant within an export instruction. This is another candidate, not separately timed here.
+- `VideoBackgroundCompositor.swift:887`: the ordinary shadow blurs the changing source image. Caching that entire shadow as static would freeze content-dependent appearance. Only invariant inset shadows can safely be precomputed without changing the design.
+- `apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift:612`: every movie export assigns a video composition. The styling `isPassthrough` branch means simpler composition, not compressed-stream passthrough.
+- `apps/macos/Sources/OpenRecorderMac/AppModel.swift:649`: saving copies the completed temporary file, then removes it. This adds a file operation but is outside the renderer timings above.
+
+Core Image intermediate caching is explicitly disabled. Apple documents the speed/memory tradeoff, and recommends disabling general intermediate caching for changing video frames in its video pipeline guidance. Prefer a small explicit cache for known static assets rather than enabling arbitrary intermediate retention: [cacheIntermediates](https://developer.apple.com/documentation/coreimage/cicontextoption/cacheintermediates), [video pipeline guidance](https://developer.apple.com/videos/play/wwdc2020/10008/).
+
+## OpenCut comparison
+
+Cloned the requested [OpenCut repository](https://github.com/OpenCut-app/OpenCut) into `/tmp/opencut-export-investigation-20260907`, main commit `400f097becba5db0fbc305d5a65348cb81c20356`. Its README says it is being rewritten and directs users to Classic. The current desktop code is a GPUI scaffold, not a completed export engine to adopt. Also inspected its `deploy` branch at `fdb4dff755faff2ee48efb673410438c55214046`, then cloned canonical Classic into `/tmp/opencut-classic-export-20260907` at `cf5e79e919144200294fb9fed22a222592a0aeea`.
+
+Useful patterns verified in Classic:
+
+1. **Cache unchanged visual resources.** [`wasm-compositor.ts`](https://github.com/opencut-app/opencut-classic/blob/cf5e79e919144200294fb9fed22a222592a0aeea/apps/web/src/services/renderer/compositor/wasm-compositor.ts) checks content hashes/source identity and dimensions; skips unchanged uploads, reuses backing canvases, and releases absent texture IDs. This is the strongest directly applicable idea.
+2. **Reuse GPU scratch resources.** [`texture_pool.rs`](https://github.com/opencut-app/opencut-classic/blob/cf5e79e919144200294fb9fed22a222592a0aeea/rust/crates/compositor/src/texture_pool.rs) recycles render textures by dimensions between frames. Open Recorder already uses AVFoundation's output pixel-buffer pool; focus additional reuse on its manually created masks/backgrounds.
+3. **Measure stages.** [`render-perf.ts`](https://github.com/opencut-app/opencut-classic/blob/cf5e79e919144200294fb9fed22a222592a0aeea/apps/web/src/diagnostics/render-perf.ts) records stage timings, percentiles and texture-upload/cache-hit counters. Equivalent measurements would distinguish decode, composition, encode, and final-save costs for real projects.
+4. **Bounded forward decoding.** [`video-cache/service.ts`](https://github.com/opencut-app/opencut-classic/blob/cf5e79e919144200294fb9fed22a222592a0aeea/apps/web/src/services/video-cache/service.ts) uses a forward iterator and current/next-frame prefetching. Native movie export already delegates media scheduling to AVFoundation; this is more relevant if replacing the sequential image-generator GIF path.
+
+Classic's [`scene-exporter.ts`](https://github.com/opencut-app/opencut-classic/blob/cf5e79e919144200294fb9fed22a222592a0aeea/apps/web/src/services/renderer/scene-exporter.ts) uses Mediabunny CanvasSource, AVC for MP4 / VP9 for WebM, and sequentially awaits rendering and adding each frame. It buffers the output through BufferTarget. Its GPU compositor is Rust/wgpu with browser backend support. Neither Rust nor this export loop establishes superior end-to-end speed. No OpenCut export benchmark was run, and no claim is made that it exports faster than Open Recorder.
+
+## Recommended implementation order
+
+1. Add a bounded, instruction-scoped cache of rendered wallpapers/gradients and static blur in an IOSurface-backed pixel buffer. Retain ownership, key/invalidate for instruction, dimensions and style, release on context/lifecycle changes; keep solid and transparent backgrounds cheap.
+2. Cache invariant masks with geometry/radius keys. Preserve crop edges and alpha; skipping radius-zero masks is safe only after proving equivalent clipping. Keep changing source-dependent shadows dynamic.
+3. Add render-stage timing and cache counters. Validate longer real projects at 1080p and 4K with zoom, cursor, facecam, blur, cancellation, and repeated exports; measure peak memory and compare rendered appearance/colors.
+4. Only then measure bounded two-frame concurrency if composition is still limiting throughput. Preserve backpressure and synchronization; concurrency is not required for the measured 2.07x gain.
+5. Separately implement eligible compressed-stream passthrough and a same-volume move with cross-volume fallback. Respect output resolution, frame rate, codec/container, transforms, styling, overlays and edits before selecting passthrough.
+
+## Reproduction artifacts
+
+Temporary investigation files retained on this machine:
+
+- `/tmp/ExportInvestigationProbeTests.swift` — disposable XCTest source; place into `apps/macos/Tests/OpenRecorderMacTests/` to rerun.
+- `/tmp/export-investigation-baseline-20260907.log`
+- `/tmp/export-investigation-cached-20260907.log`
+- `/tmp/export-investigation-pixelbuffer-20260907.log`
+- `/tmp/export-investigation-cgimage-cache.patch`
+- `/tmp/export-investigation-pixelbuffer-cache.patch` — experiment only; not hardened for release.
+- `/tmp/export-investigation-ssim-pixelbuffer.log`
+
+Command: `swift test --package-path apps/macos --filter ExportInvestigationProbeTests`. Input path is in the test. All three test runs passed. The disposable benchmark test was removed after measuring. The production cache and permanent regression tests remain in the PR.
+
+
+## Implemented change and final validation
+
+`VideoStaticBackgroundCache` stores one rendered wallpaper/gradient (including static blur) in a BGRA IOSurface pixel buffer. Keys include background style, extent and blur radius. Context changes and cancellation invalidate the cache; replacing keys releases the previous entry. Solid/transparent colors bypass rasterization. AVFoundation encoding, serial backpressure, rounded masks, source-dependent shadows and animated overlays keep their existing behavior.
+
+Final A/B run on the same M1 Max and original compositor at `897e2b2`, build time excluded:
+
+| Fixture / actual output | Original | Final cache | Speedup |
+| --- | ---: | ---: | ---: |
+| 8 seconds, 1080p30 | 3.013s | 1.496s | 2.01x |
+| 4 seconds, 4K30 | 2.304s | 1.897s | 1.21x |
+| 60 seconds, 1080p30 | 19.845s | 8.509s | 2.33x |
+
+These are synthetic clips and single A/B measurements of the final code; the earlier prototype table used three-run medians. FFmpeg verified matching duration, dimensions and decoded frame counts (240 / 120 / 1800). Whole-video SSIM was 0.999428 / 0.999328 / 0.999157. Test-run maximum resident set size from `time -l` was 409,714,688 bytes original and 394,100,736 bytes optimized; this is not a packaged-app memory benchmark.
+
+The 4K fixture contains 60 fps and the probe requested 60 fps, but both baseline and optimized exports actually encoded 30 fps. That pre-existing frame-rate discrepancy is outside this performance patch; the table reports the verified output rate rather than the requested rate.
+
+Validation completed:
+
+- `make test-macos`: 31 Rust tests passed; 691 Swift tests executed, one opt-in test skipped, zero failures.
+- `OPEN_RECORDER_ZOOM_RENDER_CHECK=1 swift test --package-path apps/macos --filter AdaptiveZoomRenderTests`: passed separately; 20 encoded videos covering ten scenarios, including cached wallpaper/blurred-gradient backgrounds, crop/aspect ratios, adaptive/legacy zoom, inset and fixed/moving facecam. Sampled marker positions and decoded durations are asserted; representative frames were visually inspected.
+- Five permanent cache tests verify repeated-frame reuse, size/style/blur invalidation, capacity-one eviction/release, constant-color bypass and gradient/blur/alpha fidelity (maximum channel difference two 8-bit levels).
+- `make package-macos-dev` and `codesign --verify --deep --strict` passed.
+- Computer Use launched that package, opened the synthetic `.openrecorder` project, used Export Video, observed rendering and the Save dialog, and saved `/tmp/export-cache-native-wallpaper.mov`. ffprobe confirmed 1920x1080, 30 fps, six seconds, 180 frames; an extracted frame was visually inspected. The save click's post-action AX read and subsequent editor AX/screenshot reads timed out, so return-to-editor interaction and a second native export were not verified. A process sample showed the main thread idle in its event loop. The saved output itself was successfully verified.
+
+Final experiment artifacts: `/tmp/ExportCacheFinalProbeTests.swift`, `/tmp/export-cache-{baseline,optimized}-performance.log`, `/tmp/export-cache-ssim-{1080p,4k,long}.log`, `/tmp/export-cache-full-tests.log`, `/tmp/export-cache-integration.log`, `/tmp/export-cache-package.log`. These temporary paths are local evidence, not repository fixtures.


### PR DESCRIPTION
Styled exports rebuild the same wallpaper/gradient and static blur for every frame. Cache that rendered background in one IOSurface-backed pixel buffer, keyed by style, dimensions and blur, and invalidate it on render-context changes and cancellation. Constant colors remain on the cheaper generator path; encoding, serial backpressure, masks and dynamic shadows are unchanged.

On an M1 Max synthetic A/B run, default-styled 1080p export fell from 3.01s to 1.50s for an 8-second clip and from 19.84s to 8.51s for a 60-second clip. A 4-second 4K30 output improved from 2.30s to 1.90s. Matching frame counts/durations were verified; SSIM against original output was 0.9991–0.9994. Test-run maximum RSS did not increase. These are synthetic measurements, not universal speed guarantees.

Validation:
- 31 Rust tests and 691 Swift tests (one opt-in skipped), zero failures.
- Opt-in render integration test passed separately: 20 encoded videos covering ten scenarios, including wallpaper, blurred gradients, crop/aspect ratios, zoom, inset, and fixed/moving facecam.
- Five cache tests cover reuse, invalidation, bounded eviction/release, constant-color bypass, and gradient/blur/alpha pixel fidelity.
- Development app packaging and strict code-signature verification passed.
- Computer Use opened a synthetic project and exported/saved a six-second 1080p movie; ffprobe verified 180 frames and an extracted frame was inspected. Post-save AX/screenshot reads timed out, so subsequent editor interaction was not verified.

The investigation report includes the OpenCut comparison and reproduction evidence. It also records a pre-existing discrepancy: the 4K probe requested 60 fps, but both original and optimized exports encoded 30 fps. This patch does not alter frame-rate selection.
