### PR TITLE
docs: list the docs directory in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `apps/macos` - native SwiftUI macOS app
 - `apps/rust-service` - Rust JSON-lines service and one-shot command backend
 - `apps/landing` - Next.js landing page for the project
+- `docs` - project documentation and supporting artifacts
 
 ## Build From Source
 


### PR DESCRIPTION
## Summary
- Document the repository-level `docs/` directory in the README Repository Layout section.

## Verification
- `git diff --check`
- Confirmed `docs/` exists and contains tracked project documentation on `origin/main`.
- No runtime regression test is applicable to this documentation-only change.
- Independent frontier review: passed; no security or logic concerns.

## Risk
Documentation-only clarification; no source, generated, dependency, lockfile, workflow, release, or runtime behavior changes.

Closes #1159
