### PR TITLE
Build production macOS packages in release mode and measure export performance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run tests
-        run: make test-macos
+        run: make test-macos test-macos-release
 
       - name: Import macOS signing certificate
         run: zsh scripts/import-macos-production-signing-certificate.zsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,17 +29,28 @@ jobs:
               - 'Makefile'
               - 'package.json'
 
-  test:
-    name: Native macOS tests
+  native-tests:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
-    runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-26, macos-26-intel]
+    runs-on: ${{ matrix.runner }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
+      - name: Debug and release tests
+        run: make test-macos test-macos-release
+      - name: Script tests
+        run: node --test scripts/*.test.mjs
 
-      - name: Run tests
-        run: make test-macos
-
-      - name: Test release-note rendering and appcast updates
-        run: node --test scripts/render-release-notes.test.mjs
+  test:
+    name: Native macOS tests
+    needs: [changes, native-tests]
+    if: always() && needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require both native architectures
+        env:
+          RESULT: ${{ needs.native-tests.result }}
+        run: test "$RESULT" = success

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,8 @@ test-macos:
 clean-macos:
 	cd apps/rust-service && cargo clean
 	cd apps/macos && swift package clean
+
+.PHONY: test-macos-release
+test-macos-release:
+	cd apps/rust-service && CARGO_INCREMENTAL=0 cargo test --release
+	cd apps/macos && swift test -c release -Xswiftc -DOPEN_RECORDER_TESTING

--- a/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppShellStateMachines.swift
@@ -239,7 +239,7 @@ final class AppShellDriver {
         workspaces.discard(session: editorSession)
     }
 
-    #if DEBUG
+    #if DEBUG || OPEN_RECORDER_TESTING
     var sessionWorkspaceCountForTesting: Int {
         workspaces.sessionCountForTesting
     }

--- a/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
@@ -38,7 +38,7 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
     private var mode: CaptureMode = .recording
     private var presentationGeneration = 0
 
-#if DEBUG
+#if DEBUG || OPEN_RECORDER_TESTING
     var presentedWindowCountForTesting: Int { windows.count }
     var presentedWindowsForTesting: [NSWindow] { windows }
 #endif

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -265,7 +265,7 @@ final class CaptureController: ObservableObject {
         screenRecordingPermission.currentState()
     }
 
-    #if DEBUG
+    #if DEBUG || OPEN_RECORDER_TESTING
     func setRecordingForTesting(_ isRecording: Bool) {
         self.isRecording = isRecording
     }

--- a/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorWorkspaceRegistry.swift
@@ -321,7 +321,7 @@ final class EditorWorkspaceRegistry {
         return sessionsByID[sessionID]
     }
 
-    #if DEBUG
+    #if DEBUG || OPEN_RECORDER_TESTING
     var sessionCountForTesting: Int {
         workspacesBySessionID.count
     }

--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -109,6 +109,7 @@ struct VideoBackgroundStyling: Equatable {
 }
 
 final class VideoBackgroundCompositionInstruction: NSObject, AVVideoCompositionInstructionProtocol, @unchecked Sendable {
+    var diagnostics: VideoExportDiagnostics?
     let timeRange: CMTimeRange
     let enablePostProcessing: Bool = false
     let containsTweening: Bool = true
@@ -285,6 +286,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
             throw VideoCompositorError.renderBufferUnavailable
         }
 
+        let preparationStart = instruction.diagnostics?.detailed == true ? CACurrentMediaTime() : 0
         let composedImage = try makeComposedImage(
             source: sourceBuffer,
             facecam: instruction.facecamTrackID.flatMap { request.sourceFrame(byTrackID: $0) },
@@ -292,13 +294,23 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
             compositionTime: request.compositionTime.seconds
         )
 
-        ciContext.render(
-            composedImage,
-            to: outputBuffer,
-            bounds: CGRect(origin: .zero, size: instruction.renderSize),
-            colorSpace: CGColorSpace(name: CGColorSpace.sRGB)
-        )
+        if let diagnostics = instruction.diagnostics, diagnostics.detailed {
+            let preparationSeconds = CACurrentMediaTime() - preparationStart
+            let destination = CIRenderDestination(pixelBuffer: outputBuffer)
+            destination.colorSpace = CGColorSpace(name: CGColorSpace.sRGB)
+            let task = try ciContext.startTask(toRender: composedImage, to: destination)
+            let info = try task.waitUntilCompleted()
+            diagnostics.record(preparationSeconds: preparationSeconds, info: info)
+        } else {
+            ciContext.render(
+                composedImage, to: outputBuffer,
+                bounds: CGRect(origin: .zero, size: instruction.renderSize),
+                colorSpace: CGColorSpace(name: CGColorSpace.sRGB)
+            )
+            instruction.diagnostics?.record()
+        }
 
+        instruction.diagnostics?.frameObserver?(outputBuffer, request.compositionTime.seconds)
         return outputBuffer
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportDiagnostics.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportDiagnostics.swift
@@ -1,0 +1,41 @@
+import CoreImage
+import CoreVideo
+import Foundation
+
+/// Opt-in, per-export measurements. Never logs media paths or changes encoder settings.
+final class VideoExportDiagnostics: @unchecked Sendable {
+    struct Snapshot: Codable {
+        var renderedFrames = 0
+        var preparationSeconds = 0.0
+        var kernelSeconds = 0.0
+        var renderPasses = 0
+        var processedPixels = 0
+    }
+    let detailed: Bool
+    let frameObserver: (@Sendable (CVPixelBuffer, Double) -> Void)?
+    private let lock = NSLock()
+    private var values = Snapshot()
+
+    init(detailed: Bool = false, frameObserver: (@Sendable (CVPixelBuffer, Double) -> Void)? = nil) {
+        self.detailed = detailed
+        self.frameObserver = frameObserver
+    }
+
+    func record(preparationSeconds: Double = 0, info: CIRenderInfo? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.renderedFrames += 1
+        values.preparationSeconds += preparationSeconds
+        if let info {
+            values.kernelSeconds += info.kernelExecutionTime
+            values.renderPasses += info.passCount
+            values.processedPixels += info.pixelsProcessed
+        }
+    }
+
+    func snapshot() -> Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -506,6 +506,7 @@ enum VideoExportRenderer {
         options: VideoExportOptions,
         cancellationToken: VideoExportCancellationToken? = nil,
         edits: TimelineEditSnapshot = .empty,
+        diagnostics: VideoExportDiagnostics? = nil,
         progressHandler: @escaping @MainActor (Double) -> Void = { _ in }
     ) async throws {
         if FileManager.default.fileExists(atPath: targetURL.path) {
@@ -513,6 +514,9 @@ enum VideoExportRenderer {
         }
 
         let context = try await makeRenderContext(sourceURL: sourceURL, options: options, edits: edits)
+        for instruction in context.videoComposition.instructions {
+            (instruction as? VideoBackgroundCompositionInstruction)?.diagnostics = diagnostics
+        }
         if options.format.isAnimatedImage {
             try await exportGIF(context: context, targetURL: targetURL, options: options, cancellationToken: cancellationToken, progressHandler: progressHandler)
         } else {

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoExportBenchmarkTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoExportBenchmarkTests.swift
@@ -1,0 +1,188 @@
+import AVFoundation
+import CoreImage
+import ImageIO
+import UniformTypeIdentifiers
+import Darwin
+import Foundation
+import XCTest
+@testable import OpenRecorderMac
+
+/// Explicit opt-in: JSON manifest + output directory; no timing thresholds in CI.
+final class VideoExportBenchmarkTests: XCTestCase {
+    struct Fixture: Decodable {
+        let name: String
+        let path: String
+        var appearance: String = "wallpaper"
+        var fps: Double = 30
+        var repeats: Int = 5
+        enum CodingKeys: String, CodingKey { case name, path, appearance, fps, repeats }
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            name = try c.decode(String.self, forKey: .name)
+            path = try c.decode(String.self, forKey: .path)
+            appearance = try c.decodeIfPresent(String.self, forKey: .appearance) ?? "wallpaper"
+            fps = try c.decodeIfPresent(Double.self, forKey: .fps) ?? 30
+            repeats = try c.decodeIfPresent(Int.self, forKey: .repeats) ?? 5
+        }
+    }
+    struct Media: Codable {
+        let width: Double, height: Double, duration: Double, nominalFPS: Double
+        let frames: Int
+        let firstPTS: Double, lastPTS: Double
+        let monotonic: Bool
+        let audioTracks: Int
+    }
+    struct Run: Codable {
+        let fixture: String, appearance: String, revision: String, configuration: String
+        let warmup: Bool, detailed: Bool
+        let requestedFPS: Double
+        let input: Media, output: Media
+        let exportSeconds: Double, saveSeconds: Double
+        let rssSamples: [UInt64]
+        let peakResidentBytes: UInt64
+        let composition: VideoExportDiagnostics.Snapshot
+    }
+    final class MemorySamples: @unchecked Sendable {
+        private let lock = NSLock()
+        private var samples: [UInt64] = []
+        func sample() {
+            var info = mach_task_basic_info()
+            var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<integer_t>.size)
+            let result = withUnsafeMutablePointer(to: &info) { p in
+                p.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                    task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+                }
+            }
+            if result == KERN_SUCCESS { lock.lock(); samples.append(info.resident_size); lock.unlock() }
+        }
+        func snapshot() -> [UInt64] { lock.lock(); defer { lock.unlock() }; return samples }
+    }
+
+    final class FrameCapture: @unchecked Sendable {
+        let directory: URL
+        let context = CIContext(options: [.cacheIntermediates: false])
+        let lock = NSLock()
+        init(_ directory: URL) { self.directory = directory }
+        func capture(_ buffer: CVPixelBuffer, time: Double) {
+            guard [0.0, 1.0, 2.0].contains(where: { abs($0 - time) < 0.0001 }) else { return }
+            lock.lock(); defer { lock.unlock() }
+            let source = CIImage(cvPixelBuffer: buffer)
+            guard let image = context.createCGImage(source, from: source.extent),
+                  let destination = CGImageDestinationCreateWithURL(directory.appendingPathComponent("frame-\(Int(time)).png") as CFURL, UTType.png.identifier as CFString, 1, nil) else { return }
+            CGImageDestinationAddImage(destination, image, nil)
+            _ = CGImageDestinationFinalize(destination)
+        }
+    }
+
+    @MainActor func testExportBenchmarks() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let manifest = env["OPEN_RECORDER_EXPORT_BENCH_MANIFEST"],
+              let resultPath = env["OPEN_RECORDER_EXPORT_BENCH_OUTPUT"] else {
+            throw XCTSkip("Set explicit benchmark manifest and output directory")
+        }
+        let root = URL(fileURLWithPath: resultPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let fixtures = try JSONDecoder().decode([Fixture].self, from: Data(contentsOf: URL(fileURLWithPath: manifest)))
+        var results: [Run] = []
+        #if DEBUG
+        let configuration = "debug"
+        #else
+        let configuration = "release"
+        #endif
+        for fixture in fixtures {
+            let source = URL(fileURLWithPath: fixture.path)
+            let input = try await metadata(source)
+            var options = VideoExportOptions.default
+            options.resolution = .source
+            options.frameRate = fixture.fps == 60 ? .fps60 : .fps30
+            XCTAssertTrue([30, 60].contains(fixture.fps))
+            if fixture.appearance != "plain" {
+                options.styling = VideoBackgroundStyling(background: BackgroundPresets.default,
+                    paddingRatio: 0.036, borderRadiusRatio: fixture.appearance == "rounded" ? 0.04 : 0,
+                    shadowIntensity: 0.35, backgroundBlurRatio: fixture.appearance == "blur" ? 0.04 : 0, inset: .none)
+            }
+            if fixture.appearance == "facecam" {
+                options.facecamVideoURL = source
+                options.facecamFallbackSettings = defaultFacecamSettings(enabled: true)
+            }
+            for index in 0...max(1, fixture.repeats) {
+                let captureDirectory = root.appendingPathComponent("\(fixture.name)-\(index)-frames", isDirectory: true)
+                let capturing = env["OPEN_RECORDER_EXPORT_CAPTURE_FRAMES"] == "1"
+                if capturing { try FileManager.default.createDirectory(at: captureDirectory, withIntermediateDirectories: true) }
+                let observer: (@Sendable (CVPixelBuffer, Double) -> Void)?
+                if capturing {
+                    let capture = FrameCapture(captureDirectory)
+                    observer = { buffer, time in capture.capture(buffer, time: time) }
+                }
+                else { observer = nil }
+                let diagnostics = VideoExportDiagnostics(detailed: env["OPEN_RECORDER_EXPORT_DIAGNOSTICS"] == "1", frameObserver: observer)
+                let output = root.appendingPathComponent("\(fixture.name)-\(index).mov")
+                let saved = root.appendingPathComponent("\(fixture.name)-\(index)-saved.mov")
+                let memory = MemorySamples()
+                memory.sample()
+                let timer = Task.detached {
+                    while !Task.isCancelled {
+                        memory.sample()
+                        try? await Task.sleep(for: .milliseconds(100))
+                    }
+                }
+                let start = ContinuousClock.now
+                do {
+                    try await VideoExportRenderer.export(sourceURL: source, targetURL: output, options: options, diagnostics: diagnostics)
+                } catch { timer.cancel(); throw error }
+                let exportSeconds = seconds(start.duration(to: .now))
+                memory.sample(); timer.cancel()
+                await timer.value
+                let saveStart = ContinuousClock.now
+                if FileManager.default.fileExists(atPath: saved.path) { try FileManager.default.removeItem(at: saved) }
+                try FileManager.default.copyItem(at: output, to: saved)
+                let saveSeconds = seconds(saveStart.duration(to: .now))
+                try FileManager.default.removeItem(at: saved)
+                let actual = try await metadata(output)
+                let samples = memory.snapshot()
+                results.append(Run(fixture: fixture.name, appearance: fixture.appearance,
+                    revision: env["OPEN_RECORDER_EXPORT_REVISION"] ?? "unspecified", configuration: configuration,
+                    warmup: index == 0, detailed: diagnostics.detailed, requestedFPS: fixture.fps,
+                    input: input, output: actual, exportSeconds: exportSeconds, saveSeconds: saveSeconds,
+                    rssSamples: samples, peakResidentBytes: samples.max() ?? 0, composition: diagnostics.snapshot()))
+                let encoder = JSONEncoder(); encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                try encoder.encode(results).write(to: root.appendingPathComponent("results.json"), options: .atomic)
+                XCTAssertEqual(actual.duration, input.duration, accuracy: 0.05, fixture.name)
+                XCTAssertEqual(actual.width, input.width, fixture.name)
+                XCTAssertEqual(actual.height, input.height, fixture.name)
+                XCTAssertEqual(actual.nominalFPS, fixture.fps, accuracy: 0.01, "Requested FPS mismatch: \(fixture.name)")
+                XCTAssertEqual(actual.frames, Int((input.duration * fixture.fps).rounded()), fixture.name)
+                XCTAssertEqual(actual.audioTracks, input.audioTracks, fixture.name)
+                XCTAssertTrue(actual.monotonic, fixture.name)
+                print("EXPORT_BENCH \(fixture.name) run=\(index) seconds=\(exportSeconds) frames=\(actual.frames)")
+            }
+        }
+    }
+
+    private func seconds(_ duration: Duration) -> Double {
+        Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1e18
+    }
+    @MainActor private func metadata(_ url: URL) async throws -> Media {
+        let asset = AVURLAsset(url: url)
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        let track = try XCTUnwrap(tracks.first)
+        let size = try await track.load(.naturalSize)
+        let duration = try await asset.load(.duration).seconds
+        let fps = try await track.load(.nominalFrameRate)
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA])
+        reader.add(output)
+        XCTAssertTrue(reader.startReading())
+        var times: [Double] = []
+        while let sample = output.copyNextSampleBuffer() {
+            times.append(CMSampleBufferGetPresentationTimeStamp(sample).seconds)
+        }
+        if reader.status == .failed { throw reader.error! }
+        // Decode frames: compressed samples may include encoder preroll and duplicates.
+        // Preserve decoder presentation order so timestamp regressions fail validation.
+        return Media(width: size.width, height: size.height, duration: duration, nominalFPS: Double(fps),
+                     frames: times.count, firstPTS: times.first ?? 0, lastPTS: times.last ?? 0,
+                     monotonic: zip(times, times.dropFirst()).allSatisfy { $0 < $1 },
+                     audioTracks: try await asset.loadTracks(withMediaType: .audio).count)
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoExportBenchmarkTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoExportBenchmarkTests.swift
@@ -30,6 +30,7 @@ final class VideoExportBenchmarkTests: XCTestCase {
         let frames: Int
         let firstPTS: Double, lastPTS: Double
         let monotonic: Bool
+        let maximumFrameIntervalError: Double
         let audioTracks: Int
     }
     struct Run: Codable {
@@ -151,9 +152,10 @@ final class VideoExportBenchmarkTests: XCTestCase {
                 XCTAssertEqual(actual.width, input.width, fixture.name)
                 XCTAssertEqual(actual.height, input.height, fixture.name)
                 XCTAssertEqual(actual.nominalFPS, fixture.fps, accuracy: 0.01, "Requested FPS mismatch: \(fixture.name)")
-                XCTAssertEqual(actual.frames, Int((input.duration * fixture.fps).rounded()), fixture.name)
+                XCTAssertEqual(actual.frames, Int(ceil(actual.duration * fixture.fps - 0.000001)), fixture.name)
                 XCTAssertEqual(actual.audioTracks, input.audioTracks, fixture.name)
                 XCTAssertTrue(actual.monotonic, fixture.name)
+                XCTAssertLessThanOrEqual(actual.maximumFrameIntervalError, 0.001, fixture.name)
                 print("EXPORT_BENCH \(fixture.name) run=\(index) seconds=\(exportSeconds) frames=\(actual.frames)")
             }
         }
@@ -183,6 +185,7 @@ final class VideoExportBenchmarkTests: XCTestCase {
         return Media(width: size.width, height: size.height, duration: duration, nominalFPS: Double(fps),
                      frames: times.count, firstPTS: times.first ?? 0, lastPTS: times.last ?? 0,
                      monotonic: zip(times, times.dropFirst()).allSatisfy { $0 < $1 },
+                     maximumFrameIntervalError: zip(times, times.dropFirst()).map { abs(($1 - $0) - 1 / Double(fps)) }.max() ?? 0,
                      audioTracks: try await asset.loadTracks(withMediaType: .audio).count)
     }
 }

--- a/docs/export-benchmarking.md
+++ b/docs/export-benchmarking.md
@@ -1,0 +1,26 @@
+# Native export benchmarking
+
+Production bundles use optimized Swift/Rust release builds. Development bundles default to debug; use `zsh scripts/package-macos-development-app.zsh --configuration release` for an optimized app under the development identity. Production rejects debug configuration. Bundles contain `OpenRecorderBuildConfiguration` and `OpenRecorderSourceRevision` metadata and are checked before signing.
+
+Create a local JSON manifest, for example:
+
+```json
+[
+  {"name":"1080-wallpaper","path":"/absolute/path/1080p.mp4","appearance":"wallpaper","fps":30,"repeats":5},
+  {"name":"4k-rounded","path":"/absolute/path/4k.mp4","appearance":"rounded","fps":30,"repeats":5}
+]
+```
+
+Run `python3 scripts/benchmark-macos-export.py manifest.json /tmp/export-baseline --configuration release`. Supported appearances: plain, wallpaper, rounded, blur, facecam. Sources should have upright dimensions; the harness preserves source resolution. The harness performs one warm-up followed by the requested measured runs, uses real MOV export, and separately measures the save-copy phase. JSON includes revision/configuration, metadata, composition request count, output frame count/PTS ordering, elapsed times and resident-memory samples at 100 ms intervals. Baseline memory includes the test host; peaks are sampled rather than exact allocation high-water marks. Frames are decoded outside the timed export to verify counts and presentation timestamps; compressed encoder preroll is not counted as output.
+
+Use `--diagnostics` in a separate run to gather Core Image kernel time, passes, processed pixels and CPU preparation time. Use `--capture-frames` in a separate run to save pre-encode frames at 0, 1 and 2 seconds. These diagnostic modes perturb timing and must not be used for performance acceptance. Plain exports use AVFoundation's built-in compositor, so their custom-compositor counter is zero; output frame count remains available.
+
+Comparative measurements use identical fixtures and hardware, one warm-up and five short runs. Include 1080p/4K, 60 seconds and ten minutes; use one measured run for the ten-minute stress case. Compare matching frames with FFmpeg SSIM (minimum 0.999) and captured pre-encode SDR PNG channels (maximum difference two). Check audio timing and decode every output independently. Retain a pixel-format/concurrency experiment only at >=10% improvement, <=5% slowdown in every measured scenario, and (for concurrency) <=25% peak-memory increase. Inspect long-run memory samples for growth.
+
+The harness intentionally fails on requested-versus-actual FPS mismatch and retains its JSON report. The previously observed 60-to-30 fps output discrepancy must not be counted as an optimization.
+
+Fixtures and outputs remain local; do not commit recordings or upload benchmark reports containing private file paths.
+
+Release tests and the benchmark runner enable `OPEN_RECORDER_TESTING` for existing test accessors. Normal packaging does not define it. `make test-macos-release` runs the optimized test suite; CI exercises both Apple Silicon and Intel and exposes one aggregate required check that fails if either architecture fails.
+
+The local validation fixtures can be reproduced using FFmpeg's `testsrc2=size=1920x1080:rate=30:duration=8` video and `sine=frequency=440:sample_rate=48000:duration=8` audio, encoded with `h264_videotoolbox` at 12 Mbps and AAC. Scale that fixture to 3840x2160 for a four-second 4K input (30 Mbps); stream-loop the 1080p fixture with stream copy and trim to 60 and 600 seconds for stress inputs. These are synthetic workloads, not evidence for every screen recording.

--- a/docs/export-performance-2026-09-08.md
+++ b/docs/export-performance-2026-09-08.md
@@ -1,0 +1,28 @@
+# Export optimization measurements — 2026-09-08
+
+Hardware: Apple M1 Max, 32 GiB memory, macOS 26.5 (25F71). Local synthetic H.264/AAC fixtures; no recordings uploaded. Baseline includes the static-background cache merged in #1097. Packaging/measurement source is the tree introduced in `c328cb1` (initial measurements used that uncommitted tree over `06309ee`). Detailed composition diagnostics and frame capture are disabled for comparative timings.
+
+## Stage 1: build configuration
+
+One warm-up and five measured exports per short fixture; medians in seconds. Upright source resolution, requested and decoded 30 fps, unchanged default codec/quality settings. 1080p clips contain 240 frames over eight seconds; 4K contains 120 over four seconds. Decoded counts, dimensions, duration, audio-track presence and strictly increasing presentation timestamps pass in both configurations.
+
+| Fixture | Debug | Release |
+| --- | ---: | ---: |
+| Plain 1080p | 0.874 | 0.872 |
+| Wallpaper 1080p | 1.391 | 1.378 |
+| Rounded 1080p | 1.499 | 1.483 |
+| Blurred background 1080p | 1.397 | 1.391 |
+| Facecam 1080p | 1.596 | 1.569 |
+| Rounded 4K | 2.334 | 2.329 |
+
+The observed 0–2% differences do not establish a material export speedup. Production release configuration remains a build-correctness fix. Most expensive compositor operations already execute in system frameworks/on the GPU, so optimizing Swift alone need not substantially change these workloads.
+
+Same-volume save-copy medians were approximately 0.3 ms on APFS; this is not a cross-volume copy measurement. Resident memory is sampled every 100 ms, includes the XCTest host and AVFoundation caches, and is not an exact allocation high-water mark. Decode verification happens outside timed export; memory comparisons must use matching fixture order and fresh processes.
+
+Local debug and optimized suites: 31 Rust tests and 692 Swift tests per configuration, with two explicit opt-in tests skipped. Real export benchmarks run those encoding paths separately. Release tests use `OPEN_RECORDER_TESTING` to expose test accessors without enabling DEBUG behavior in optimized code.
+
+Long 1080p rounded baseline: 60-second median 9.729 s (five measured runs), ten-minute measured export 99.666 s after a 99.238 s warm-up. The latter's sampled peak was 331 MiB; first/middle/final ten-second resident-memory medians were approximately 296/297/289 MiB, with no sustained growth observed. Stream-looped fixtures have fractional final frames: 60.017 s input produces 1,801 frames and 600.014 s produces 18,001. The initial harness incorrectly rounded frame counts down; verification uses the ceiling of output duration times FPS, and checks frame cadence separately. This measurement correction changes no export behavior.
+
+A separate 4K requested-60-fps probe reproduces the existing mismatch: 30 fps and 120 frames over four seconds, rather than the requested 240. Its benchmark intentionally fails and its timings are excluded from performance comparisons. Fixing that discrepancy is separate work.
+
+The opt-in optimized integration suite produced 20 real exports covering plain/padded, wallpaper, blurred gradient, crop, portrait/square aspect, inset, adaptive/legacy zoom and fixed/moving facecam. Native packaging completed with configuration `release`, matching source binary UUIDs/resources, arm64 architecture, version 0.2.49, and a valid development signature. Apple Silicon and Intel debug/release CI passed on the initial implementation. Interactive export/save/playback/settings/repeat validation is blocked by a locked Mac; Computer Use's automatic unlock failed. Compilation, packaging and API integration tests do not substitute for that UI coverage.

--- a/scripts/benchmark-macos-export.py
+++ b/scripts/benchmark-macos-export.py
@@ -1,0 +1,44 @@
+"""Run opt-in native export benchmarks. Output contains local fixture paths: do not upload it."""
+import argparse
+import json
+import os
+import platform
+from pathlib import Path
+import statistics
+import subprocess
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("manifest", type=Path)
+parser.add_argument("output", type=Path)
+parser.add_argument("--configuration", choices=["debug", "release"], default="release")
+parser.add_argument("--diagnostics", action="store_true")
+parser.add_argument("--capture-frames", action="store_true")
+args = parser.parse_args()
+root = Path(__file__).resolve().parent.parent
+modified = bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=root, text=True).strip())
+hardware = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip()
+revision = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+environment = {**os.environ, "OPEN_RECORDER_EXPORT_BENCH_MANIFEST": str(args.manifest.resolve()),
+               "OPEN_RECORDER_EXPORT_BENCH_OUTPUT": str(args.output.resolve()),
+               "OPEN_RECORDER_EXPORT_REVISION": revision,
+               "OPEN_RECORDER_EXPORT_DIAGNOSTICS": "1" if args.diagnostics else "0",
+               "OPEN_RECORDER_EXPORT_CAPTURE_FRAMES": "1" if args.capture_frames else "0"}
+result = subprocess.run(["swift", "test", "--package-path", "apps/macos", "-c", args.configuration,
+                         "-Xswiftc", "-DOPEN_RECORDER_TESTING", "--filter", "VideoExportBenchmarkTests"], env=environment, cwd=root)
+report = args.output / "results.json"
+if report.exists():
+    rows = json.loads(report.read_text())
+    for row in rows:
+        row.update(hardware=hardware, operatingSystem=platform.mac_ver()[0], sourceModified=modified, captureFrames=args.capture_frames)
+    report.write_text(json.dumps(rows, indent=2) + "\n")
+    summary = []
+    for name in dict.fromkeys(row["fixture"] for row in rows):
+        measurements = [row for row in rows if row["fixture"] == name and not row["warmup"]]
+        if measurements:
+            summary.append({"fixture": name, "runs": len(measurements),
+                            "exportMedianSeconds": statistics.median(row["exportSeconds"] for row in measurements),
+                            "saveMedianSeconds": statistics.median(row["saveSeconds"] for row in measurements),
+                            "peakResidentBytes": max(row["peakResidentBytes"] for row in measurements)})
+    (args.output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps(summary, indent=2))
+raise SystemExit(result.returncode)

--- a/scripts/benchmark-macos-export.py
+++ b/scripts/benchmark-macos-export.py
@@ -14,6 +14,8 @@ parser.add_argument("--configuration", choices=["debug", "release"], default="re
 parser.add_argument("--diagnostics", action="store_true")
 parser.add_argument("--capture-frames", action="store_true")
 args = parser.parse_args()
+if (args.output / "results.json").exists():
+    parser.error("Choose a fresh output directory; existing results must not be mixed with a new run")
 root = Path(__file__).resolve().parent.parent
 modified = bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=root, text=True).strip())
 hardware = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip()

--- a/scripts/package-macos-app-shared.zsh
+++ b/scripts/package-macos-app-shared.zsh
@@ -6,15 +6,21 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 app_variant="production"
 install=false
 launch=false
+build_configuration=""
 
-for arg in "$@"; do
-	case "$arg" in
+while (( $# > 0 )); do
+	case "$1" in
 		--dev)
 			app_variant="development"
 			;;
 		--production)
 			app_variant="production"
 			;;
+		--configuration)
+            (( $# >= 2 )) || { print -u2 -- "--configuration requires debug or release"; exit 2; }
+            build_configuration="$2"
+            shift
+            ;;
 		--install)
 			install=true
 			;;
@@ -22,11 +28,25 @@ for arg in "$@"; do
 			launch=true
 			;;
 		*)
-			print -u2 -- "Unknown argument: $arg"
+			print -u2 -- "Unknown argument: $1"
 			exit 2
 			;;
 	esac
+    shift
 done
+
+if [[ -z "$build_configuration" ]]; then
+    [[ "$app_variant" == "production" ]] && build_configuration=release || build_configuration=debug
+fi
+if [[ "$build_configuration" != debug && "$build_configuration" != release ]]; then
+    print -u2 -- "--configuration must be debug or release"
+    exit 2
+fi
+if [[ "$app_variant" == production && "$build_configuration" != release ]]; then
+    print -u2 -- "Production packages require release configuration"
+    exit 2
+fi
+source_revision="$(git -C "$repo_root" rev-parse HEAD)"
 
 if [[ "$app_variant" == "development" ]]; then
 	app_name="${OPEN_RECORDER_DEV_APP_NAME:-Open Recorder Dev}"
@@ -40,10 +60,10 @@ bundle_dir="$repo_root/release/${app_name}.app"
 contents_dir="$bundle_dir/Contents"
 macos_dir="$contents_dir/MacOS"
 resources_dir="$contents_dir/Resources"
-swift_binary="$repo_root/apps/macos/.build/debug/OpenRecorderMac"
+
 swift_resource_bundle_name="OpenRecorderMac_OpenRecorderMac.bundle"
-swift_resource_bundle="$repo_root/apps/macos/.build/debug/$swift_resource_bundle_name"
-service_binary="$repo_root/apps/rust-service/target/debug/open-recorder-service"
+
+
 info_plist="$repo_root/apps/macos/Resources/Info.plist"
 icon_source="$repo_root/apps/macos/Resources/AppIcon.icns"
 
@@ -69,19 +89,20 @@ binary_has_rpath() {
 }
 
 cd "$repo_root/apps/rust-service"
-CARGO_INCREMENTAL=0 cargo build
+rust_flags=()
+[[ "$build_configuration" == release ]] && rust_flags+=(--release)
+CARGO_INCREMENTAL=0 cargo build "${rust_flags[@]}"
+rust_target_dir="$(cargo metadata --format-version 1 --no-deps | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')"
+service_binary="$rust_target_dir/$build_configuration/open-recorder-service"
 
 cd "$repo_root/apps/macos"
-swift build
-
-if [[ ! -d "$swift_resource_bundle" ]]; then
-	swift_resource_bundle="$(find "$repo_root/apps/macos/.build" -type d -name "$swift_resource_bundle_name" -print -quit)"
-fi
-
-if [[ ! -d "$swift_resource_bundle" ]]; then
-	print -u2 -- "Swift resource bundle not found: $swift_resource_bundle_name"
-	exit 1
-fi
+swift build -c "$build_configuration"
+swift_bin_path="$(swift build -c "$build_configuration" --show-bin-path)"
+swift_binary="$swift_bin_path/OpenRecorderMac"
+swift_resource_bundle="$swift_bin_path/$swift_resource_bundle_name"
+for required_path in "$swift_binary" "$service_binary" "$swift_resource_bundle"; do
+    [[ -e "$required_path" ]] || { print -u2 -- "Missing $build_configuration artifact: $required_path"; exit 1; }
+done
 
 rm -rf "$bundle_dir"
 mkdir -p "$macos_dir" "$resources_dir"
@@ -109,6 +130,8 @@ ditto "$sparkle_framework_source" "$contents_dir/Frameworks/Sparkle.framework"
 set_plist_string "CFBundleName" "$app_name"
 set_plist_string "CFBundleDisplayName" "$app_name"
 set_plist_string "CFBundleIdentifier" "$bundle_identifier"
+set_plist_string "OpenRecorderBuildConfiguration" "$build_configuration"
+set_plist_string "OpenRecorderSourceRevision" "$source_revision"
 
 if [[ -f "$icon_source" ]]; then
 	cp "$icon_source" "$resources_dir/AppIcon.icns"
@@ -124,6 +147,7 @@ if ! binary_has_rpath "$macos_dir/OpenRecorderMac" "$frameworks_rpath"; then
 	fi
 	install_name_tool -add_rpath "$frameworks_rpath" "$macos_dir/OpenRecorderMac"
 fi
+python3 "$repo_root/scripts/verify-macos-build.py" "$bundle_dir" --configuration "$build_configuration" --revision "$source_revision" --architecture "$(uname -m)" --swift-bin-path "$swift_bin_path" --rust-bin-path "$rust_target_dir/$build_configuration" --version "$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$info_plist")"
 find "$bundle_dir" \( -name '._*' -o -name '.__CodeSignature' \) -delete
 if [[ "$app_variant" == "development" ]]; then
 	zsh "$repo_root/scripts/sign-macos-development-app.zsh" "$bundle_dir"

--- a/scripts/package-macos.test.mjs
+++ b/scripts/package-macos.test.mjs
@@ -1,0 +1,17 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+
+for (const args of [
+  ['--production', '--configuration', 'debug'],
+  ['--dev', '--configuration', 'invalid'],
+  ['--configuration'],
+  ['--unknown'],
+  ['--configuration', 'debug', '--production'],
+]) {
+  test(`reject unsafe/invalid packaging arguments: ${args.join(' ')}`, () => {
+    const result = spawnSync('zsh', ['scripts/package-macos-app-shared.zsh', ...args], {encoding: 'utf8'});
+    assert.equal(result.status, 2, result.stderr);
+    assert.doesNotMatch(result.stdout, /Compiling|Building/);
+  });
+}

--- a/scripts/verify-macos-build.py
+++ b/scripts/verify-macos-build.py
@@ -1,0 +1,54 @@
+"""Verify a packaged native build before signing or distributing it."""
+import argparse
+import hashlib
+import plistlib
+import subprocess
+from pathlib import Path
+
+
+def verify(bundle, configuration, revision, architecture, version, swift_bin_path, rust_bin_path):
+    contents = Path(bundle) / "Contents"
+    with (contents / "Info.plist").open("rb") as handle:
+        metadata = plistlib.load(handle)
+    expected = {"OpenRecorderBuildConfiguration": configuration,
+                "OpenRecorderSourceRevision": revision,
+                "CFBundleShortVersionString": version, "CFBundleVersion": version}
+    for key, value in expected.items():
+        if metadata.get(key) != value:
+            raise ValueError(f"{key}: expected {value}, got {metadata.get(key)}")
+    resources = contents / "Resources" / "OpenRecorderMac_OpenRecorderMac.bundle"
+    if not resources.is_dir() or not any(resources.rglob("*.jpg")):
+        raise ValueError("Missing packaged Swift wallpaper resources")
+    def digest(path):
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    for path in [Path(swift_bin_path), Path(rust_bin_path)]:
+        if path.resolve().name != configuration:
+            raise ValueError(f"Artifact directory is not {configuration}: {path}")
+    source_resources = Path(swift_bin_path) / resources.name
+    for path in source_resources.rglob("*"):
+        if path.is_file() and digest(path) != digest(resources / path.relative_to(source_resources)):
+            raise ValueError(f"Resource differs from selected build: {path}")
+    if not source_resources.is_dir():
+        raise ValueError("Missing resources in selected build directory")
+    for executable, source_dir in [("OpenRecorderMac", swift_bin_path), ("open-recorder-service", rust_bin_path)]:
+        binary = contents / "MacOS" / executable
+        source = Path(source_dir) / executable
+        # Packaging may add an rpath or replace a signature; the Mach-O UUID stays stable.
+        def uuids(path):
+            return [line.split()[1:3] for line in subprocess.check_output(
+                ["dwarfdump", "--uuid", str(path)], text=True).splitlines()]
+        if not uuids(source) or uuids(source) != uuids(binary):
+            raise ValueError(f"{executable}: does not match selected build")
+        architectures = subprocess.check_output(["lipo", "-archs", str(binary)], text=True).split()
+        if set(architectures) != set(architecture.split(",")):
+            raise ValueError(f"{executable}: unexpected architectures {architectures}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle")
+    for name in ["configuration", "revision", "architecture", "version", "swift-bin-path", "rust-bin-path"]:
+        parser.add_argument("--" + name, required=True)
+    args = parser.parse_args()
+    verify(**vars(args))
+    print(f"Verified {args.configuration} bundle at {args.revision}")

--- a/scripts/verify-macos-build.test.mjs
+++ b/scripts/verify-macos-build.test.mjs
@@ -1,0 +1,36 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+
+test('packaging verifier rejects incorrect metadata and resources', () => {
+  const result = spawnSync('python3', ['-c', `
+import importlib.util, pathlib, plistlib, tempfile, sys
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location('verify', 'scripts/verify-macos-build.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    contents = root / 'Contents'
+    contents.mkdir()
+    good = dict(OpenRecorderBuildConfiguration='release', OpenRecorderSourceRevision='abc',
+                CFBundleShortVersionString='1.0', CFBundleVersion='1.0')
+    for field in good:
+        metadata = {**good, field: 'incorrect'}
+        (contents / 'Info.plist').write_bytes(plistlib.dumps(metadata))
+        try:
+            module.verify(root, 'release', 'abc', 'arm64', '1.0', '/tmp/release', '/tmp/release')
+        except ValueError as error:
+            assert field in str(error), error
+        else:
+            raise AssertionError(field)
+    (contents / 'Info.plist').write_bytes(plistlib.dumps(good))
+    try:
+        module.verify(root, 'release', 'abc', 'arm64', '1.0', '/tmp/release', '/tmp/release')
+    except ValueError as error:
+        assert 'resources' in str(error), error
+    else:
+        raise AssertionError('missing resources accepted')
+`], {encoding: 'utf8'});
+  assert.equal(result.status, 0, result.stderr);
+});


### PR DESCRIPTION
Production packaging currently builds and copies debug Swift and Rust binaries. Use release builds for production, allow an explicitly optimized development package, and resolve resources only from the selected Swift build directory. Verify bundle metadata, architecture, source binary identity and resource contents before signing.

Add an opt-in export benchmark that calls the real exporter, decodes output to check frame count/FPS/timestamps, records timing and sampled resident memory, and supports separate Core Image diagnostics and pre-encode frame capture. Existing test accessors use a dedicated testing flag so optimized tests do not enable DEBUG behavior. Run debug and release suites on Apple Silicon and Intel, including before release packaging.

Validation: local Rust suites and 692 Swift tests pass in both configurations (two opt-in tests skipped); packaging argument tests pass. Short-fixture medians show only 0–2% debug/release differences; this is a build correction, not a claimed material export speedup. The 1080p ten-minute fixture exported in 99.7 s with stable sampled memory. The optimized integration suite produced 20 exports and development packaging/signing passed. Native UI testing is blocked by a locked Mac. See docs/export-performance-2026-09-08.md for measurements and the separately reproduced requested-60/output-30 FPS defect. No codec, frame-rate, resolution or quality setting is changed. This PR does not publish a release.
