### PR TITLE
docs: list root Mintlify pages in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `apps/rust-service` - Rust JSON-lines service and one-shot command backend
 - `apps/landing` - Next.js landing page for the project
 - `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
+- `index.mdx` and `changelog.mdx` - root Mintlify pages for the Overview and Updates navigation groups
 - `docs` - project documentation and supporting artifacts
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling


### PR DESCRIPTION
## Summary

- Document the root-level Mintlify pages `index.mdx` and `changelog.mdx` in the README repository layout.
- Identify their Overview and Updates navigation roles as configured in `docs.json`.

## Validation

- `git diff --check`
- Verified `docs.json` maps Overview to `index` and Updates to `changelog`, and both root pages exist.
- Independent frontier review: APPROVE, no findings.

Documentation-only change; no runtime regression test or native/landing build gate is applicable.

Closes #1174