### PR TITLE
docs: list CONTRIBUTING.md in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling
 - `skills` - repository-local maintainer automation guidance
+- `CONTRIBUTING.md` - contribution guidelines for the project
 - `TRANSLATION_GUIDE.md` - contributor guide for app localization
 
 ## Build From Source


### PR DESCRIPTION
Summary
- Add the root-level `CONTRIBUTING.md` file to the README Repository Layout.

Issue
- Refs #1186

Tests
- Not run (documentation-only change).
- `git diff --check` passes.
