### PR TITLE
Add isolated OpenRecorderNightly builds through GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,113 @@
+name: Build Nightly macOS App
+run-name: Nightly · ${{ github.ref_name }} · ${{ github.run_number }}
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-nightly:
+    name: Nightly (${{ matrix.artifact_arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact_arch: arm64
+            runner: macos-26
+            binary_arch: arm64
+          - artifact_arch: x64
+            runner: macos-26-intel
+            binary_arch: x86_64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout selected branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        run: |
+          make test-macos
+          python3 scripts/tests/test_macos_notarization.py
+
+      - name: Import existing release signing certificate
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE || secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+          CSC_NAME: ${{ secrets.APPLE_SIGNING_IDENTITY || secrets.CSC_NAME }}
+        run: zsh scripts/import-macos-production-signing-certificate.zsh
+
+      - name: Build, sign, notarize, and staple nightly
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: make package-macos-nightly
+
+      - name: Verify nightly identity and architecture
+        env:
+          EXPECTED_ARCH: ${{ matrix.binary_arch }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          app="release/OpenRecorderNightly.app"
+          plist="$app/Contents/Info.plist"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = 'dev.openrecorder.app.nightly'
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$plist")" = 'OpenRecorderNightly'
+          for key in SUFeedURL CFBundleDocumentTypes UTExportedTypeDeclarations; do
+            if /usr/libexec/PlistBuddy -c "Print :$key" "$plist" >/dev/null 2>&1; then
+              echo "Unexpected production metadata in nightly: $key" >&2
+              exit 1
+            fi
+          done
+          for binary in OpenRecorderMac open-recorder-service; do
+            test "$(lipo -archs "$app/Contents/MacOS/$binary")" = "$EXPECTED_ARCH"
+          done
+          zsh scripts/verify-macos-production-signature.zsh "$app"
+          codesign --verify --deep --strict "$app"
+          xcrun stapler validate "$app"
+          spctl -a -vv -t exec "$app"
+
+      - name: Create downloadable ZIP
+        env:
+          ARTIFACT_ARCH: ${{ matrix.artifact_arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p nightly-download
+          ditto -c -k --sequesterRsrc --keepParent \
+            release/OpenRecorderNightly.app \
+            "nightly-download/OpenRecorderNightly-${ARTIFACT_ARCH}.zip"
+          python3 - <<'PY'
+          import json, os, pathlib
+          metadata = {
+              'commit': os.environ['GITHUB_SHA'],
+              'ref': os.environ['GITHUB_REF'],
+              'architecture': os.environ['ARTIFACT_ARCH'],
+              'run': os.environ['GITHUB_SERVER_URL'] + '/' + os.environ['GITHUB_REPOSITORY'] + '/actions/runs/' + os.environ['GITHUB_RUN_ID'],
+          }
+          pathlib.Path('nightly-download/build-info.json').write_text(json.dumps(metadata, indent=2) + '\n')
+          PY
+          shasum -a 256 "nightly-download/OpenRecorderNightly-${ARTIFACT_ARCH}.zip" > nightly-download/SHA256SUMS.txt
+          echo "Download the nightly artifact below, extract the app ZIP, and move OpenRecorderNightly.app to Applications. Architecture: ${ARTIFACT_ARCH}. Commit: ${GITHUB_SHA}." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload notarized nightly app
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenRecorderNightly-${{ matrix.artifact_arch }}-${{ github.run_number }}
+          path: nightly-download/
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove temporary signing material
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/open-recorder-signing.keychain-db" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/open-recorder-signing.p12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Debug and release tests
-        run: make test-macos test-macos-release
+        run: |
+          make test-macos
+          python3 scripts/tests/test_macos_notarization.py test-macos-release
       - name: Script tests
         run: node --test scripts/*.test.mjs
 

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,13 @@ clean-macos:
 test-macos-release:
 	cd apps/rust-service && CARGO_INCREMENTAL=0 cargo test --release
 	cd apps/macos && swift test -c release -Xswiftc -DOPEN_RECORDER_TESTING
+
+.PHONY: package-macos-nightly install-macos-nightly run-macos-nightly
+package-macos-nightly:
+	zsh scripts/package-macos-nightly-app.zsh
+
+install-macos-nightly:
+	zsh scripts/package-macos-nightly-app.zsh --install
+
+run-macos-nightly:
+	zsh scripts/package-macos-nightly-app.zsh --install --launch

--- a/README.md
+++ b/README.md
@@ -213,3 +213,68 @@ Thanks to everyone who has contributed to Open Recorder. The historical acknowle
 ## License
 
 Open Recorder is licensed under the Apache License 2.0.
+
+### Download a signed nightly app from GitHub (recommended)
+
+In GitHub, open **Actions → Build Nightly macOS App → Run workflow**, select the
+branch to build, and start the run. Once both architecture jobs finish, download
+`OpenRecorderNightly-arm64-…` for Apple Silicon or `OpenRecorderNightly-x64-…` for
+Intel from the run's **Artifacts** section. Extract the downloaded artifact, then
+extract the app ZIP inside it and move `OpenRecorderNightly.app` to Applications.
+Quit an existing nightly instance before replacing it.
+
+The workflow reuses the production signing and Apple notarization secrets already
+configured in GitHub. It does not require signing credentials on your Mac. Each
+artifact contains a notarized, stapled app, build commit metadata, and a ZIP
+checksum; downloads are retained for 30 days. The workflow runs manually and
+neither creates a GitHub release nor changes the production appcast. GitHub only
+builds committed code on the selected remote branch, not uncommitted local edits.
+The workflow must be merged into the default branch before its Run workflow
+button becomes available.
+
+### Signed local nightly app (optional)
+
+
+`make run-macos-nightly` builds, Developer ID signs, notarizes, staples, installs,
+and launches `/Applications/OpenRecorderNightly.app`. Use
+`make package-macos-nightly` to produce only the bundle, or
+`make install-macos-nightly` to install without launching. Each invocation builds
+from the current checkout, including local changes, using an optimized release build.
+Quit nightly before replacing its installed bundle.
+
+One-time setup on your Mac:
+
+1. Import your **Developer ID Application** certificate **and private key** into
+   Keychain Access (a `.p12` export from the signing Mac, or create a Developer ID
+   certificate through your Apple Developer account). An Apple Development
+   certificate is insufficient for this workflow.
+2. Confirm it appears in `security find-identity -v -p codesigning`.
+3. Run `xcrun notarytool store-credentials OpenRecorderNightly` and follow its
+   interactive prompts for your Apple ID, team ID, and app-specific password.
+   Credentials stay in Keychain; do not commit or paste them into source files.
+4. Run `make run-macos-nightly`.
+
+If multiple Developer ID identities exist, select the intended certificate with
+`CODE_SIGN_IDENTITY`. A non-default signing keychain can be selected with
+`OPEN_RECORDER_SIGNING_KEYCHAIN`; a different notarization profile with
+`OPEN_RECORDER_NOTARY_PROFILE`. Nightly refuses missing signing credentials and
+never falls back to ad-hoc signing. Installation happens only after signature,
+notarization ticket, and Gatekeeper checks pass. Notarization requires internet.
+
+Nightly uses bundle ID `dev.openrecorder.app.nightly`, separate preferences and
+privacy grants, and `OpenRecorderNightly` folders under Application Support,
+Movies, and Pictures. No production library is copied or migrated. Global
+shortcuts start disabled; configure nonconflicting shortcuts in Settings if needed.
+Nightly has no automatic updates or default project-file association; use its
+in-app Open command to deliberately open a project. Opening the same project in
+both apps still means editing the same file.
+
+Both updated variants exclude their own app from capture while allowing the
+other variant. Nightly can record an older production app immediately; production
+can record nightly after production receives the capture-exclusion fix. The
+nightly command never replaces production or the existing Dev installation.
+
+macOS will still ask for nightly's own screen-recording, microphone, and camera
+permissions when those features are first used, and may show OS-mandated reminders.
+Keep the bundle identity and signing identity consistent across rebuilds. Signing
+and notarization establish app trust; they do not bypass privacy consent.

--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -1937,7 +1937,7 @@ final class AppModel: ObservableObject {
             in: .userDomainMask
         ).first {
             projectsDirectory = applicationSupport
-                .appendingPathComponent("Open Recorder", isDirectory: true)
+                .appendingPathComponent(AppVariant.storageDirectoryName, isDirectory: true)
                 .appendingPathComponent("Projects", isDirectory: true)
         } else if let mediaURL = screenshotURL ?? recordingURL {
             projectsDirectory = mediaURL.deletingLastPathComponent()

--- a/apps/macos/Sources/OpenRecorderMac/AppVariant.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppVariant.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Bundle identity is the source of truth; inherited shell variables cannot select app storage.
+enum AppVariant {
+    static let nightlyBundleIdentifier = "dev.openrecorder.app.nightly"
+    static var isNightly: Bool { isNightly(bundleIdentifier: Bundle.main.bundleIdentifier) }
+    static func isNightly(bundleIdentifier: String?) -> Bool {
+        bundleIdentifier == nightlyBundleIdentifier
+    }
+    static var storageDirectoryName: String { isNightly ? "OpenRecorderNightly" : "Open Recorder" }
+    static func serviceEnvironment(
+        inherited: [String: String] = ProcessInfo.processInfo.environment,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier
+    ) -> [String: String] {
+        var environment = inherited
+        environment["OPEN_RECORDER_APP_VARIANT"] = isNightly(bundleIdentifier: bundleIdentifier) ? "nightly" : "production"
+        return environment
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureController.swift
@@ -111,7 +111,8 @@ enum WindowSourceFilter {
             cleaned(currentApplicationName)
         ].compactMap(\.self)
 
-        if let ownerName,
+        // Bundle identity wins over names shared by production and nightly.
+        if bundleIdentifier == nil, let ownerName,
            currentApplicationNames.contains(where: { ownerName.caseInsensitiveCompare($0) == .orderedSame }) {
             return nil
         }

--- a/apps/macos/Sources/OpenRecorderMac/CaptureShortcuts.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureShortcuts.swift
@@ -388,15 +388,19 @@ public struct ShortcutPreferences: Codable, Equatable, Sendable {
     }
 
     public static var defaultPreferences: ShortcutPreferences {
+        defaults(globalShortcutsEnabled: !AppVariant.isNightly)
+    }
+
+    static func defaults(globalShortcutsEnabled: Bool) -> ShortcutPreferences {
         var map: [CaptureShortcutAction: ShortcutItem] = [:]
         for action in CaptureShortcutAction.allCases {
-            map[action] = ShortcutItem(id: action, isEnabled: true, keyCombination: action.defaultKeyCombination)
+            map[action] = ShortcutItem(id: action, isEnabled: globalShortcutsEnabled, keyCombination: action.defaultKeyCombination)
         }
         return ShortcutPreferences(shortcuts: map)
     }
 
     public func item(for action: CaptureShortcutAction) -> ShortcutItem {
-        shortcuts[action] ?? ShortcutItem(id: action, isEnabled: true, keyCombination: action.defaultKeyCombination)
+        shortcuts[action] ?? ShortcutItem(id: action, isEnabled: !AppVariant.isNightly, keyCombination: action.defaultKeyCombination)
     }
 
     public mutating func setItem(_ item: ShortcutItem) {

--- a/apps/macos/Sources/OpenRecorderMac/OpenRecorderCaptureExclusion.swift
+++ b/apps/macos/Sources/OpenRecorderMac/OpenRecorderCaptureExclusion.swift
@@ -22,25 +22,10 @@ enum OpenRecorderCaptureExclusion {
             return true
         }
 
-        if let normalizedBundleIdentifier,
-           normalizedBundleIdentifier.hasPrefix("dev.openrecorder.app") {
-            return true
-        }
-
-        if normalizedCurrentBundleIdentifier?.hasPrefix("dev.openrecorder.app") == true,
-           let applicationName = cleaned(applicationName)?.lowercased(),
-           openRecorderApplicationNames.contains(applicationName) {
-            return true
-        }
-
+        // Other variants must remain capturable, including unbundled processes.
+        // Names are not reliable identity: both variants use OpenRecorderMac internally.
         return false
     }
-
-    private static let openRecorderApplicationNames: Set<String> = [
-        "open recorder",
-        "open recorder dev",
-        "openrecordermac"
-    ]
 
     private static func cleaned(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
+++ b/apps/macos/Sources/OpenRecorderMac/RustServiceClient.swift
@@ -85,6 +85,7 @@ struct RustServiceClient: Sendable {
 
         let process = Process()
         process.executableURL = executableURL
+        process.environment = AppVariant.serviceEnvironment()
         process.arguments = ["--oneshot", method, paramsString]
 
         let outputPipe = Pipe()

--- a/apps/macos/Tests/OpenRecorderMacTests/AppVariantTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppVariantTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import OpenRecorderMac
+
+final class AppVariantTests: XCTestCase {
+    func testNightlyHelperEnvironmentCannotBeOverriddenByParent() {
+        let environment = AppVariant.serviceEnvironment(
+            inherited: ["HOME": "/test/home", "OPEN_RECORDER_APP_VARIANT": "production"],
+            bundleIdentifier: "dev.openrecorder.app.nightly"
+        )
+        XCTAssertEqual(environment["HOME"], "/test/home")
+        XCTAssertEqual(environment["OPEN_RECORDER_APP_VARIANT"], "nightly")
+    }
+
+    func testProductionAndDevKeepExistingStorage() {
+        for identifier in ["dev.openrecorder.app", "dev.openrecorder.app.dev"] {
+            let environment = AppVariant.serviceEnvironment(
+                inherited: ["OPEN_RECORDER_APP_VARIANT": "nightly"], bundleIdentifier: identifier
+            )
+            XCTAssertEqual(environment["OPEN_RECORDER_APP_VARIANT"], "production")
+        }
+    }
+
+    func testNightlyShortcutDefaultsAreDisabledAndCanBeEnabled() {
+        var preferences = ShortcutPreferences.defaults(globalShortcutsEnabled: false)
+        for action in CaptureShortcutAction.allCases {
+            XCTAssertFalse(preferences.item(for: action).isEnabled)
+        }
+        var item = preferences.item(for: .toggleRecording)
+        item.isEnabled = true
+        preferences.setItem(item)
+        XCTAssertTrue(preferences.item(for: .toggleRecording).isEnabled)
+        XCTAssertTrue(ShortcutPreferences.defaults(globalShortcutsEnabled: true).item(for: .toggleRecording).isEnabled)
+    }
+}

--- a/apps/macos/Tests/OpenRecorderMacTests/OpenRecorderCaptureExclusionTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/OpenRecorderCaptureExclusionTests.swift
@@ -12,8 +12,8 @@ final class OpenRecorderCaptureExclusionTests: XCTestCase {
         ))
     }
 
-    func testExcludesProductionAndDevelopmentOpenRecorderBundles() {
-        XCTAssertTrue(OpenRecorderCaptureExclusion.shouldExcludeApplication(
+    func testAllowsOtherVariantsAndExcludesOwnBundle() {
+        XCTAssertFalse(OpenRecorderCaptureExclusion.shouldExcludeApplication(
             bundleIdentifier: "dev.openrecorder.app",
             applicationName: "Open Recorder",
             processID: 100,
@@ -29,8 +29,8 @@ final class OpenRecorderCaptureExclusionTests: XCTestCase {
         ))
     }
 
-    func testExcludesOpenRecorderOwnerNamesForLocalBuildsWithoutBundleIdentifiers() {
-        XCTAssertTrue(OpenRecorderCaptureExclusion.shouldExcludeApplication(
+    func testDoesNotExcludeAnotherProcessByNameAlone() {
+        XCTAssertFalse(OpenRecorderCaptureExclusion.shouldExcludeApplication(
             bundleIdentifier: nil,
             applicationName: "OpenRecorderMac",
             processID: 100,
@@ -47,6 +47,21 @@ final class OpenRecorderCaptureExclusionTests: XCTestCase {
             currentProcessID: 200,
             currentBundleIdentifier: "dev.openrecorder.app.dev"
         ))
+    }
+
+    func testProductionAndNightlyCanCaptureEachOther() {
+        for (current, target) in [
+            ("dev.openrecorder.app", "dev.openrecorder.app.nightly"),
+            ("dev.openrecorder.app.nightly", "dev.openrecorder.app")
+        ] {
+            XCTAssertFalse(OpenRecorderCaptureExclusion.shouldExcludeApplication(
+                bundleIdentifier: target,
+                applicationName: "OpenRecorderMac",
+                processID: 100,
+                currentProcessID: 200,
+                currentBundleIdentifier: current
+            ))
+        }
     }
 
     func testAllowsUnrelatedApplications() {

--- a/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/UpdateCheckerTests.swift
@@ -33,6 +33,14 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
     }
 
+    func testNightlyCannotUseProductionFeed() throws {
+        let bundle = try makeBundle(
+            identifier: "dev.openrecorder.app.nightly",
+            feedURLString: "https://openrecorder.dev/appcast.xml"
+        )
+        XCTAssertFalse(UpdateChecker.isEnabled(for: bundle))
+    }
+
     func testUpdateCheckerIsDisabledWithoutBundleIdentifier() throws {
         let bundle = try makeBundle(
             identifier: nil,

--- a/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/WindowSourceFilterTests.swift
@@ -31,7 +31,14 @@ final class WindowSourceFilterTests: XCTestCase {
         XCTAssertNil(displayInfo(title: "Choose Source", ownerName: currentProcessName))
         XCTAssertNil(displayInfo(title: "Choose Source", ownerName: "Open Recorder", bundleIdentifier: "dev.openrecorder.app"))
         XCTAssertNil(displayInfo(title: "Open Recorder", ownerName: "Open Recorder", bundleIdentifier: nil))
-        XCTAssertNil(displayInfo(title: "Open Recorder", ownerName: "Open Recorder", bundleIdentifier: "dev.openrecorder.app.dev"))
+        XCTAssertNotNil(displayInfo(title: "Open Recorder", ownerName: "Open Recorder", bundleIdentifier: "dev.openrecorder.app.dev"))
+    }
+
+    func testKeepsNightlyWindowEvenWhenExecutableNamesMatch() {
+        XCTAssertNotNil(displayInfo(
+            title: "Editor", ownerName: currentProcessName,
+            bundleIdentifier: "dev.openrecorder.app.nightly"
+        ))
     }
 
     func testKeepsNormalAppWindows() {

--- a/apps/rust-service/src/main.rs
+++ b/apps/rust-service/src/main.rs
@@ -422,15 +422,24 @@ impl InternalPaths {
         let home = env::var_os("HOME")
             .map(PathBuf::from)
             .ok_or_else(|| "HOME is not set".to_string())?;
+        Self::for_home(home, env::var("OPEN_RECORDER_APP_VARIANT").ok().as_deref())
+    }
+
+    fn for_home(home: PathBuf, variant: Option<&str>) -> Result<Self, String> {
+        let directory_name = match variant {
+            Some("nightly") => "OpenRecorderNightly",
+            None | Some("production") => "Open Recorder",
+            Some(other) => return Err(format!("Unknown app variant: {other}")),
+        };
         let support_dir = home
             .join("Library")
             .join("Application Support")
-            .join("Open Recorder");
+            .join(directory_name);
         let projects_dir = support_dir.join("Projects");
 
         Ok(Self {
-            recordings_dir: home.join("Movies").join("Open Recorder"),
-            screenshots_dir: home.join("Pictures").join("Open Recorder"),
+            recordings_dir: home.join("Movies").join(directory_name),
+            screenshots_dir: home.join("Pictures").join(directory_name),
             project_index: projects_dir.join("index.json"),
             projects_dir,
             support_dir,
@@ -1122,6 +1131,20 @@ fn unique_suffix() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nightly_paths_are_isolated_from_production() {
+        let home = PathBuf::from("/test/home");
+        let production = InternalPaths::for_home(home.clone(), None).unwrap();
+        let nightly = InternalPaths::for_home(home.clone(), Some("nightly")).unwrap();
+        assert_eq!(production.support_dir, home.join("Library/Application Support/Open Recorder"));
+        assert_eq!(nightly.support_dir, home.join("Library/Application Support/OpenRecorderNightly"));
+        assert_eq!(nightly.recordings_dir, home.join("Movies/OpenRecorderNightly"));
+        assert_eq!(nightly.screenshots_dir, home.join("Pictures/OpenRecorderNightly"));
+        assert_ne!(nightly.project_index, production.project_index);
+        assert_ne!(nightly.projects_dir, production.projects_dir);
+        assert!(InternalPaths::for_home(home, Some("unknown")).is_err());
+    }
 
     #[test]
     fn sanitizes_file_names_for_project_files() {

--- a/scripts/notarize-macos-production-app.zsh
+++ b/scripts/notarize-macos-production-app.zsh
@@ -6,6 +6,7 @@ bundle_dir="${1:-}"
 apple_id="${APPLE_ID:-}"
 apple_password="${APPLE_APP_SPECIFIC_PASSWORD:-}"
 apple_team_id="${APPLE_TEAM_ID:-}"
+notary_profile="${OPEN_RECORDER_NOTARY_PROFILE:-}"
 notary_max_attempts="${NOTARYTOOL_MAX_ATTEMPTS:-3}"
 notary_retry_delay_seconds="${NOTARYTOOL_RETRY_DELAY_SECONDS:-15}"
 
@@ -23,14 +24,17 @@ submit_for_notarization() {
 	while (( attempt <= notary_max_attempts )); do
 		print -- "Submitting $(basename "$file_path") for notarization (attempt ${attempt}/${notary_max_attempts})"
 		if xcrun notarytool submit "$file_path" \
-			--apple-id "$apple_id" \
-			--password "$apple_password" \
-			--team-id "$apple_team_id" \
-			--wait; then
-			return 0
-		fi
-
-		exit_status=$?
+            "${notary_auth[@]}" \
+			--wait --output-format json >"$tmp_dir/notary-result.json"; then
+            if [[ "$(/usr/bin/plutil -extract status raw -o - "$tmp_dir/notary-result.json")" == "Accepted" ]]; then
+                return 0
+            fi
+            print -u2 -- "Apple did not accept notarization."
+            cat "$tmp_dir/notary-result.json" >&2
+            return 1
+        else
+            exit_status=$?
+        fi
 		if (( attempt == notary_max_attempts )); then
 			print -u2 -- "Notarization failed after ${notary_max_attempts} attempts."
 			return "$exit_status"
@@ -44,9 +48,14 @@ submit_for_notarization() {
 }
 
 [[ -n "$bundle_dir" && -d "$bundle_dir" ]] || die "Usage: zsh scripts/notarize-macos-production-app.zsh PATH_TO_APP"
-[[ -n "$apple_id" ]] || die "Missing APPLE_ID secret."
-[[ -n "$apple_password" ]] || die "Missing APPLE_APP_SPECIFIC_PASSWORD secret."
-[[ -n "$apple_team_id" ]] || die "Missing APPLE_TEAM_ID secret."
+if [[ -n "$notary_profile" ]]; then
+    notary_auth=(--keychain-profile "$notary_profile")
+else
+    [[ -n "$apple_id" ]] || die "Missing APPLE_ID secret."
+    [[ -n "$apple_password" ]] || die "Missing APPLE_APP_SPECIFIC_PASSWORD secret."
+    [[ -n "$apple_team_id" ]] || die "Missing APPLE_TEAM_ID secret."
+    notary_auth=(--apple-id "$apple_id" --password "$apple_password" --team-id "$apple_team_id")
+fi
 [[ "$notary_max_attempts" == <-> && "$notary_max_attempts" -ge 1 ]] || die "NOTARYTOOL_MAX_ATTEMPTS must be a positive integer."
 [[ "$notary_retry_delay_seconds" == <-> ]] || die "NOTARYTOOL_RETRY_DELAY_SECONDS must be a non-negative integer."
 

--- a/scripts/package-macos-app-shared.zsh
+++ b/scripts/package-macos-app-shared.zsh
@@ -13,6 +13,9 @@ while (( $# > 0 )); do
 		--dev)
 			app_variant="development"
 			;;
+		--nightly)
+			app_variant="nightly"
+			;;
 		--production)
 			app_variant="production"
 			;;
@@ -36,7 +39,7 @@ while (( $# > 0 )); do
 done
 
 if [[ -z "$build_configuration" ]]; then
-    [[ "$app_variant" == "production" ]] && build_configuration=release || build_configuration=debug
+    [[ "$app_variant" == "development" ]] && build_configuration=debug || build_configuration=release
 fi
 if [[ "$build_configuration" != debug && "$build_configuration" != release ]]; then
     print -u2 -- "--configuration must be debug or release"
@@ -48,7 +51,10 @@ if [[ "$app_variant" == production && "$build_configuration" != release ]]; then
 fi
 source_revision="$(git -C "$repo_root" rev-parse HEAD)"
 
-if [[ "$app_variant" == "development" ]]; then
+if [[ "$app_variant" == "nightly" ]]; then
+	app_name="OpenRecorderNightly"
+	bundle_identifier="dev.openrecorder.app.nightly"
+elif [[ "$app_variant" == "development" ]]; then
 	app_name="${OPEN_RECORDER_DEV_APP_NAME:-Open Recorder Dev}"
 	bundle_identifier="${OPEN_RECORDER_DEV_BUNDLE_IDENTIFIER:-dev.openrecorder.app.dev}"
 else
@@ -133,6 +139,13 @@ set_plist_string "CFBundleIdentifier" "$bundle_identifier"
 set_plist_string "OpenRecorderBuildConfiguration" "$build_configuration"
 set_plist_string "OpenRecorderSourceRevision" "$source_revision"
 
+if [[ "$app_variant" == "nightly" ]]; then
+    # Nightly is manually installed and must never own production project files.
+    for key in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks SUScheduledCheckInterval SUAllowsAutomaticUpdates UTExportedTypeDeclarations CFBundleDocumentTypes; do
+        /usr/libexec/PlistBuddy -c "Delete :$key" "$contents_dir/Info.plist" 2>/dev/null || true
+    done
+fi
+
 if [[ -f "$icon_source" ]]; then
 	cp "$icon_source" "$resources_dir/AppIcon.icns"
 	/usr/libexec/PlistBuddy -c "Set :CFBundleIconFile AppIcon" "$contents_dir/Info.plist"
@@ -155,17 +168,28 @@ else
 	zsh "$repo_root/scripts/sign-macos-production-app.zsh" "$bundle_dir"
 fi
 
+if [[ "$app_variant" == "nightly" ]]; then
+    zsh "$repo_root/scripts/verify-macos-production-signature.zsh" "$bundle_dir"
+    zsh "$repo_root/scripts/notarize-macos-production-app.zsh" "$bundle_dir"
+fi
+
 print -- "Packaged $bundle_dir"
 
 if [[ "$install" == true ]]; then
 	install_dir="${OPEN_RECORDER_INSTALL_DIR:-/Applications}"
 	installed_bundle="$install_dir/${app_name}.app"
+    if [[ "$app_variant" == "nightly" ]] && /usr/bin/pgrep -f '/OpenRecorderNightly[.]app/Contents/MacOS/OpenRecorderMac' >/dev/null; then
+        print -u2 -- "Quit OpenRecorderNightly before installing this build. The existing app was not replaced."
+        exit 1
+    fi
 	temp_bundle="$install_dir/.${app_name}.app.installing.$$"
 
 	rm -rf "$temp_bundle"
 	ditto "$bundle_dir" "$temp_bundle"
 	find "$temp_bundle" \( -name '._*' -o -name '.__CodeSignature' \) -delete
-	xattr -r -d com.apple.quarantine "$temp_bundle" 2>/dev/null || true
+	if [[ "$app_variant" != "nightly" ]]; then
+		xattr -r -d com.apple.quarantine "$temp_bundle" 2>/dev/null || true
+	fi
 	rm -rf "$installed_bundle"
 	mv "$temp_bundle" "$installed_bundle"
 	/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$installed_bundle" 2>/dev/null || true

--- a/scripts/package-macos-nightly-app.zsh
+++ b/scripts/package-macos-nightly-app.zsh
@@ -1,0 +1,32 @@
+#!/bin/zsh
+set -euo pipefail
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# Pin a real Developer ID identity; never use the development/ad-hoc fallback.
+identity_args=(-v -p codesigning)
+[[ -z "${OPEN_RECORDER_SIGNING_KEYCHAIN:-}" ]] || identity_args+=("$OPEN_RECORDER_SIGNING_KEYCHAIN")
+identities="$(security find-identity "${identity_args[@]}")"
+candidates="$(print -r -- "$identities" | grep -F '"Developer ID Application:' || true)"
+if [[ -n "${CODE_SIGN_IDENTITY:-}" ]]; then
+    candidates="$(print -r -- "$candidates" | grep -F -- "$CODE_SIGN_IDENTITY" || true)"
+fi
+if [[ -z "$candidates" || "$(print -r -- "$candidates" | wc -l | tr -d ' ')" != 1 ]]; then
+    print -u2 -- "Nightly requires one valid Developer ID Application identity with its private key. Import it into Keychain; if multiple exist, select one with CODE_SIGN_IDENTITY."
+    exit 1
+fi
+export CODE_SIGN_IDENTITY="$(print -r -- "$candidates" | sed -n 's/.*"\([^"]*\)".*/\1/p')"
+# GitHub uses the existing release secrets; local builds use a Keychain profile.
+if [[ -n "${OPEN_RECORDER_NOTARY_PROFILE:-}" ]]; then
+    xcrun notarytool history --keychain-profile "$OPEN_RECORDER_NOTARY_PROFILE" >/dev/null
+elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
+    : # The notarization helper consumes these existing CI credentials.
+else
+    export OPEN_RECORDER_NOTARY_PROFILE="OpenRecorderNightly"
+    xcrun notarytool history --keychain-profile "$OPEN_RECORDER_NOTARY_PROFILE" >/dev/null
+fi
+for arg in "$@"; do
+    case "$arg" in
+        --install|--launch) ;;
+        *) print -u2 -- "Unknown argument: $arg"; exit 2 ;;
+    esac
+done
+exec zsh "$repo_root/scripts/package-macos-app-shared.zsh" --nightly "$@"

--- a/scripts/tests/test_macos_notarization.py
+++ b/scripts/tests/test_macos_notarization.py
@@ -1,0 +1,122 @@
+"""Exercise notarization gates without credentials or contacting Apple."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'notarize-macos-production-app.zsh'
+
+
+class NotarizationTests(unittest.TestCase):
+    def run_notary(self, mode, profile=True):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app = root / 'Nightly.app'
+            app.mkdir()
+            commands = root / 'commands'
+            xcrun = root / 'xcrun'
+            xcrun.write_text('''#!/bin/zsh
+print -r -- "$*" >> "$TEST_COMMANDS"
+if [[ "$1 $2" == "notarytool submit" ]]; then
+    if [[ "$TEST_MODE" == "failure" ]]; then exit 42; fi
+    if [[ "$TEST_MODE" == "rejected" ]]; then
+        print -r -- '{"status":"Invalid"}'
+    else
+        print -r -- '{"status":"Accepted"}'
+    fi
+fi
+''')
+            xcrun.chmod(0o755)
+            spctl = root / 'spctl'
+            spctl.write_text('#!/bin/zsh\nprint -r -- "gatekeeper" >> "$TEST_COMMANDS"\n')
+            spctl.chmod(0o755)
+            environment = {
+                **os.environ,
+                'PATH': str(root) + ':/usr/bin:/bin:/usr/sbin:/sbin',
+                'TEST_COMMANDS': str(commands), 'TEST_MODE': mode,
+                'NOTARYTOOL_MAX_ATTEMPTS': '2', 'NOTARYTOOL_RETRY_DELAY_SECONDS': '0',
+                'OPEN_RECORDER_NOTARY_PROFILE': 'fixture-profile' if profile else '',
+                'APPLE_ID': 'fixture@example.invalid',
+                'APPLE_TEAM_ID': 'TESTTEAM', 'APPLE_APP_SPECIFIC_PASSWORD': 'fixture-only',
+            }
+            result = subprocess.run(['zsh', str(SCRIPT), str(app)], env=environment,
+                                    capture_output=True, text=True)
+            return result, commands.read_text()
+
+    def test_failed_submission_preserves_exit_code_and_never_staples(self):
+        result, commands = self.run_notary('failure')
+        self.assertEqual(result.returncode, 42, result.stderr)
+        self.assertEqual(commands.count('notarytool submit'), 2)
+        self.assertNotIn('stapler', commands)
+        self.assertNotIn('gatekeeper', commands)
+
+    def test_rejected_submission_with_zero_exit_code_never_staples(self):
+        result, commands = self.run_notary('rejected')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn('stapler', commands)
+
+    def test_accepted_profile_submission_staples_validates_and_assesses(self):
+        result, commands = self.run_notary('accepted')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('--keychain-profile fixture-profile', commands)
+        self.assertNotIn('--password', commands)
+        self.assertIn('stapler staple', commands)
+        self.assertIn('stapler validate', commands)
+        self.assertIn('gatekeeper', commands)
+
+    def test_existing_ci_credentials_remain_supported(self):
+        result, commands = self.run_notary('accepted', profile=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('--apple-id fixture@example.invalid', commands)
+        self.assertNotIn('--keychain-profile', commands)
+
+
+class NightlyCredentialSelectionTests(unittest.TestCase):
+    def test_ci_secrets_do_not_require_a_local_keychain_profile(self):
+        self.check_preflight(profile='', ci_credentials=True, expects_profile=False)
+
+    def test_local_build_defaults_to_nightly_profile(self):
+        self.check_preflight(profile='', ci_credentials=False, expects_profile=True)
+
+    def test_explicit_profile_wins_over_ci_secrets(self):
+        self.check_preflight(profile='fixture-profile', ci_credentials=True, expects_profile=True)
+
+    def check_preflight(self, profile, ci_credentials, expects_profile):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            commands = root / 'commands'
+            scripts = root / 'scripts'
+            scripts.mkdir()
+            wrapper = scripts / 'package-macos-nightly-app.zsh'
+            wrapper.write_text((SCRIPT.parent / wrapper.name).read_text())
+            (scripts / 'package-macos-app-shared.zsh').write_text('#!/bin/zsh\nexit 73\n')
+            stubs = {
+                'security': '#!/bin/zsh\nprint \'1) ABCDEF "Developer ID Application: Fixture (TESTTEAM)"\'\n',
+                'xcrun': '#!/bin/zsh\nprint -r -- "$*" >> "$TEST_COMMANDS"\n',
+            }
+            for name, source in stubs.items():
+                path = root / name
+                path.write_text(source)
+                path.chmod(0o755)
+            environment = {
+                **os.environ,
+                'PATH': str(root) + ':/usr/bin:/bin:/usr/sbin:/sbin',
+                'TEST_COMMANDS': str(commands),
+                'OPEN_RECORDER_NOTARY_PROFILE': profile,
+                'OPEN_RECORDER_SIGNING_KEYCHAIN': '', 'CODE_SIGN_IDENTITY': '',
+                'APPLE_ID': 'fixture@example.invalid' if ci_credentials else '',
+                'APPLE_TEAM_ID': 'TESTTEAM' if ci_credentials else '',
+                'APPLE_APP_SPECIFIC_PASSWORD': 'fixture-only' if ci_credentials else '',
+            }
+            result = subprocess.run(['zsh', str(wrapper)],
+                                    env=environment, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 73, result.stderr)
+            recorded = commands.read_text() if commands.exists() else ''
+            self.assertEqual('notarytool history --keychain-profile' in recorded, expects_profile)
+            if expects_profile:
+                self.assertIn(profile or 'OpenRecorderNightly', recorded)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds `OpenRecorderNightly.app` so production and Nightly can run independently and record each other. Nightly has its own bundle identity, preferences, media/project storage, disabled-by-default global shortcuts, and no production updater or file association. Capture filtering now excludes the current app identity rather than every Open Recorder variant.

The manually dispatched **Build Nightly macOS App** workflow builds optimized Apple Silicon and Intel bundles using the existing GitHub Developer ID and notarization secrets. Downloads include the notarized/stapled app, source metadata, and a checksum; no production release or appcast is published. Optional local packaging remains available.

Notarization now accepts Keychain profiles as well as existing CI credentials, requires an Accepted result, and preserves failed submission exit codes. Workflow regression tests cover both authentication paths and failure gates.

Validation: `make test-macos`, seven notarization/credential workflow tests, actionlint, shell syntax, and diff whitespace checks pass. Actual Apple signing/notarization will be exercised by dispatching the new workflow after merge; native cross-app recording has not yet been exercised.
