### PR TITLE
docs: list scripts directory in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
 - `docs` - project documentation and supporting artifacts
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
+- `scripts` - repository build, packaging, verification, and maintenance tooling
 - `skills` - repository-local maintainer automation guidance
 
 ## Build From Source


### PR DESCRIPTION
## Summary
- Add the root `scripts` directory to the README Repository Layout section.
- Describe its build, packaging, verification, and maintenance tooling.

## Verification
- `git diff --check origin/main...HEAD` passed.
- Independent frontier review passed with no security concerns or logic errors.
- Documentation-only change; runtime and native gates are not applicable.

Closes #1171
