### PR TITLE
docs: list .github directory in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `index.mdx` and `changelog.mdx` - root Mintlify pages for the Overview and Updates navigation groups
 - `docs.json` - Mintlify documentation configuration and navigation file
 - `docs` - project documentation and supporting artifacts
+- `.github` - GitHub templates and repository automation configuration
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling
 - `skills` - repository-local maintainer automation guidance


### PR DESCRIPTION
## Summary

- Document the root `.github` directory in the README repository layout.
- Describe its GitHub templates and repository automation configuration.

## Verification

- `git diff --check`
- Independent frontier review approved with no findings.

Fixes #1180
