### PR TITLE
fix(landing): make StepList item metadata readonly

### DIFF
--- a/apps/landing/src/components/redesign/StepList.tsx
+++ b/apps/landing/src/components/redesign/StepList.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement } from "react";
 
 export type Step = {
-  number?: string; // "01" — omit for rows without numbers (Swift app / Rust service)
-  title: string;
-  description: string;
+  readonly number?: string; // "01" — omit for rows without numbers (Swift app / Rust service)
+  readonly title: string;
+  readonly description: string;
 };
 
 interface Props {


### PR DESCRIPTION
## Summary

- Make all `Step` metadata fields readonly: `number`, `title`, and `description`.
- Preserve the optional `number` field and all existing rendering behavior.

Closes #1150

## Root cause

The exported `Step` metadata contract exposed mutable properties even though `StepList` consumes readonly step arrays and its callers provide immutable metadata. This allowed consumers to type-check accidental mutation of shared landing-page data.

## Validation

- `git diff --check`
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`
- Independent frontier review: approved; no findings.

This is a type-only landing change limited to `apps/landing/src/components/redesign/StepList.tsx`; no native gates are applicable.
