### PR TITLE
docs: list Makefile in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `.github` - GitHub templates and repository automation configuration
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling
+- `Makefile` - top-level command entry point for setup, macOS build, development, packaging, testing, and cleanup
 - `skills` - repository-local maintainer automation guidance
 - `CONTRIBUTING.md` - contribution guidelines for the project
 - `TRANSLATION_GUIDE.md` - contributor guide for app localization


### PR DESCRIPTION
## Summary

- Document the root `Makefile` in the README repository layout.
- Describe its setup, macOS build/development, packaging, testing, and cleanup command entry points.

## Validation

- `git diff --check`
- Static proof against `origin/main`: exactly one `Makefile` layout bullet; Build From Source section unchanged.

Fixes #1195
