### PR TITLE
fix(landing): resolve JSX lint error in hero label

### DIFF
--- a/apps/landing/src/components/redesign/RedesignHero.tsx
+++ b/apps/landing/src/components/redesign/RedesignHero.tsx
@@ -17,7 +17,7 @@ export function RedesignHero({ docsUrl, sourceUrl }: Props): ReactElement {
       <div className="rd-inner rd-hero-layout">
         {/* Left Column: Heading, Lead, CTAs, and Metadata */}
         <div className="rd-hero-left">
-          <p className="rd-hero-tag">//01 LOCAL-FIRST MACOS</p>
+          <p className="rd-hero-tag">{"//01 LOCAL-FIRST MACOS"}</p>
 
           <h1 className="rd-hero-title">
             The native<br />


### PR DESCRIPTION
## Summary
- Render the slash-prefixed hero metadata label through a JSX expression.
- Preserve the exact visible text `//01 LOCAL-FIRST MACOS` while satisfying `react/jsx-no-comment-textnodes`.

## Validation
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`
- `git diff --check`

## Scope and risk
One-line, behavior-preserving TSX syntax cleanup in `RedesignHero.tsx`; no runtime data flow, styling, dependencies, or generated files changed. No runtime regression test added because this is a static JSX lint fix.

Closes #1131