### PR TITLE
docs: list licenses directory in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `apps/landing` - Next.js landing page for the project
 - `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
 - `docs` - project documentation and supporting artifacts
+- `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 
 ## Build From Source
 


### PR DESCRIPTION
## Summary

- Document the root `licenses/` directory in the README repository layout.
- Identify its current secondary MIT license notices for OpenScreen and RECORDLY.

## Verification

- `git diff --check`
- Confirmed `licenses/` exists on `origin/main` and contains exactly `LICENSE-OpenScreen` and `LICENSE-RECORDLY`.
- Confirmed both license files are unchanged by this patch.
- Confirmed only `README.md` changes (one added line).
- No runtime regression test is applicable to this documentation-only change.
- Independent frontier review: approved with no findings.

## Risk

Documentation-only clarification; no source, generated, dependency, lockfile, workflow, release, or runtime behavior changes.

Closes #1165
