### PR TITLE
docs: list Mintlify configuration in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `apps/landing` - Next.js landing page for the project
 - `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
 - `index.mdx` and `changelog.mdx` - root Mintlify pages for the Overview and Updates navigation groups
+- `docs.json` - Mintlify documentation configuration and navigation file
 - `docs` - project documentation and supporting artifacts
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling


### PR DESCRIPTION
Summary:
- Document the root `docs.json` file in the README repository layout.
- Identify it as the Mintlify documentation configuration and navigation file.

Testing:
- `git diff --check origin/main...HEAD`
- Documentation-only change; no runtime tests are applicable.

Fixes #1177
