### PR TITLE
docs: list Mintlify content roots in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `apps/macos` - native SwiftUI macOS app
 - `apps/rust-service` - Rust JSON-lines service and one-shot command backend
 - `apps/landing` - Next.js landing page for the project
+- `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
 - `docs` - project documentation and supporting artifacts
 
 ## Build From Source


### PR DESCRIPTION
## Summary

- Identify `recording`, `editing`, and `reference` as the Mintlify documentation content roots in the README repository layout.
- Describe their relationship to the corresponding navigation groups declared in `docs.json`.

## Verification

- `git diff --check`
- Confirmed the mapped Mintlify routes and checked-in `.mdx` pages under all three roots.
- Confirmed only `README.md` changes (one added line).
- Independent frontier review passed with no security concerns or logic errors.

Refs #1162
