### PR TITLE
type(landing): make RedesignCTA source URL prop readonly

### DIFF
--- a/apps/landing/src/components/redesign/RedesignCTA.tsx
+++ b/apps/landing/src/components/redesign/RedesignCTA.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-interface Props { sourceUrl: string }
+interface Props { readonly sourceUrl: string }
 
 export function RedesignCTA({ sourceUrl }: Props): ReactElement {
   return (


### PR DESCRIPTION
## Summary
- Mark the `RedesignCTA` `sourceUrl` prop as `readonly`.
- Preserve runtime behavior while preventing mutation through the component contract.

## Validation
- `git diff --check`
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`
- Independent frontier review: passed

Closes #1147