### PR TITLE
docs: list translation guide in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling
 - `skills` - repository-local maintainer automation guidance
+- `TRANSLATION_GUIDE.md` - contributor guide for app localization
 
 ## Build From Source
 


### PR DESCRIPTION
## Summary

- Add the existing `TRANSLATION_GUIDE.md` to the README repository layout.
- Accurately describe it as the contributor guide for app localization.

Fixes #1183

## Validation

- `git diff --check`
- `git show --check --stat --oneline HEAD`
- Independent frontier review approved the one-line documentation diff with no findings.
- Documentation-only change; no runtime or native tests are applicable.
