### PR TITLE
fix(landing): make StepList props readonly

### DIFF
--- a/apps/landing/src/components/redesign/StepList.tsx
+++ b/apps/landing/src/components/redesign/StepList.tsx
@@ -7,8 +7,8 @@ export type Step = {
 };
 
 interface Props {
-  steps: readonly Step[];
-  parallax?: boolean;
+  readonly steps: readonly Step[];
+  readonly parallax?: boolean;
 }
 
 export function StepList({ steps, parallax = true }: Props): ReactElement {


### PR DESCRIPTION
## Summary

- Make `StepList` component props readonly to match the component's read-only usage.
- Preserve the existing runtime behavior and readonly `Step` element type.

Fixes #1153

## Verification

- `git diff --check`
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`
- Independent frontier review: passed; no security concerns or logic errors.

This is a behavior-preserving type-only cleanup, so no source-reading or source-string regression test was added.
