### PR TITLE
docs: document skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
 - `docs` - project documentation and supporting artifacts
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
+- `skills` - repository-local maintainer automation guidance
 
 ## Build From Source
 


### PR DESCRIPTION
## Summary
- Document the top-level `skills` directory in the root README repository layout.
- Identify it as repository-local maintainer automation guidance.

## Verification
- `git diff --check origin/main...HEAD`
- Confirmed `skills/publish-github-release/SKILL.md` exists on `origin/main`.
- Documentation-only change; no runtime test applies.

## Scope
- `README.md` only; no behavior, dependency, workflow, or native changes.

Closes #1168