### PR TITLE
Fix Nightly CI release-test command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Debug and release tests
         run: |
-          make test-macos
-          python3 scripts/tests/test_macos_notarization.py test-macos-release
+          make test-macos test-macos-release
+          python3 scripts/tests/test_macos_notarization.py
       - name: Script tests
         run: node --test scripts/*.test.mjs
 


### PR DESCRIPTION
Fix the test command introduced in #1117: the existing `test-macos-release` target belongs on the `make` command, not as an argument to Python unittest. Both debug and release suites run before the seven notarization workflow tests.

The initial PR CI run passed all 704 Swift tests but then failed because unittest interpreted `test-macos-release` as a Python test name. This restores the existing release-test gate on both architectures.
