### PR TITLE
merge queue: checking #1100 on main (6915002)

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.base_ref }}
           fetch-depth: 0
@@ -93,7 +93,7 @@ jobs:
         run: make test-macos
 
       - name: Create or update release PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: ${{ steps.prepare.outputs.branch_name }}
           base: ${{ github.event.inputs.base_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       make_latest: ${{ steps.resolve.outputs.make_latest }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run tests
         run: make test-macos
@@ -175,7 +175,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download arm64 artifacts
         uses: actions/download-artifact@v4
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run tests
         run: make test-macos


### PR DESCRIPTION
**✨ Merge queue reset: an external action moved the base branch head to 962c82e86974523591c5de4735cbe1fb8fb36a1c. The pull request [#1100](/imbhargav5/open-recorder/pull/1100) has been requeued. ✨**

[#1100](/imbhargav5/open-recorder/pull/1100) is queued for merge on branch **main** (6915002).

This pull request has been created by Mergify to check the mergeability of [#1100](/imbhargav5/open-recorder/pull/1100).
    You don't need to do anything. Mergify will close this pull request automatically when it is complete.

**Required conditions of queue rule** `Default merge queue` **for merge:**

- [ ] any of:
  - [ ] `check-skipped=Native macOS tests`
  - [ ] `check-success=Native macOS tests`
- [X] `check-success=GitGuardian Security Checks`
- [X] `check-success=changes`

**Required conditions to stay in the queue:** None

```yaml
---
checking_base_sha: 691500244dd2ccceeeac9e199f56392d9330c26e
previous_check_retries: []
previous_failed_batches: []
pull_requests:
  - number: 1100
    scopes: []
scopes: []
...

```