### PR TITLE
type(landing): make redesign feature metadata readonly

### DIFF
--- a/apps/landing/src/components/redesign/RedesignFeatures.tsx
+++ b/apps/landing/src/components/redesign/RedesignFeatures.tsx
@@ -19,7 +19,7 @@ const features = [
     copy: "Crop and reframe videos for fixed aspect layouts, compose screenshots on styled backgrounds, and export MOV, MP4, GIF, or PNG outputs.",
     icon: <ExportIcon />,
   },
-];
+] as const;
 
 export function RedesignFeatures(): ReactElement {
   return (


### PR DESCRIPTION
## Summary
- Applies `as const` to the module-private redesign feature metadata.
- Preserves the existing render loop and emitted JavaScript.

## Static proof
`features` is only consumed by `features.map` and field reads in `RedesignFeatures`; no array or item mutation exists. The change is type-only and keeps the one-file, one-line scope.

## Test plan
- `git diff --check`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm lint:landing`
- `pnpm build:landing`

## Risk
No runtime, markup, styling, dependency, workflow, or public API changes.

Fixes #1134