### PR TITLE
fix(landing): import ReactElement explicitly in ScrollProgress

### DIFF
--- a/apps/landing/src/components/redesign/ScrollProgress.tsx
+++ b/apps/landing/src/components/redesign/ScrollProgress.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useEffect, useRef } from "react";
+import type { ReactElement } from "react";
 
-export function ScrollProgress(): React.ReactElement {
+export function ScrollProgress(): ReactElement {
   const barRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Import `ReactElement` explicitly as a type in `ScrollProgress`.
- Replace the ambient `React.ReactElement` return annotation with the local type.

## Root cause
`ScrollProgress` relied on the ambient `React` namespace for its return type instead of declaring the type dependency locally. The explicit type-only import matches the established landing code pattern and keeps the dependency visible to TypeScript.

## Verification
- `git diff --check` — passed.
- `pnpm --dir apps/landing exec tsc --noEmit` — passed on baseline and resulting diff.
- `pnpm --dir apps/landing exec eslint src/components/redesign/ScrollProgress.tsx` — passed.
- `pnpm build:landing` — passed.
- `pnpm lint:landing` — blocked by an unchanged pre-existing `RedesignHero.tsx:20` `react/jsx-no-comment-textnodes` error; no error in the changed file.
- Static proof: the only runtime statements, event listener, DOM updates, cleanup, JSX, and styling classes are unchanged; the new import is erased from emitted JavaScript.

Fixes #1128