### PR TITLE
fix(macos): accept first drag in area selection overlays

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AreaSelectionViews.swift
@@ -116,7 +116,7 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
             window.collectionBehavior = AreaSelectionOverlayChrome.collectionBehavior
             window.isMovableByWindowBackground = false
             window.acceptsMouseMovedEvents = true
-            window.contentView = NSHostingView(rootView: AreaSelectionScreenOverlayView(
+            window.contentView = AreaSelectionHostingView(rootView: AreaSelectionScreenOverlayView(
                 screen: screen,
                 mode: mode,
                 onSelect: { [weak self] area in
@@ -184,6 +184,11 @@ final class AreaSelectionOverlayController: AreaSelectionPresenting {
             }
         }
     }
+}
+
+final class AreaSelectionHostingView: NSHostingView<AreaSelectionScreenOverlayView> {
+    // The activating mouse-down must also begin selection, including on non-key displays.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 }
 
 final class AreaSelectionOverlayPanel: NSPanel {

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDWindowMetricsTests.swift
@@ -140,6 +140,44 @@ final class HUDWindowMetricsTests: XCTestCase {
     }
 
     @MainActor
+    func testAreaSelectionContentAcceptsFirstMouseWhenPanelIsNotKey() throws {
+        guard !NSScreen.screens.isEmpty else {
+            throw XCTSkip("Area overlay input requires an attached display.")
+        }
+        let controller = AreaSelectionOverlayController()
+        defer { controller.dismiss() }
+
+        for mode in [CaptureMode.recording, .screenshot] {
+            controller.present(mode: mode, onSelect: { _ in }, onCancel: {})
+            let windows = controller.presentedWindowsForTesting
+            XCTAssertEqual(windows.count, NSScreen.screens.count)
+
+            for window in windows {
+                window.resignKey()
+                XCTAssertFalse(window.isKeyWindow)
+                let content = try XCTUnwrap(window.contentView)
+                content.layoutSubtreeIfNeeded()
+                let point = NSPoint(x: 40, y: 40)
+                let event = try XCTUnwrap(NSEvent.mouseEvent(
+                    with: .leftMouseDown,
+                    location: point,
+                    modifierFlags: [],
+                    timestamp: 0,
+                    windowNumber: window.windowNumber,
+                    context: nil,
+                    eventNumber: 1,
+                    clickCount: 1,
+                    pressure: 1
+                ))
+                XCTAssertTrue(content.acceptsFirstMouse(for: event))
+                let hitView = try XCTUnwrap(content.hitTest(point))
+                XCTAssertTrue(hitView.acceptsFirstMouse(for: event),
+                              "The actual drag target must accept the activating mouse-down.")
+            }
+        }
+    }
+
+    @MainActor
     func testAreaSelectionFocusRestoresEveryOverlay() throws {
         guard !NSScreen.screens.isEmpty else {
             throw XCTSkip("Area overlay focus requires an attached display.")


### PR DESCRIPTION
Area-selection overlays can consume the initial mouse-down while becoming key, requiring a second drag. Use an area-specific hosting view that accepts the activating mouse-down on every display. Selection geometry and cancellation behavior are unchanged.

Adds a regression exercising the actual content and hit-tested drag target while each panel is non-key, in recording and screenshot modes. This test failed before the change and passed afterward.

Validation: the original branch passed 655 Swift and 31 Rust tests, and the signed development app completed first-drag recording and screenshot selections, reverse drags starting on the instruction card, cancellation, undersized selection rejection, and reopening. After rebasing onto current main, make test-macos passed: 705 Swift tests with 3 skips and no failures, plus 32 Rust tests.

Verification limits: the user's reported production keyboard-shortcut sequence has not been reproduced or verified with this patch; their installed production binary does not contain the change. Computer use is currently blocked by the locked Mac. Inactive-app and physical secondary-display coverage remain unverified. This PR does not publish a release or update the installed production app.
