### PR TITLE
docs: list README UI preview asset in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `.mintignore` - excludes separately deployed application source from Mintlify documentation assets
 - `.all-contributorsrc` - All Contributors configuration that generates the README contributor table
 - `docs` - project documentation and supporting artifacts
+- `open-recorder-ui.png` - root-level preview of the Open Recorder Editor UI embedded above
 - `.github` - GitHub templates and repository automation configuration
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling


### PR DESCRIPTION
Closes #1198

Summary:
- Add the existing root-level `open-recorder-ui.png` asset to the README Repository Layout list.
- Document its current role as the embedded Open Recorder Editor UI preview.

Validation:
- `git diff --check origin/main...HEAD`
- Confirmed `open-recorder-ui.png` resolves from the README preview path.
- Confirmed the committed diff changes only `README.md` (one inserted line).
- Independent frontier review approved the bounded documentation-only change.

Scope:
- No source, configuration, generated, binary, dependency, lockfile, runtime, or native code changes.