### PR TITLE
Cache invariant video masks without changing export quality

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -201,6 +201,12 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     private let renderingQueue = DispatchQueue(label: "com.openrecorder.video.compositor", qos: .userInitiated)
     private let ciContext: CIContext
     private let backgroundCache: VideoStaticBackgroundCache
+    let roundedMaskCache = VideoRoundedMaskCache()
+    #if OPEN_RECORDER_TESTING
+    private let cacheMasks = ProcessInfo.processInfo.environment["OPEN_RECORDER_EXPORT_UNCACHED_MASKS"] != "1"
+    #else
+    private let cacheMasks = true
+    #endif
     private var renderContext: AVVideoCompositionRenderContext?
     private let renderContextLock = NSLock()
     private var annotationCache: [String: CIImage] = [:]
@@ -238,6 +244,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         renderContext = newRenderContext
         renderContextLock.unlock()
         backgroundCache.invalidate()
+        roundedMaskCache.invalidate()
     }
 
     func startRequest(_ request: AVAsynchronousVideoCompositionRequest) {
@@ -266,7 +273,10 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     }
 
     func cancelAllPendingVideoCompositionRequests() {
-        defer { backgroundCache.invalidate() }
+        defer {
+            backgroundCache.invalidate()
+            roundedMaskCache.invalidate()
+        }
         if DispatchQueue.getSpecific(key: renderingQueueKey) == true {
             return
         }
@@ -372,7 +382,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
             height: scaledSize.height
         )
         let cornerRadius = instruction.styling.borderRadiusRatio * minDim
-        let maskedSource = applyRoundedMask(positionedImage, cornerRadius: cornerRadius, in: placedRect)
+        let maskedSource = applyRoundedMask(positionedImage, cornerRadius: cornerRadius, in: placedRect, role: .recording)
 
         let blurRadius = instruction.styling.backgroundBlurRatio * minDim
         let background = backgroundCache.image(
@@ -567,7 +577,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         let dx = frame.midX - image.extent.midX
         let dy = frame.midY - image.extent.midY
         image = image.transformed(by: CGAffineTransform(translationX: dx, y: dy))
-        let clipped = applyRoundedMask(image.cropped(to: frame), cornerRadius: radius, in: frame)
+        let clipped = applyRoundedMask(image.cropped(to: frame), cornerRadius: radius, in: frame, role: .facecam)
 
         guard settings.clamped.borderWidth > 0 else {
             return clipped
@@ -877,28 +887,17 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         return filter.outputImage ?? image
     }
 
-    private func applyRoundedMask(_ image: CIImage, cornerRadius: CGFloat, in rect: CGRect) -> CIImage {
-        let width = max(Int(ceil(rect.width)), 1)
-        let height = max(Int(ceil(rect.height)), 1)
-        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
-        guard let context = CGContext(
-            data: nil,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: 0,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return image }
-
-        context.setFillColor(NSColor.white.cgColor)
-        let maskRect = CGRect(x: 0, y: 0, width: width, height: height)
-        let radius = max(0, min(cornerRadius, min(rect.width, rect.height) / 2))
-        context.addPath(CGPath(roundedRect: maskRect, cornerWidth: radius, cornerHeight: radius, transform: nil))
-        context.fillPath()
-
-        guard let maskCG = context.makeImage() else { return image }
-        let maskImage = CIImage(cgImage: maskCG).transformed(by: CGAffineTransform(translationX: rect.minX, y: rect.minY))
+    private func applyRoundedMask(_ image: CIImage, cornerRadius: CGFloat, in rect: CGRect,
+                                  role: VideoRoundedMaskCache.Role? = nil) -> CIImage {
+        let localMask: CIImage?
+        if let role, cacheMasks {
+            localMask = roundedMaskCache.mask(size: rect.size, cornerRadius: cornerRadius, role: role)
+        } else {
+            // Inset/decorative geometry must not evict the recording or facecam raster.
+            localMask = VideoRoundedMaskCache.makeMask(size: rect.size, cornerRadius: cornerRadius)
+        }
+        guard let localMask else { return image }
+        let maskImage = localMask.transformed(by: CGAffineTransform(translationX: rect.minX, y: rect.minY))
 
         guard let filter = CIFilter(name: "CIBlendWithMask") else { return image }
         filter.setValue(image, forKey: kCIInputImageKey)

--- a/apps/macos/Sources/OpenRecorderMac/VideoRoundedMaskCache.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoRoundedMaskCache.swift
@@ -1,0 +1,51 @@
+import AppKit
+import CoreImage
+
+/// One invariant raster per content role. Placement is applied by the compositor.
+final class VideoRoundedMaskCache: @unchecked Sendable {
+    enum Role: Hashable { case recording, facecam }
+    private struct Key: Equatable {
+        let width: Int, height: Int
+        let radius: CGFloat
+        init(size: CGSize, cornerRadius: CGFloat) {
+            width = max(Int(ceil(size.width)), 1)
+            height = max(Int(ceil(size.height)), 1)
+            radius = max(0, min(cornerRadius, min(size.width, size.height) / 2))
+        }
+    }
+    private struct Entry { let key: Key; let image: CIImage }
+    private let lock = NSLock()
+    private var entries: [Role: Entry] = [:]
+
+    func mask(size: CGSize, cornerRadius: CGFloat, role: Role) -> CIImage? {
+        lock.lock(); defer { lock.unlock() }
+        let key = Key(size: size, cornerRadius: cornerRadius)
+        if let entry = entries[role], entry.key == key { return entry.image }
+        // Replace the role even if allocation fails; never retain obsolete geometry.
+        entries[role] = nil
+        guard let image = Self.makeMask(key: key) else { return nil }
+        entries[role] = Entry(key: key, image: image)
+        return image
+    }
+
+    func invalidate() {
+        lock.lock(); defer { lock.unlock() }
+        entries.removeAll(keepingCapacity: true)
+    }
+
+    static func makeMask(size: CGSize, cornerRadius: CGFloat) -> CIImage? {
+        makeMask(key: Key(size: size, cornerRadius: cornerRadius))
+    }
+
+    private static func makeMask(key: Key) -> CIImage? {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(data: nil, width: key.width, height: key.height,
+            bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+        context.setFillColor(NSColor.white.cgColor)
+        let rect = CGRect(x: 0, y: 0, width: key.width, height: key.height)
+        context.addPath(CGPath(roundedRect: rect, cornerWidth: key.radius, cornerHeight: key.radius, transform: nil))
+        context.fillPath()
+        return context.makeImage().map { CIImage(cgImage: $0) }
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/AdaptiveZoomRenderTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AdaptiveZoomRenderTests.swift
@@ -57,6 +57,7 @@ final class AdaptiveZoomRenderTests: XCTestCase {
             ("plain", plain, [click(220, 180, 1000)]),
             ("padded", padded, [click(220, 180, 1000)]),
             ("wallpaper", wallpaper, [click(220, 180, 1000)]),
+            ("cursor-annotation", wallpaper, [click(220, 180, 1000)]),
             ("blurred-gradient", blurredGradient, [click(220, 180, 1000)]),
             ("cropped", cropped, [click(320, 120, 1000)]),
             ("portrait", portrait, [click(320, 120, 1000)]),
@@ -65,11 +66,26 @@ final class AdaptiveZoomRenderTests: XCTestCase {
             ("camera-fixed", camera, [click(220, 180, 1000)]),
             ("camera-moving", movingCamera, [click(220, 180, 1000)])
         ]
-        for (name, options, clicks) in scenarios {
-            let telemetry = CursorTelemetryPayload(width: 640, height: 360, samples: [], clicks: clicks)
+        for (name, initialOptions, clicks) in scenarios {
+            var options = initialOptions
+            let samples: [CursorTelemetrySample] = name == "cursor-annotation"
+                ? stride(from: 0, through: 6000, by: 100).map {
+                    CursorTelemetrySample(x: 520, y: 300, timestamp: $0, cursorType: "arrow")
+                } : []
+            let telemetry = CursorTelemetryPayload(width: 640, height: 360, samples: samples, clicks: clicks)
+            if name == "cursor-annotation" {
+                let telemetryURL = root.appendingPathComponent("overlay-telemetry.json")
+                try JSONEncoder().encode(telemetry).write(to: telemetryURL)
+                options.cursorOverlay = .default
+                options.cursorTelemetryURL = telemetryURL
+            }
             let regions = AutoZoomGenerator.generate(from: telemetry, duration: 6, cameraSettings: options.facecamFallbackSettings)
             XCTAssertFalse(regions.isEmpty, name)
-            let edits = TimelineEditSnapshot(zoomRegions: regions)
+            var edits = TimelineEditSnapshot(zoomRegions: regions)
+            if name == "cursor-annotation" {
+                edits.annotationRegions = [TimelineAnnotationRegion(span: TimelineSpan(start: 0.25, end: 5.5),
+                    text: "Export fidelity: Aa 0123", x: 0.5, y: 0.8, fontSize: 20)]
+            }
             if name == "pan-inset" {
                 let telemetryURL = CursorTelemetryRecorder.telemetryURL(for: source)
                 try JSONEncoder().encode(telemetry).write(to: telemetryURL)

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoExportBenchmarkTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoExportBenchmarkTests.swift
@@ -15,7 +15,8 @@ final class VideoExportBenchmarkTests: XCTestCase {
         var appearance: String = "wallpaper"
         var fps: Double = 30
         var repeats: Int = 5
-        enum CodingKeys: String, CodingKey { case name, path, appearance, fps, repeats }
+        var warmup: Bool = true
+        enum CodingKeys: String, CodingKey { case name, path, appearance, fps, repeats, warmup }
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             name = try c.decode(String.self, forKey: .name)
@@ -23,6 +24,7 @@ final class VideoExportBenchmarkTests: XCTestCase {
             appearance = try c.decodeIfPresent(String.self, forKey: .appearance) ?? "wallpaper"
             fps = try c.decodeIfPresent(Double.self, forKey: .fps) ?? 30
             repeats = try c.decodeIfPresent(Int.self, forKey: .repeats) ?? 5
+            warmup = try c.decodeIfPresent(Bool.self, forKey: .warmup) ?? true
         }
     }
     struct Media: Codable {
@@ -106,7 +108,7 @@ final class VideoExportBenchmarkTests: XCTestCase {
                 options.facecamVideoURL = source
                 options.facecamFallbackSettings = defaultFacecamSettings(enabled: true)
             }
-            for index in 0...max(1, fixture.repeats) {
+            for index in (fixture.warmup ? 0 : 1)...max(1, fixture.repeats) {
                 let captureDirectory = root.appendingPathComponent("\(fixture.name)-\(index)-frames", isDirectory: true)
                 let capturing = env["OPEN_RECORDER_EXPORT_CAPTURE_FRAMES"] == "1"
                 if capturing { try FileManager.default.createDirectory(at: captureDirectory, withIntermediateDirectories: true) }

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoExportCancellationIntegrationTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoExportCancellationIntegrationTests.swift
@@ -1,0 +1,46 @@
+import AVFoundation
+import XCTest
+@testable import OpenRecorderMac
+
+final class VideoExportCancellationIntegrationTests: XCTestCase {
+    @MainActor func testCancelActiveExportThenExportAgain() async throws {
+        guard let path = ProcessInfo.processInfo.environment["OPEN_RECORDER_EXPORT_CANCEL_FIXTURE"] else {
+            throw XCTSkip("Set a local video fixture for real cancellation validation")
+        }
+        let source = URL(fileURLWithPath: path)
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("export-cancellation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        var options = VideoExportOptions.default
+        options.resolution = .source
+        options.frameRate = .fps30
+        options.styling = VideoBackgroundStyling(background: BackgroundPresets.default, paddingRatio: 0.036,
+            borderRadiusRatio: 0.04, shadowIntensity: 0.35, backgroundBlurRatio: 0, inset: .none)
+        let diagnostics = VideoExportDiagnostics()
+        let token = VideoExportCancellationToken()
+        let task = Task {
+            try await VideoExportRenderer.export(sourceURL: source, targetURL: root.appendingPathComponent("cancelled.mov"),
+                options: options, cancellationToken: token, diagnostics: diagnostics)
+        }
+        for _ in 0..<500 {
+            if diagnostics.snapshot().renderedFrames >= 2 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertGreaterThanOrEqual(diagnostics.snapshot().renderedFrames, 2, "Cancel admitted rendering work")
+        token.cancel(); task.cancel()
+        do {
+            try await task.value
+            XCTFail("Cancelled export reported success")
+        } catch VideoExportRendererError.exportCancelled { }
+        let finishedFrames = diagnostics.snapshot().renderedFrames
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(diagnostics.snapshot().renderedFrames, finishedFrames, "No stale completions after cancellation")
+        let retry = root.appendingPathComponent("retry.mov")
+        try await VideoExportRenderer.export(sourceURL: source, targetURL: retry, options: options)
+        let asset = AVURLAsset(url: retry)
+        let duration = try await asset.load(.duration).seconds
+        let sourceDuration = try await AVURLAsset(url: source).load(.duration).seconds
+        XCTAssertEqual(duration, sourceDuration, accuracy: 0.05)
+        XCTAssertGreaterThan(try retry.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0, 0)
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/VideoRoundedMaskCacheTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/VideoRoundedMaskCacheTests.swift
@@ -1,0 +1,74 @@
+import AVFoundation
+import CoreImage
+import XCTest
+@testable import OpenRecorderMac
+
+final class VideoRoundedMaskCacheTests: XCTestCase {
+    func testReusesInvariantRasterAcrossPlacement() throws {
+        let cache = VideoRoundedMaskCache()
+        let first = try XCTUnwrap(cache.mask(size: CGSize(width: 100.2, height: 80.1), cornerRadius: 12, role: .recording))
+        let second = try XCTUnwrap(cache.mask(size: CGSize(width: 100.2, height: 80.1), cornerRadius: 12, role: .recording))
+        XCTAssertTrue(first === second)
+        XCTAssertEqual(first.extent, CGRect(x: 0, y: 0, width: 101, height: 81))
+        let placed = second.transformed(by: CGAffineTransform(translationX: 25.5, y: 44.25))
+        XCTAssertEqual(placed.extent, first.extent.offsetBy(dx: 25.5, dy: 44.25).integral)
+    }
+
+    func testGeometryReplacementDoesNotEvictOtherRole() throws {
+        let cache = VideoRoundedMaskCache()
+        let size = CGSize(width: 100, height: 80)
+        let recording = try XCTUnwrap(cache.mask(size: size, cornerRadius: 8, role: .recording))
+        let camera = try XCTUnwrap(cache.mask(size: size, cornerRadius: 20, role: .facecam))
+        for width in 101...120 {
+            let next = try XCTUnwrap(cache.mask(size: CGSize(width: width, height: 80), cornerRadius: 8, role: .recording))
+            XCTAssertFalse(next === recording)
+            XCTAssertTrue(camera === cache.mask(size: size, cornerRadius: 20, role: .facecam))
+        }
+        XCTAssertFalse(recording === cache.mask(size: size, cornerRadius: 8, role: .recording))
+        XCTAssertFalse(camera === cache.mask(size: size, cornerRadius: 21, role: .facecam))
+    }
+
+    func testEffectiveRadiusIncludesFractionalGeometry() throws {
+        let cache = VideoRoundedMaskCache()
+        let a = try XCTUnwrap(cache.mask(size: CGSize(width: 20.1, height: 20.1), cornerRadius: 100, role: .recording))
+        let b = try XCTUnwrap(cache.mask(size: CGSize(width: 20.9, height: 20.9), cornerRadius: 100, role: .recording))
+        XCTAssertFalse(a === b) // Same pixel dimensions, different clamped radius.
+    }
+
+    func testCancellationAndContextChangeDiscardBothRoles() throws {
+        let compositor = VideoBackgroundCompositor()
+        let size = CGSize(width: 64, height: 48)
+        for contextChange in [false, true] {
+            let recording = try XCTUnwrap(compositor.roundedMaskCache.mask(size: size, cornerRadius: 8, role: .recording))
+            let camera = try XCTUnwrap(compositor.roundedMaskCache.mask(size: size, cornerRadius: 12, role: .facecam))
+            if contextChange { compositor.renderContextChanged(AVVideoCompositionRenderContext()) }
+            else { compositor.cancelAllPendingVideoCompositionRequests() }
+            XCTAssertFalse(recording === compositor.roundedMaskCache.mask(size: size, cornerRadius: 8, role: .recording))
+            XCTAssertFalse(camera === compositor.roundedMaskCache.mask(size: size, cornerRadius: 12, role: .facecam))
+        }
+    }
+
+    func testAlphaFidelityAndRadiusZero() throws {
+        let cache = VideoRoundedMaskCache()
+        let context = CIContext(options: [.useSoftwareRenderer: true])
+        let size = CGSize(width: 32, height: 24)
+        for radius in [CGFloat(0), 7.25, 100] {
+            let cached = try XCTUnwrap(cache.mask(size: size, cornerRadius: radius, role: .recording))
+            let uncached = try XCTUnwrap(VideoRoundedMaskCache.makeMask(size: size, cornerRadius: radius))
+            func pixels(_ image: CIImage) -> [UInt8] {
+                var data = [UInt8](repeating: 0, count: 32 * 24 * 4)
+                context.render(image, toBitmap: &data, rowBytes: 32 * 4, bounds: CGRect(origin: .zero, size: size), format: .RGBA8, colorSpace: CGColorSpace(name: CGColorSpace.sRGB))
+                return data
+            }
+            let actual = pixels(cached)
+            XCTAssertEqual(actual, pixels(uncached))
+            let alpha = stride(from: 3, to: actual.count, by: 4).map { actual[$0] }
+            if radius == 0 { XCTAssertTrue(alpha.allSatisfy { $0 == 255 }) }
+            else {
+                XCTAssertEqual(alpha.first, 0)
+                XCTAssertEqual(alpha[12 * 32 + 16], 255)
+                XCTAssertTrue(alpha.contains { $0 > 0 && $0 < 255 }, "Antialiased edges must remain")
+            }
+        }
+    }
+}

--- a/docs/export-benchmarking.md
+++ b/docs/export-benchmarking.md
@@ -24,3 +24,17 @@ Fixtures and outputs remain local; do not commit recordings or upload benchmark 
 Release tests and the benchmark runner enable `OPEN_RECORDER_TESTING` for existing test accessors. Normal packaging does not define it. `make test-macos-release` runs the optimized test suite; CI exercises both Apple Silicon and Intel and exposes one aggregate required check that fails if either architecture fails.
 
 The local validation fixtures can be reproduced using FFmpeg's `testsrc2=size=1920x1080:rate=30:duration=8` video and `sine=frequency=440:sample_rate=48000:duration=8` audio, encoded with `h264_videotoolbox` at 12 Mbps and AAC. Scale that fixture to 3840x2160 for a four-second 4K input (30 Mbps); stream-loop the 1080p fixture with stream copy and trim to 60 and 600 seconds for stress inputs. These are synthetic workloads, not evidence for every screen recording.
+
+For long stress fixtures that follow shorter warm-up runs in the same process, set `"warmup":false,"repeats":1` to measure the long export once. Short comparative fixtures retain the default one warm-up and five measured runs. Resident memory excludes some GPU/IOSurface allocations; it must not be described as total GPU memory use.
+
+Compare two matching artifact directories with `python3 scripts/compare-export-artifacts.py BASELINE CANDIDATE` (FFmpeg/ffprobe required). It decodes the first measured MOV from each fixture, compares stream settings/counts/timing, requires whole-video SSIM >=0.999, and compares any first-measured-run pre-encode PNG captures with maximum per-channel difference two. Run comparisons outside timed benchmarks.
+
+Exercise cancellation while real compositor requests are active, followed by a fresh export:
+
+```sh
+OPEN_RECORDER_EXPORT_CANCEL_FIXTURE=/absolute/path/local-video.mp4 \
+  swift test --package-path apps/macos -c release -Xswiftc -DOPEN_RECORDER_TESTING \
+  --filter VideoExportCancellationIntegrationTests
+```
+
+Use `--uncached-masks` as an A/B control when evaluating mask caching. This control exists only in builds compiled with `OPEN_RECORDER_TESTING`; production packages always use the cache. For memory comparisons, put one short fixture in each manifest and run each control/candidate in a fresh process. This separates per-scenario peaks from delayed AVFoundation/Core Image reclamation across a batch of many completed exports.

--- a/docs/export-performance-2026-09-08.md
+++ b/docs/export-performance-2026-09-08.md
@@ -26,3 +26,26 @@ Long 1080p rounded baseline: 60-second median 9.729 s (five measured runs), ten-
 A separate 4K requested-60-fps probe reproduces the existing mismatch: 30 fps and 120 frames over four seconds, rather than the requested 240. Its benchmark intentionally fails and its timings are excluded from performance comparisons. Fixing that discrepancy is separate work.
 
 The opt-in optimized integration suite produced 20 real exports covering plain/padded, wallpaper, blurred gradient, crop, portrait/square aspect, inset, adaptive/legacy zoom and fixed/moving facecam. Native packaging completed with configuration `release`, matching source binary UUIDs/resources, arm64 architecture, version 0.2.49, and a valid development signature. Apple Silicon and Intel debug/release CI passed on the initial implementation. Interactive export/save/playback/settings/repeat validation is blocked by a locked Mac; Computer Use's automatic unlock failed. Compilation, packaging and API integration tests do not substitute for that UI coverage.
+
+Additional 4K rounded baseline: 60-second median 29.890 s across five measured runs; ten-minute export 328.986 s after a 335.714 s warm-up. Decoded 30 fps, dimensions, duration, frame count and cadence checks pass. Ten-minute sampled peak RSS was 272 MiB; first/final ten-second medians were 199/99 MiB, without sustained growth. RSS does not include all GPU/IOSurface memory.
+
+A separate detailed 1080p rounded run recorded 240 compositor frames, 0.420 s CPU preparation, 0.215 s Core Image kernel execution, 960 render passes and 1,983,369,600 processed pixels. These timings are diagnostic only. Whole-video debug/release comparisons of all six short fixtures produced SSIM 1.000000, with matching decoded stream settings, frame counts and audio/video timing metadata.
+
+## Stage 2: invariant masks
+
+One raster is retained for recording content and one for facecam, keyed by integer bitmap dimensions and the exact effective radius. Placement uses transforms. Inset/decorative masks and content-dependent shadows keep their existing dynamic path. Cancellation and render-context changes invalidate both retained masks.
+
+Fresh-process A/B controls use the same optimized test binary with caching disabled only by the testing flag. One warm-up and five measured runs per fixture:
+
+| Fixture | Uncached seconds | Cached seconds | Time reduction | Uncached peak MiB | Cached peak MiB |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Plain | 0.882 | 0.876 | 0.7% | 61 | 61 |
+| Wallpaper | 1.335 | 1.042 | 21.9% | 656 | 661 |
+| Rounded | 1.436 | 1.024 | 28.7% | 670 | 660 |
+| Blurred background | 1.360 | 1.051 | 22.8% | 524 | 612 |
+| Facecam | 1.640 | 1.264 | 23.0% | 538 | 597 |
+| 4K rounded | 2.295 | 1.675 | 27.0% | 573 | 611 |
+
+An earlier multi-fixture batch peaked near 2.1 GiB, then dropped to approximately 0.7 GiB while continuing to export. Its peak combines delayed reclamation across prior exports and is not a clean per-scenario comparison. Fresh-process controls show bounded additional memory (largest observed peak increase 17%), not a promise of zero memory overhead.
+
+Five styled whole-video comparisons have SSIM 1.000000; all 15 captured pre-encode PNG frames have maximum per-channel difference zero. The expanded integration suite produces 22 exports and includes visible cursor/annotation output, inspected in the generated frame. A synthetic flash/beep fixture has matching video and audio onsets at 0, 2, 4 and 6 seconds after export (audio detection resolution 10 ms). Active Task/token cancellation followed by another export passes, including no late compositor-counter changes after cancellation returns. Local full suites pass: 31 Rust and 698 Swift tests in debug and release, with three explicit opt-in tests skipped and exercised separately as relevant.

--- a/docs/export-performance-2026-09-08.md
+++ b/docs/export-performance-2026-09-08.md
@@ -49,3 +49,34 @@ Fresh-process A/B controls use the same optimized test binary with caching disab
 An earlier multi-fixture batch peaked near 2.1 GiB, then dropped to approximately 0.7 GiB while continuing to export. Its peak combines delayed reclamation across prior exports and is not a clean per-scenario comparison. Fresh-process controls show bounded additional memory (largest observed peak increase 17%), not a promise of zero memory overhead.
 
 Five styled whole-video comparisons have SSIM 1.000000; all 15 captured pre-encode PNG frames have maximum per-channel difference zero. The expanded integration suite produces 22 exports and includes visible cursor/annotation output, inspected in the generated frame. A synthetic flash/beep fixture has matching video and audio onsets at 0, 2, 4 and 6 seconds after export (audio detection resolution 10 ms). Active Task/token cancellation followed by another export passes, including no late compositor-counter changes after cancellation returns. Local full suites pass: 31 Rust and 698 Swift tests in debug and release, with three explicit opt-in tests skipped and exercised separately as relevant.
+
+Long cached exports: 1080p60-second median 6.632 s versus 9.729 s baseline; ten minutes 64.129 s versus 99.666 s. 4K60-second median 21.189 s versus 29.890 s; ten minutes 213.373 s versus 328.986 s. All requested/decoded 30-fps, dimension, duration, frame-count and cadence checks pass. The ten-minute cached runs are single stress measurements after the six 60-second runs, not five-run medians.
+
+For comparable memory histories, compare the first ten-minute pass after the 60-second fixtures: baseline/cached peaks are 554/574 MiB at 1080p and 394/408 MiB at 4K. The baseline's *second* ten-minute pass had lower peaks (331/272 MiB) after additional reclamation and is not the matching first-pass memory control. Cached first/final ten-second RSS medians were 468/461 MiB at 1080p and 316/152 MiB at 4K; no sustained growth was observed.
+
+Cached CPU preparation in the separate detailed run is 0.115 s versus 0.420 s baseline; Core Image kernel time remains 0.213 s versus 0.215 s, with unchanged passes/pixels. The 20 matching adaptive/legacy integration videos have minimum SSIM 0.999709, above the 0.999 gate.
+
+All four long output comparisons (1080p/4K, 60 seconds/ten minutes) have whole-video SSIM 1.000000. The comparator reuses unchanged benchmark files' recorded decoded counts and performs the full SSIM decode with VideoToolbox, avoiding redundant full-file decoding solely for counting.
+
+## Stage 3: native input formats — rejected
+
+The experimental source requirements accepted 8-bit bi-planar video-range (`420v`) and full-range (`420f`) buffers alongside BGRA; output remained BGRA. Detailed counters confirmed actual `420v`/`420f` delivery. The alpha-bearing ProRes fixture correctly stayed BGRA and its captured frames were identical.
+
+The YCbCr path failed correctness: full-range H.264 had whole-video SSIM 0.995687 and maximum pre-encode channel differences of 133, 154 and 200 at the sampled frames. Ordinary video-range H.264 had differences of 132, 135 and 202. Both exceed the maximum two-level tolerance. No speed result is accepted from this experiment. Its source-format changes and temporary diagnostics were reverted; inputs remain on the existing BGRA path. HDR support is unchanged.
+
+## Stage 4: two render slots — rejected
+
+The prototype admitted at most two requests before queueing retained work, gave each slot its own mutable caches, shared the thread-safe Core Image context, waited for each render task before finishing the request, and drained admitted/rejected requests on cancellation. Active cancellation/retry and decoded-output checks passed.
+
+Fresh-process controls, one warm-up/five measurements per fixture, compared against the cached serial exporter:
+
+| Fixture | Serial seconds | Two-slot seconds | Time reduction | Peak RSS increase |
+| --- | ---: | ---: | ---: | ---: |
+| Plain | 0.876 | 0.877 | -0.1% | 0.2% |
+| Wallpaper | 1.042 | 0.993 | 4.7% | 16.7% |
+| Rounded | 1.024 | 0.998 | 2.5% | 17.1% |
+| Blurred background | 1.051 | 0.991 | 5.6% | 25.5% |
+| Facecam | 1.264 | 0.990 | 21.7% | 28.2% |
+| 4K rounded | 1.675 | 1.519 | 9.3% | 39.8% |
+
+Median fixture-relative reduction across styled scenarios was only 5.6%, below the 10% gate; several memory peaks also exceeded the 25% limit. The prototype was reverted. Serial rendering remains the default, and no concurrency improvement is claimed. Failed gates make additional long-run acceptance tests for this prototype unnecessary.

--- a/scripts/benchmark-macos-export.py
+++ b/scripts/benchmark-macos-export.py
@@ -13,6 +13,7 @@ parser.add_argument("output", type=Path)
 parser.add_argument("--configuration", choices=["debug", "release"], default="release")
 parser.add_argument("--diagnostics", action="store_true")
 parser.add_argument("--capture-frames", action="store_true")
+parser.add_argument("--uncached-masks", action="store_true", help="Testing-only A/B control for invariant masks")
 args = parser.parse_args()
 if (args.output / "results.json").exists():
     parser.error("Choose a fresh output directory; existing results must not be mixed with a new run")
@@ -24,14 +25,15 @@ environment = {**os.environ, "OPEN_RECORDER_EXPORT_BENCH_MANIFEST": str(args.man
                "OPEN_RECORDER_EXPORT_BENCH_OUTPUT": str(args.output.resolve()),
                "OPEN_RECORDER_EXPORT_REVISION": revision,
                "OPEN_RECORDER_EXPORT_DIAGNOSTICS": "1" if args.diagnostics else "0",
-               "OPEN_RECORDER_EXPORT_CAPTURE_FRAMES": "1" if args.capture_frames else "0"}
+               "OPEN_RECORDER_EXPORT_CAPTURE_FRAMES": "1" if args.capture_frames else "0",
+               "OPEN_RECORDER_EXPORT_UNCACHED_MASKS": "1" if args.uncached_masks else "0"}
 result = subprocess.run(["swift", "test", "--package-path", "apps/macos", "-c", args.configuration,
                          "-Xswiftc", "-DOPEN_RECORDER_TESTING", "--filter", "VideoExportBenchmarkTests"], env=environment, cwd=root)
 report = args.output / "results.json"
 if report.exists():
     rows = json.loads(report.read_text())
     for row in rows:
-        row.update(hardware=hardware, operatingSystem=platform.mac_ver()[0], sourceModified=modified, captureFrames=args.capture_frames)
+        row.update(hardware=hardware, operatingSystem=platform.mac_ver()[0], sourceModified=modified, captureFrames=args.capture_frames, uncachedMasks=args.uncached_masks)
     report.write_text(json.dumps(rows, indent=2) + "\n")
     summary = []
     for name in dict.fromkeys(row["fixture"] for row in rows):

--- a/scripts/compare-export-artifacts.py
+++ b/scripts/compare-export-artifacts.py
@@ -6,9 +6,9 @@ import re
 import subprocess
 
 
-def probe(path):
+def probe(path, decode_frames=True):
     result = subprocess.check_output([
-        "ffprobe", "-v", "error", "-count_frames", "-show_streams", "-of", "json", str(path)], text=True)
+        "ffprobe", "-v", "error", *(["-count_frames"] if decode_frames else []), "-show_streams", "-of", "json", str(path)], text=True)
     return json.loads(result)["streams"]
 
 
@@ -22,9 +22,27 @@ parser.add_argument("baseline", type=Path)
 parser.add_argument("candidate", type=Path)
 args = parser.parse_args()
 results = []
+
+def recorded_output(directory, video):
+    report = directory / "results.json"
+    if not report.exists() or video.stat().st_mtime > report.stat().st_mtime:
+        return None
+    name = video.stem.rsplit("-", 1)[0]
+    return next((r["output"] for r in json.loads(report.read_text())
+                 if r["fixture"] == name and not r["warmup"]), None)
+
 for baseline in sorted(args.baseline.glob("*-1.mov")):
     candidate = args.candidate / baseline.name
-    before, after = probe(baseline), probe(candidate)
+    recorded_before = recorded_output(args.baseline, baseline)
+    recorded_after = recorded_output(args.candidate, candidate)
+    decoded_counts_available = recorded_before is not None and recorded_after is not None
+    if decoded_counts_available:
+        for key in ["frames", "width", "height", "nominalFPS"]:
+            assert recorded_before[key] == recorded_after[key], f"{baseline.name}: decoded {key} changed"
+        assert recorded_before["monotonic"] and recorded_after["monotonic"]
+    # The benchmark already decoded these exact files. Avoid decoding them twice more
+    # just to count frames; the SSIM pass below still decodes every video frame.
+    before, after = probe(baseline, not decoded_counts_available), probe(candidate, not decoded_counts_available)
     for kind in ["video", "audio"]:
         a = [s for s in before if s["codec_type"] == kind]
         b = [s for s in after if s["codec_type"] == kind]
@@ -36,7 +54,7 @@ for baseline in sorted(args.baseline.glob("*-1.mov")):
                 assert x.get(key) == y.get(key), f"{baseline.name}: {key} changed"
             for key in ["start_time", "duration"]:
                 assert abs(float(x.get(key, 0)) - float(y.get(key, 0))) <= 0.001, f"{baseline.name}: {kind} {key} changed"
-    result = subprocess.run(["ffmpeg", "-v", "info", "-i", str(baseline), "-i", str(candidate),
+    result = subprocess.run(["ffmpeg", "-v", "info", "-hwaccel", "videotoolbox", "-i", str(baseline), "-hwaccel", "videotoolbox", "-i", str(candidate),
                              "-lavfi", "[0:v][1:v]ssim", "-an", "-f", "null", "-"], capture_output=True, text=True, check=True)
     match = re.search(r"All:([0-9.]+)", result.stderr)
     assert match, result.stderr[-2000:]

--- a/scripts/compare-export-artifacts.py
+++ b/scripts/compare-export-artifacts.py
@@ -1,0 +1,56 @@
+"""Compare local benchmark exports and optional pre-encode captures (requires FFmpeg)."""
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+
+
+def probe(path):
+    result = subprocess.check_output([
+        "ffprobe", "-v", "error", "-count_frames", "-show_streams", "-of", "json", str(path)], text=True)
+    return json.loads(result)["streams"]
+
+
+def rgba(path):
+    return subprocess.check_output([
+        "ffmpeg", "-v", "error", "-i", str(path), "-f", "rawvideo", "-pix_fmt", "rgba", "-"])
+
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("baseline", type=Path)
+parser.add_argument("candidate", type=Path)
+args = parser.parse_args()
+results = []
+for baseline in sorted(args.baseline.glob("*-1.mov")):
+    candidate = args.candidate / baseline.name
+    before, after = probe(baseline), probe(candidate)
+    for kind in ["video", "audio"]:
+        a = [s for s in before if s["codec_type"] == kind]
+        b = [s for s in after if s["codec_type"] == kind]
+        assert len(a) == len(b), f"{baseline.name}: {kind} track count changed"
+        for x, y in zip(a, b):
+            keys = ["codec_name", "width", "height", "pix_fmt", "color_range", "color_space", "color_transfer",
+                    "color_primaries", "r_frame_rate", "nb_read_frames", "sample_rate", "channels"]
+            for key in keys:
+                assert x.get(key) == y.get(key), f"{baseline.name}: {key} changed"
+            for key in ["start_time", "duration"]:
+                assert abs(float(x.get(key, 0)) - float(y.get(key, 0))) <= 0.001, f"{baseline.name}: {kind} {key} changed"
+    result = subprocess.run(["ffmpeg", "-v", "info", "-i", str(baseline), "-i", str(candidate),
+                             "-lavfi", "[0:v][1:v]ssim", "-an", "-f", "null", "-"], capture_output=True, text=True, check=True)
+    match = re.search(r"All:([0-9.]+)", result.stderr)
+    assert match, result.stderr[-2000:]
+    ssim = float(match.group(1))
+    results.append({"file": baseline.name, "ssim": ssim})
+    assert ssim >= 0.999, f"{baseline.name}: SSIM {ssim} < 0.999"
+
+for baseline in sorted(args.baseline.glob("*-1-frames/*.png")):
+    candidate = args.candidate / baseline.relative_to(args.baseline)
+    before, after = rgba(baseline), rgba(candidate)
+    assert len(before) == len(after), "Pre-encode dimensions changed"
+    delta = max(abs(a - b) for a, b in zip(before, after))
+    results.append({"frame": str(baseline.relative_to(args.baseline)), "maximumChannelDifference": delta})
+    assert delta <= 2, f"{baseline}: pre-encode difference {delta} > 2"
+
+assert results, "No matching benchmark artifacts found"
+print(json.dumps(results, indent=2))


### PR DESCRIPTION
Styled exports reconstruct recording and facecam mask bitmaps on every frame. Cache one invariant raster per role, keyed by bitmap dimensions and effective corner radius, and apply placement with transforms. Invalidate both roles on cancellation/context changes; preserve existing antialiasing, radius-zero behavior, dynamic shadows, encoder settings, colors, resolution and FPS.

On an M1 Max, fresh-process short-fixture controls show 22–29% less styled export time. Ten-minute 1080p exports improve from 99.7 to 64.1 seconds and 4K from 329 to 213 seconds, at verified 30 fps. All four long video comparisons have SSIM 1.000000; the sampled pre-encode frames are identical. Memory is bounded with no sustained growth observed; the report includes peaks and matching control histories rather than claiming zero overhead.

Validation includes debug/release Rust and Swift suites, cache lifecycle/alpha tests, 22 real integration exports, active cancellation followed by another export, and a flash/beep audio-sync fixture. Native interactive QA remains blocked by a locked Mac. The optimized development package passed configuration/resource/binary-identity/architecture checks and strict signature verification at this PR head.

YCbCr inputs failed color-fidelity gates. Two rendering slots failed the 10% improvement and 25% memory gates. Both experiments were reverted; this PR retains BGRA inputs and serial rendering. No app release is published.

[Full measurements and validation](https://github.com/imbhargav5/open-recorder/blob/a3f8be7/docs/export-performance-2026-09-08.md)
