### PR TITLE
Keep recorder HUD hidden on launch

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -503,6 +503,7 @@ final class AppModel: ObservableObject {
                 self?.objectWillChange.send()
             }
         )
+        setCaptureStateMirror(captureState.withPresentation(.hidden))
         NotificationCenter.default.addObserver(
             forName: AVCaptureDevice.wasConnectedNotification,
             object: nil,
@@ -959,11 +960,15 @@ final class AppModel: ObservableObject {
                 restoredSource,
                 preferredSourceKind: storedCaptureSetup.preferredSourceKind
             ))
-            if let restoredSource {
+            if let restoredSource, isHUDVisible {
                 dispatch(.selectSource(restoredSource))
             }
         } else if let defaultSource = capture.sources.first(where: { $0.kind == .display }) ?? capture.sources.first {
-            dispatch(.selectSource(defaultSource))
+            dispatch(.restoreSetup(
+                captureMode,
+                defaultSource,
+                preferredSourceKind: defaultSource.kind
+            ))
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/CaptureState.swift
@@ -585,6 +585,7 @@ struct CaptureState: Hashable {
                 return finish(self)
             }
             next.setPhase(.setup(mode), clearSource: false)
+            next.presentation = .visible
             next.preferredSourceKind = next.selectedSource?.kind ?? next.preferredSourceKind ?? .display
             statusMessage = next.selectedSource == nil ? "Choose a source." : nil
             effects.append(.dismissScreenSelection)

--- a/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/AppModelStateTests.swift
@@ -52,6 +52,18 @@ final class AppModelStateTests: XCTestCase {
         )
     }
 
+    func testLaunchKeepsHUDHiddenUntilExplicitlyRequested() {
+        let model = AppModel()
+
+        XCTAssertFalse(model.isHUDVisible)
+        XCTAssertNil(model.windowCommand)
+
+        model.showHUD()
+
+        XCTAssertTrue(model.isHUDVisible)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+    }
+
     func testBeginRecordingMovesToReusableSetupAndRequestsHUD() {
         let model = AppModel()
 
@@ -87,7 +99,7 @@ final class AppModelStateTests: XCTestCase {
 
         let model = AppModel(captureSetupPreferencesStore: store)
 
-        XCTAssertEqual(model.hudState, .setup(.screenshot, preferredSourceKind: .window))
+        XCTAssertEqual(model.hudState, .setup(.screenshot, preferredSourceKind: .window).withPresentation(.hidden))
         XCTAssertEqual(model.captureMode, .screenshot)
         XCTAssertEqual(model.preferredSourceSelectorKind, .window)
     }
@@ -2141,12 +2153,12 @@ final class AppModelStateTests: XCTestCase {
 
         XCTAssertEqual(
             titles(in: controller.makeMenu(updateChecksEnabled: false)),
-            ["New Recording", "New Screenshot", "-", "Hide Recorder", "-", "Settings…", "-", "Quit Open Recorder"]
+            ["New Recording", "New Screenshot", "-", "Show Recorder", "-", "Settings…", "-", "Quit Open Recorder"]
         )
         XCTAssertEqual(
             titles(in: controller.makeMenu(updateChecksEnabled: true)),
             [
-                "New Recording", "New Screenshot", "-", "Hide Recorder", "-", "Settings…",
+                "New Recording", "New Screenshot", "-", "Show Recorder", "-", "Settings…",
                 "Check for Updates…", "-", "Quit Open Recorder",
             ]
         )

--- a/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/CaptureStateReducerTests.swift
@@ -186,6 +186,17 @@ final class CaptureStateReducerTests: XCTestCase {
         XCTAssertEqual(withoutSource.effects, [.showHUD])
     }
 
+    func testRestoringSourceKeepsLaunchHUDHiddenWithoutPresentationEffects() {
+        let source = makeSource(id: "display:restored", kind: .display)
+        let state = CaptureState.setup(.recording).withPresentation(.hidden)
+
+        let transition = state.applying(.restoreSetup(.recording, source, preferredSourceKind: .display))
+
+        XCTAssertEqual(transition.state.source, source)
+        XCTAssertEqual(transition.state.presentation, .hidden)
+        XCTAssertTrue(transition.effects.isEmpty)
+    }
+
     func testRestoreSetupUsesRestoredSourceKindOrRequestedFallback() {
         let window = makeSource(id: "window:restored", kind: .window)
 

--- a/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/HUDStateMachineTests.swift
@@ -198,13 +198,13 @@ final class HUDStateMachineTests: XCTestCase {
 
         model.toggleHUDPresentation()
 
-        XCTAssertEqual(model.hudState.presentation, .hidden)
-        XCTAssertEqual(model.windowCommand?.action, .hideHUD)
+        XCTAssertEqual(model.hudState.presentation, .visible)
+        XCTAssertEqual(model.windowCommand?.action, .showHUD)
 
         model.toggleHUDPresentation()
 
-        XCTAssertEqual(model.hudState.presentation, .visible)
-        XCTAssertEqual(model.windowCommand?.action, .showHUD)
+        XCTAssertEqual(model.hudState.presentation, .hidden)
+        XCTAssertEqual(model.windowCommand?.action, .hideHUD)
     }
 
     func testAreaSelectionBlocksNewCapturesUntilCanceled() {


### PR DESCRIPTION
Opening Open Recorder now keeps the recorder HUD hidden until the user chooses Show Recorder or starts a new capture. Restoring the saved source in the background also preserves the hidden state, avoiding a delayed HUD opening after launch.

Explicit new-capture actions make the HUD visible. Onboarding remains available on first run.

Validation: `make test-macos` passed (32 Rust tests; 707 Swift tests, 3 skipped), `make package-macos-dev` passed, and the packaged app passed strict code-signature verification. Native visual verification was blocked because the Mac was locked.
