### PR TITLE
docs: list .mintignore in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `recording`, `editing`, and `reference` - Mintlify documentation content roots for the Recording, Editing, and Reference navigation groups
 - `index.mdx` and `changelog.mdx` - root Mintlify pages for the Overview and Updates navigation groups
 - `docs.json` - Mintlify documentation configuration and navigation file
+- `.mintignore` - excludes separately deployed application source from Mintlify documentation assets
 - `docs` - project documentation and supporting artifacts
 - `.github` - GitHub templates and repository automation configuration
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY


### PR DESCRIPTION
## Summary
- Document `.mintignore` in the README Repository Layout.
- Explain that it excludes separately deployed application source from Mintlify documentation assets.

## Validation
- `git diff --check`
- Static acceptance checks confirmed that only `README.md` changed and the commit adds exactly one line.

## Scope
Documentation-only; no runtime, dependency, workflow, security, privacy, recording, export, or API behavior changes.

Closes #1189
