### PR TITLE
docs(landing): document the TypeScript validation command

### DIFF
--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -13,5 +13,6 @@ Validate:
 
 ```bash
 pnpm --dir apps/landing lint
+pnpm --dir apps/landing exec tsc --noEmit
 pnpm --dir apps/landing build
 ```


### PR DESCRIPTION
## Summary
- document the landing app TypeScript validation command in `apps/landing/README.md`

## Verification
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`

Fixes #1141
