### PR TITLE
refactor(landing): reuse page docs URL in nav

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home(): ReactElement {
       <ScrollProgress />
       <MotionObserver />
 
-      <RedesignNav />
+      <RedesignNav docsUrl={docsUrl} />
       <RedesignHero docsUrl={docsUrl} sourceUrl={sourceUrl} />
       <RedesignProof />
       <RedesignFeatures />

--- a/apps/landing/src/app/redesign/page.tsx
+++ b/apps/landing/src/app/redesign/page.tsx
@@ -20,7 +20,7 @@ export default function RedesignPage(): ReactElement {
       <ScrollProgress />
       <MotionObserver />
 
-      <RedesignNav />
+      <RedesignNav docsUrl={docsUrl} />
       <RedesignHero docsUrl={docsUrl} sourceUrl={sourceUrl} />
       <RedesignProof />
       <RedesignFeatures />

--- a/apps/landing/src/components/redesign/RedesignNav.tsx
+++ b/apps/landing/src/components/redesign/RedesignNav.tsx
@@ -1,7 +1,9 @@
 import Image from "next/image";
 import type { ReactElement } from "react";
 
-export function RedesignNav(): ReactElement {
+type Props = { readonly docsUrl: string };
+
+export function RedesignNav({ docsUrl }: Props): ReactElement {
   return (
     <nav className="rd-nav" aria-label="Primary navigation">
       <div className="rd-nav-inner">
@@ -19,7 +21,7 @@ export function RedesignNav(): ReactElement {
           <a className="rd-nav-link" href="#architecture">Architecture</a>
           <a
             className="rd-btn rd-btn-primary rd-btn-sm"
-            href="https://docs.openrecorder.xyz/"
+            href={docsUrl}
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary
- Add a component-local readonly `docsUrl` prop to `RedesignNav`.
- Reuse each landing route's existing `docsUrl` binding for the navigation Docs link.
- Preserve the current URL, link markup, and runtime behavior while keeping one page-local source of truth.

## Verification
- `git diff --check`
- `pnpm lint:landing`
- `pnpm --dir apps/landing exec tsc --noEmit`
- `pnpm build:landing`
- Independent frontier review: pass

Fixes #1156
