### PR TITLE
type(landing): make RedesignHero URL props readonly

### DIFF
--- a/apps/landing/src/components/redesign/RedesignHero.tsx
+++ b/apps/landing/src/components/redesign/RedesignHero.tsx
@@ -2,8 +2,8 @@ import Image from "next/image";
 import type { ReactElement } from "react";
 
 interface Props {
-  docsUrl: string;
-  sourceUrl: string;
+  readonly docsUrl: string;
+  readonly sourceUrl: string;
 }
 
 export function RedesignHero({ docsUrl, sourceUrl }: Props): ReactElement {


### PR DESCRIPTION
## Summary

- Mark `RedesignHero`'s module-private `docsUrl` and `sourceUrl` props as readonly.
- Preserve the existing emitted JavaScript and rendered landing-page behavior.

## Validation

- `python3 /Users/bee/.hermes/profiles/recorder/scripts/open-recorder-prepare-worktree.py --worktree /Users/bee/open-recorder-worktrees/1144-redesignhero-readonly --scope landing`
- `git diff --check`
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`

## Scope and risk

This is a behavior-preserving TypeScript-only change in one file: 2 source lines modified (2 additions and 2 deletions). The interface is module-private, the props are only destructured and read as anchor `href` values, and TypeScript erases `readonly` from emitted JavaScript. No runtime or rendered-behavior regression test is added because the acceptance criteria call for static proof rather than source-reading tests.

Closes #1144