### PR TITLE
feat: add 3D scenes for image and video editors

### DIFF
--- a/apps/macos/Sources/OpenRecorderMac/AppModel.swift
+++ b/apps/macos/Sources/OpenRecorderMac/AppModel.swift
@@ -644,10 +644,7 @@ final class AppModel: ObservableObject {
                 self?.videoExportSaveDestination(sourceURL: sourceURL, options: options)
             },
             copyFile: { sourceURL, targetURL in
-                if FileManager.default.fileExists(atPath: targetURL.path) {
-                    try FileManager.default.removeItem(at: targetURL)
-                }
-                try FileManager.default.copyItem(at: sourceURL, to: targetURL)
+                try ExportFileSafety.install(source: sourceURL, destination: targetURL)
             },
             deleteFile: { url in
                 try? FileManager.default.removeItem(at: url)

--- a/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorStateMachines.swift
@@ -87,7 +87,10 @@ struct VideoExportDraftState: Equatable {
 
 struct VideoEditorState: Equatable {
     var video = ProjectVideoEditorState.default
-    var previewAspectPreset: VideoPreviewAspectPreset = .auto
+    var previewAspectPreset: VideoPreviewAspectPreset {
+        get { video.canvasAspect }
+        set { video.canvasAspect = newValue }
+    }
     var activeSheet: VideoEditorSheet?
     var presentedSheet: VideoEditorSheet?
     var appliedTimelineIdentity: String?
@@ -119,6 +122,7 @@ struct VideoEditorState: Equatable {
             insetOpacity: video.insetOpacity,
             insetBalance: video.insetBalance
         )
+        .withScene(video.scene)
         .withAspectPreset(previewAspectPreset)
         .withCursorOverlay(cursorOverlaySettings, telemetryURL: cursorTelemetryURL)
     }
@@ -291,7 +295,6 @@ extension VideoEditorState {
         if appliedVideoStateIdentity != identity {
             appliedVideoStateIdentity = identity
             video = Self.initialVideoState(for: context)
-            previewAspectPreset = .auto
             didApplyState = true
         }
 
@@ -350,6 +353,16 @@ extension VideoEditorState {
 @MainActor
 final class VideoEditorDriver {
     var state = VideoEditorState()
+    var sceneHistoryIsActive = false
+    private var historyRevision = 0
+    @ObservationIgnored private var history = EditorHistory<ProjectVideoEditorState>()
+    var canUndo: Bool { _ = historyRevision; return history.canUndo }
+    var canRedo: Bool { _ = historyRevision; return history.canRedo }
+    func beginUndoTransaction() { history.beginTransaction(current: state.video) }
+    func endUndoTransaction() { if history.commitTransaction(current: state.video) { historyRevision += 1 } }
+    func undo() { if let previous = history.undo(current: state.video) { state.video = previous; historyRevision += 1 } }
+    func redo() { if let next = history.redo(current: state.video) { state.video = next; historyRevision += 1 } }
+
 
     @ObservationIgnored private let autosave = ProjectAutosaveCoordinator()
     @ObservationIgnored private var applyTimelineSnapshot: (TimelineEditSnapshot) -> Void = { _ in }
@@ -374,7 +387,12 @@ final class VideoEditorDriver {
     }
 
     func send(_ event: VideoEditorEvent) {
+        let before = state.video
+        let identity = state.appliedVideoStateIdentity
         let effects = state.applying(event)
+        if state.appliedVideoStateIdentity != identity { history.reset() }
+        else { history.recordChange(from: before, to: state.video) }
+        historyRevision += 1
         perform(effects)
     }
 
@@ -860,7 +878,7 @@ final class EditorWorkspaceDriver {
         guard state.selectedSection == .editor else { return false }
         switch kind {
         case .video:
-            return timeline.canUndo
+            return video.sceneHistoryIsActive ? video.canUndo : timeline.canUndo
         case .screenshot:
             return screenshot.canUndo
         case nil:
@@ -872,7 +890,7 @@ final class EditorWorkspaceDriver {
         guard state.selectedSection == .editor else { return false }
         switch kind {
         case .video:
-            return timeline.canRedo
+            return video.sceneHistoryIsActive ? video.canRedo : timeline.canRedo
         case .screenshot:
             return screenshot.canRedo
         case nil:
@@ -1057,9 +1075,9 @@ final class EditorWorkspaceDriver {
                     setStatusMessage(message)
                 }
             case .undoTimeline:
-                timeline.undo()
+                if video.sceneHistoryIsActive { video.undo() } else { timeline.undo() }
             case .redoTimeline:
-                timeline.redo()
+                if video.sceneHistoryIsActive { video.redo() } else { timeline.redo() }
             case .undoScreenshot:
                 screenshot.undo()
             case .redoScreenshot:

--- a/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/EditorViews.swift
@@ -130,23 +130,14 @@ struct VideoEditorStudioView: View {
     var videoExport: VideoExportDriver
     var exportRequest: EditorExportRequest?
     @State private var sidebarWidth: CGFloat = 320
+    @State private var activeInspector: InspectorTab = .appearance
+    @State private var showsTimelineSelection = false
+    @State private var sceneEndpoint: SceneEndpoint = .start
+    @State private var sceneTool: SceneTool = .tilt
     private let timelineHeight = TimelineMetrics.compactPanelHeight
 
     var body: some View {
-        StudioSplitPane(
-            axis: .horizontal,
-            secondarySize: sidebarWidth,
-            minPrimarySize: 520,
-            minSecondarySize: 280,
-            maxSecondarySize: 440,
-            spacing: 0
-        ) {
-            editorColumn
-        } secondary: {
-            sidebarContent
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .background(Theme.appBg)
+        workspacePanes
         .sheet(item: editor.activeSheetBinding(exportIsBusy: videoExport.state.phase.isBusy)) { sheet in
             switch sheet {
             case .export:
@@ -168,7 +159,54 @@ struct VideoEditorStudioView: View {
         .onChange(of: autosaveSnapshot) { _, snapshot in
             editor.send(.autosaveSnapshotChanged(snapshot))
         }
-        .onAppear {
+        .onAppear(perform: configureEditor)
+        .onDisappear {
+            editor.send(.disappeared(autosaveSnapshot))
+        }
+        .background {
+            StudioKeyDownMonitor { event in
+                handleEditorShortcut(event)
+            }
+            .frame(width: 0, height: 0)
+        }
+    }
+
+    private var workspacePanes: some View {
+        StudioSplitPane(
+            axis: .horizontal,
+            secondarySize: sidebarWidth,
+            minPrimarySize: 520,
+            minSecondarySize: 280,
+            maxSecondarySize: 440,
+            spacing: 0
+        ) {
+            editorColumn
+        } secondary: {
+            sidebarContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(Theme.appBg)
+        .onChange(of: timelineEdits.state) { old, next in
+            if old.selectedID != next.selectedID || old.selectedClipIndex != next.selectedClipIndex || old.selectedCameraClipID != next.selectedCameraClipID || old.selectedKind != next.selectedKind {
+                showsTimelineSelection = timelineEdits.hasSelection
+                editor.sceneHistoryIsActive = false
+            }
+        }
+        .onChange(of: activeInspector) { _, tab in editor.sceneHistoryIsActive = tab == .scene }
+        .onChange(of: showsTimelineSelection) { _, selected in
+            editor.sceneHistoryIsActive = !selected && activeInspector == .scene
+        }
+        .onChange(of: editor.state.video.scene) { _, _ in
+            if activeInspector == .scene && !showsTimelineSelection { playback.pause() }
+        }
+        .onChange(of: sceneEditPlan.outputDuration) { _, duration in
+            guard duration > 0 else { return }
+            let next = editor.state.video.scene.clamped(to: duration)
+            if next != editor.state.video.scene { editor.binding(\.scene).wrappedValue = next }
+        }
+    }
+
+    private func configureEditor() {
             editor.configure(
                 applyTimelineSnapshot: { snapshot in
                     timelineEdits.applySnapshot(snapshot)
@@ -192,16 +230,6 @@ struct VideoEditorStudioView: View {
                 }
             )
             syncEditorSession()
-        }
-        .onDisappear {
-            editor.send(.disappeared(autosaveSnapshot))
-        }
-        .background {
-            StudioKeyDownMonitor { event in
-                handleEditorShortcut(event)
-            }
-            .frame(width: 0, height: 0)
-        }
     }
 
     private var editorColumn: some View {
@@ -233,6 +261,11 @@ struct VideoEditorStudioView: View {
                 facecamSettings: editor.state.currentFacecamSettings,
                 cameraTimelineFallback: editor.state.currentFacecamSettings,
                 previewAspectPreset: editor.previewAspectPresetBinding,
+                scene: editor.binding(\.scene),
+                sceneEndpoint: sceneEndpoint,
+                sceneTool: $sceneTool,
+                showsSceneTools: activeInspector == .scene && !showsTimelineSelection,
+                onSceneEditingChanged: sceneUndoTransaction,
                 onCropVideo: {
                     guard let videoURL else { return }
                     editor.send(.cropRequested(videoURL))
@@ -254,34 +287,36 @@ struct VideoEditorStudioView: View {
         }
     }
 
-    @ViewBuilder
+    private var sceneEditPlan: TimelineExportEditPlan {
+        TimelineExportEditPlan.build(duration: playback.duration, edits: timelineEdits.snapshot)
+    }
+
+    private func seekScene(_ time: Double) {
+        playback.pause()
+        playback.seek(to: sceneEditPlan.sourceTime(forOutputTime: time) ?? playback.duration)
+    }
+
+    private func sceneUndoTransaction(_ editing: Bool) {
+        editor.sceneHistoryIsActive = true
+        if editing { playback.pause(); editor.beginUndoTransaction() }
+        else { editor.endUndoTransaction() }
+    }
+
     private var sidebarContent: some View {
-        if timelineEdits.hasSelection {
-            TimelineSelectionSidebar(
-                edits: timelineEdits,
-                playback: playback,
-                defaultCameraSettings: editor.state.currentFacecamSettings
-            )
-        } else {
-            SettingsInspector(
-                borderRadius: editor.binding(\.borderRadius),
-                padding: editor.binding(\.padding),
-                shadow: editor.binding(\.shadow),
-                backgroundBlur: editor.binding(\.backgroundBlur),
-                background: editor.binding(\.background),
-                inset: editor.binding(\.inset),
-                insetColor: editor.binding(\.insetColor),
-                insetOpacity: editor.binding(\.insetOpacity),
-                insetBalance: editor.binding(\.insetBalance),
-                showCursor: editor.binding(\.cursorOverlay.isVisible),
-                loopCursor: editor.binding(\.cursorOverlay.loops),
-                cursorSize: editor.binding(\.cursorOverlay.size),
-                cursorSmoothing: editor.binding(\.cursorOverlay.smoothing),
-                cursorStyleID: editor.binding(\.cursorOverlay.styleID),
-                cameraSettings: editor.binding(\.facecamSettings),
-                recordingSession: recordingSession
-            )
-        }
+        SettingsInspector(
+            borderRadius: editor.binding(\.borderRadius), padding: editor.binding(\.padding),
+            shadow: editor.binding(\.shadow), backgroundBlur: editor.binding(\.backgroundBlur),
+            background: editor.binding(\.background), inset: editor.binding(\.inset),
+            insetColor: editor.binding(\.insetColor), insetOpacity: editor.binding(\.insetOpacity),
+            insetBalance: editor.binding(\.insetBalance), showCursor: editor.binding(\.cursorOverlay.isVisible),
+            loopCursor: editor.binding(\.cursorOverlay.loops), cursorSize: editor.binding(\.cursorOverlay.size),
+            cursorSmoothing: editor.binding(\.cursorOverlay.smoothing), cursorStyleID: editor.binding(\.cursorOverlay.styleID),
+            cameraSettings: editor.binding(\.facecamSettings), recordingSession: recordingSession,
+            activeTab: $activeInspector, scene: editor.binding(\.scene), canvasAspect: editor.previewAspectPresetBinding,
+            sceneEndpoint: $sceneEndpoint, showsSelection: $showsTimelineSelection,
+            selectionSidebar: TimelineSelectionSidebar(edits: timelineEdits, playback: playback, defaultCameraSettings: editor.state.currentFacecamSettings),
+            sceneDuration: sceneEditPlan.outputDuration, seekScene: seekScene, onSceneEditingChanged: sceneUndoTransaction
+        )
     }
 
     private func handleEditorShortcut(_ event: NSEvent) -> Bool {

--- a/apps/macos/Sources/OpenRecorderMac/ExportFileSafety.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ExportFileSafety.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum ExportFileSafety {
+    enum Failure: LocalizedError {
+        case originalFile
+        var errorDescription: String? { "Choose a different filename to preserve the original media." }
+    }
+    static func sameFile(_ first: URL, _ second: URL) -> Bool {
+        if first.resolvingSymlinksInPath().standardizedFileURL == second.resolvingSymlinksInPath().standardizedFileURL { return true }
+        let keys: Set<URLResourceKey> = [.fileResourceIdentifierKey]
+        if let a = try? first.resourceValues(forKeys: keys).fileResourceIdentifier as? NSObject,
+           let b = try? second.resourceValues(forKeys: keys).fileResourceIdentifier as? NSObject { return a == b }
+        return false
+    }
+
+    /// Stage beside the destination so a failed copy cannot delete an existing export.
+    static func install(source: URL, destination: URL) throws {
+        let manager = FileManager.default
+        let staged = destination.deletingLastPathComponent().appendingPathComponent(".open-recorder-\(UUID().uuidString).tmp")
+        defer { try? manager.removeItem(at: staged) }
+        try manager.copyItem(at: source, to: staged)
+        if manager.fileExists(atPath: destination.path) {
+            _ = try manager.replaceItemAt(destination, withItemAt: staged)
+        } else { try manager.moveItem(at: staged, to: destination) }
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/InspectorViews.swift
@@ -28,7 +28,15 @@ struct SettingsInspector: View {
     var recordingSession: RecordingSession?
 
     @Namespace private var tabRailAnimation
-    @State private var activeTab: InspectorTab = .appearance
+    @Binding var activeTab: InspectorTab
+    @Binding var scene: SceneSettings
+    @Binding var canvasAspect: VideoPreviewAspectPreset
+    @Binding var sceneEndpoint: SceneEndpoint
+    @Binding var showsSelection: Bool
+    var selectionSidebar: TimelineSelectionSidebar? = nil
+    var sceneDuration: Double = 3
+    var seekScene: (Double) -> Void = { _ in }
+    var onSceneEditingChanged: (Bool) -> Void = { _ in }
     @State private var hoveredTab: InspectorTab?
     @State private var isInsetBalanceExpanded = false
     @State private var removeCameraBackground = false
@@ -62,29 +70,33 @@ struct SettingsInspector: View {
         HStack(spacing: 0) {
             verticalIconRail
 
-            ScrollViewReader { scrollProxy in
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        tabContent
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 14)
-                    .padding(.bottom, 18)
-                    .animation(.snappy(duration: 0.34), value: activeTab.id)
-                    .animation(.snappy(duration: 0.34), value: background.presetKind)
-                    .animation(.snappy(duration: 0.34), value: hasRecordedCamera)
-                    .animation(.snappy(duration: 0.34), value: cursorStyleID)
-                    .animation(.smooth(duration: 0.30), value: showsInsetControls)
-                    .onChange(of: isInsetBalanceExpanded) { _, isExpanded in
-                        guard isExpanded else { return }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-                            withAnimation(.snappy(duration: 0.34)) {
-                                scrollProxy.scrollTo(insetBalanceScrollID, anchor: .bottom)
+            if showsSelection, let selectionSidebar {
+                selectionSidebar
+            } else {
+                ScrollViewReader { scrollProxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 0) {
+                            tabContent
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.top, 14)
+                        .padding(.bottom, 18)
+                        .animation(.snappy(duration: 0.34), value: activeTab.id)
+                        .animation(.snappy(duration: 0.34), value: background.presetKind)
+                        .animation(.snappy(duration: 0.34), value: hasRecordedCamera)
+                        .animation(.snappy(duration: 0.34), value: cursorStyleID)
+                        .animation(.smooth(duration: 0.30), value: showsInsetControls)
+                        .onChange(of: isInsetBalanceExpanded) { _, isExpanded in
+                            guard isExpanded else { return }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                                withAnimation(.snappy(duration: 0.34)) {
+                                    scrollProxy.scrollTo(insetBalanceScrollID, anchor: .bottom)
+                                }
                             }
                         }
                     }
+                    .scrollIndicators(.visible)
                 }
-                .scrollIndicators(.visible)
             }
         }
     }
@@ -92,13 +104,14 @@ struct SettingsInspector: View {
     private var verticalIconRail: some View {
         VStack(spacing: 12) {
             ForEach(InspectorTab.railCases) { tab in
-                let isSelected = activeTab == tab
+                let isSelected = activeTab == tab && !showsSelection
                 let isStubbed = tab.isStubbed
 
                 StudioButton(hitTarget: .rounded(Theme.radiusSm), help: tab.helpText) {
                     guard !isStubbed else { return }
                     withAnimation(.snappy(duration: 0.20)) {
                         activeTab = tab
+                        showsSelection = false
                     }
                 } label: {
                     VStack(spacing: 4) {
@@ -165,7 +178,10 @@ struct SettingsInspector: View {
     @ViewBuilder
     private var tabContent: some View {
         switch activeTab {
+        case .scene:
+            SceneInspector(settings: $scene, endpoint: $sceneEndpoint, duration: sceneDuration, seek: seekScene, onEditingChanged: onSceneEditingChanged)
         case .appearance:
+            CanvasAspectPicker(selection: $canvasAspect).padding(.bottom, 12)
             BackgroundPickerView(selection: $background, showsTopDivider: false)
             InspectorGroup(
                 title: "Frame",
@@ -464,19 +480,21 @@ struct InspectorFooterButton: View {
 
 enum InspectorTab: String, CaseIterable, Identifiable {
     case appearance
+    case scene
     case cursor
     case camera
     case captions
     case settings
     case audio
 
-    static let availableCases: [InspectorTab] = [.appearance, .cursor, .camera]
-    static let railCases: [InspectorTab] = [.appearance, .cursor, .camera, .captions, .settings]
+    static let availableCases: [InspectorTab] = [.appearance, .scene, .cursor, .camera]
+    static let railCases: [InspectorTab] = [.appearance, .scene, .cursor, .camera, .captions, .settings]
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
+        case .scene: "Scene"
         case .appearance: "Appearance"
         case .cursor: "Cursor"
         case .camera: "Camera"
@@ -488,6 +506,7 @@ enum InspectorTab: String, CaseIterable, Identifiable {
 
     var shortTitle: String {
         switch self {
+        case .scene: "Scene"
         case .appearance: "Frame"
         case .cursor: "Cursor"
         case .camera: "Camera"
@@ -499,6 +518,7 @@ enum InspectorTab: String, CaseIterable, Identifiable {
 
     var symbolName: String {
         switch self {
+        case .scene: "rotate.3d"
         case .appearance: "slider.horizontal.3"
         case .cursor: "cursorarrow"
         case .camera: "camera"
@@ -510,13 +530,14 @@ enum InspectorTab: String, CaseIterable, Identifiable {
 
     var isStubbed: Bool {
         switch self {
-        case .appearance, .cursor, .camera: false
+        case .appearance, .scene, .cursor, .camera: false
         case .captions, .settings, .audio: true
         }
     }
 
     var helpText: String {
         switch self {
+        case .scene: "Scene · 3D Tilt & Motion (Alpha)"
         case .appearance: "Appearance & Frame"
         case .cursor: "Cursor Settings"
         case .camera: "Camera & Facecam"

--- a/apps/macos/Sources/OpenRecorderMac/Models.swift
+++ b/apps/macos/Sources/OpenRecorderMac/Models.swift
@@ -282,6 +282,8 @@ struct ProjectEditorState: Codable, Equatable {
 }
 
 struct ProjectVideoEditorState: Codable, Equatable, Hashable {
+    var scene: SceneSettings = .identity
+    var canvasAspect: VideoPreviewAspectPreset = .auto
     var background: BackgroundStyle
     var padding: Double
     var borderRadius: Double
@@ -326,6 +328,7 @@ struct ProjectVideoEditorState: Codable, Equatable, Hashable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case scene, canvasAspect
         case background
         case padding
         case borderRadius
@@ -343,6 +346,8 @@ struct ProjectVideoEditorState: Codable, Equatable, Hashable {
     init(from decoder: Decoder) throws {
         let defaults = Self.default
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        scene = try container.decodeIfPresent(SceneSettings.self, forKey: .scene) ?? .identity
+        canvasAspect = try container.decodeIfPresent(VideoPreviewAspectPreset.self, forKey: .canvasAspect) ?? .auto
         background = try container.decodeIfPresent(BackgroundStyle.self, forKey: .background) ?? defaults.background
         padding = try container.decodeIfPresent(Double.self, forKey: .padding) ?? defaults.padding
         borderRadius = try container.decodeIfPresent(Double.self, forKey: .borderRadius) ?? defaults.borderRadius

--- a/apps/macos/Sources/OpenRecorderMac/SceneImageAnimationExporter.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SceneImageAnimationExporter.swift
@@ -1,0 +1,113 @@
+import AVFoundation
+import AppKit
+import CoreImage
+import ImageIO
+import UniformTypeIdentifiers
+
+@MainActor
+enum SceneImageAnimationExporter {
+    static func export(sourceURL: URL, targetURL: URL, state: ScreenshotEditorState,
+                       options: VideoExportOptions, cancellationToken: VideoExportCancellationToken?,
+                       progressHandler: @escaping @MainActor (Double) -> Void) async throws {
+        guard !ExportFileSafety.sameFile(sourceURL, targetURL) else { throw ExportFileSafety.Failure.originalFile }
+        guard let image = NSImage(contentsOf: sourceURL) else { throw VideoExportRendererError.exportFailed }
+        var configuration = ScreenshotExportConfiguration(screenshotState: state)
+        configuration.scene = state.scene.clamped(to: state.scene.imageDuration)
+        let renderer = SceneRenderer()
+        let context = SceneImageContext.shared
+        guard let first = ScreenshotExportRenderer(configuration: configuration).renderImage(from: image, renderer: renderer) else {
+            throw VideoExportRendererError.exportFailed
+        }
+        let size = VideoExportRenderer.resolvedOutputSize(for: CGSize(width: first.width, height: first.height), options: options)
+        let fps: Int = Int(options.frameRate.rawValue.replacingOccurrences(of: "fps", with: "")) ?? 30
+        let duration = sceneClamp(state.scene.imageDuration, 0.25...60, fallback: 3)
+        let count = max(1, Int(ceil(duration * Double(fps))))
+        if FileManager.default.fileExists(atPath: targetURL.path) { try FileManager.default.removeItem(at: targetURL) }
+        var completed = false
+        defer { if !completed { try? FileManager.default.removeItem(at: targetURL) } }
+
+        func checkCancellation() throws {
+            if Task.isCancelled || cancellationToken?.isCancelled == true { throw CancellationError() }
+        }
+        func frame(at index: Int) throws -> CGImage {
+            configuration.sceneTime = count > 1 ? Double(index) / Double(count - 1) * duration : 0
+            guard let cg = ScreenshotExportRenderer(configuration: configuration).renderImage(from: image, renderer: renderer) else {
+                throw VideoExportRendererError.exportFailed
+            }
+            let transform = CGAffineTransform(scaleX: size.width / CGFloat(cg.width), y: size.height / CGFloat(cg.height))
+            guard let output = context.createCGImage(CIImage(cgImage: cg).transformed(by: transform), from: CGRect(origin: .zero, size: size)) else {
+                throw VideoExportRendererError.exportFailed
+            }
+            return output
+        }
+
+        if options.format == .gif {
+            guard let destination = CGImageDestinationCreateWithURL(targetURL as CFURL, UTType.gif.identifier as CFString, count, nil) else {
+                throw VideoExportRendererError.gifDestinationUnavailable
+            }
+            if options.gifLoops {
+                CGImageDestinationSetProperties(destination, [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]] as CFDictionary)
+            }
+            for index in 0..<count {
+                try checkCancellation()
+                try autoreleasepool {
+                    CGImageDestinationAddImage(destination, try frame(at: index), [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: 1 / Double(fps)]] as CFDictionary)
+                }
+                progressHandler(Double(index + 1) / Double(count))
+                await Task.yield()
+            }
+            try checkCancellation()
+            guard CGImageDestinationFinalize(destination) else { throw VideoExportRendererError.gifDestinationUnavailable }
+        } else {
+            guard let fileType = options.format.avFileType else { throw VideoExportRendererError.unsupportedFormat }
+            let writer = try AVAssetWriter(outputURL: targetURL, fileType: fileType)
+            let bitsPerPixel: Double = options.quality == .low ? 0.04 : (options.quality == .medium ? 0.08 : 0.16)
+            let bitRate = max(250_000, Int(size.width * size.height * Double(fps) * bitsPerPixel))
+            let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264, AVVideoWidthKey: Int(size.width), AVVideoHeightKey: Int(size.height),
+                AVVideoCompressionPropertiesKey: [AVVideoAverageBitRateKey: bitRate]
+            ])
+            let adaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: input, sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                kCVPixelBufferWidthKey as String: Int(size.width), kCVPixelBufferHeightKey as String: Int(size.height),
+                kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+            ])
+            guard writer.canAdd(input) else { throw VideoExportRendererError.exportFailed }
+            writer.add(input)
+            guard writer.startWriting() else { throw writer.error ?? VideoExportRendererError.exportFailed }
+            writer.startSession(atSourceTime: .zero)
+            do {
+                for index in 0..<count {
+                    try checkCancellation()
+                    while !input.isReadyForMoreMediaData {
+                        try checkCancellation()
+                        guard writer.status == .writing else { throw writer.error ?? VideoExportRendererError.exportFailed }
+                        try await Task.sleep(for: .milliseconds(2))
+                    }
+                    try autoreleasepool {
+                        guard let pool = adaptor.pixelBufferPool else { throw VideoExportRendererError.exportFailed }
+                        var pixelBuffer: CVPixelBuffer?
+                        guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer) == kCVReturnSuccess, let pixelBuffer else {
+                            throw VideoExportRendererError.exportFailed
+                        }
+                        let rendered = CIImage(cgImage: try frame(at: index))
+                        let opaque = rendered.composited(over: CIImage(color: .black).cropped(to: CGRect(origin: .zero, size: size)))
+                        context.render(opaque, to: pixelBuffer, bounds: CGRect(origin: .zero, size: size), colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!)
+                        guard adaptor.append(pixelBuffer, withPresentationTime: CMTime(value: Int64(index), timescale: Int32(fps))) else {
+                            throw writer.error ?? VideoExportRendererError.exportFailed
+                        }
+                    }
+                    progressHandler(Double(index + 1) / Double(count))
+                    await Task.yield()
+                }
+                input.markAsFinished()
+                writer.endSession(atSourceTime: CMTime(seconds: duration, preferredTimescale: 600))
+                await writer.finishWriting()
+                try checkCancellation()
+                guard writer.status == .completed else { throw writer.error ?? VideoExportRendererError.exportFailed }
+            } catch { writer.cancelWriting(); throw error }
+        }
+        completed = true
+        progressHandler(1)
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/SceneInspector.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SceneInspector.swift
@@ -1,0 +1,236 @@
+import AppKit
+import SwiftUI
+
+enum SceneEndpoint: String, CaseIterable { case start = "Start", end = "End" }
+enum SceneTool: String, CaseIterable { case tilt = "Tilt", move = "Move" }
+
+struct SceneInspector: View {
+    @Binding var settings: SceneSettings
+    @Binding var endpoint: SceneEndpoint
+    var duration: Double
+    var isImage = false
+    var seek: (Double) -> Void = { _ in }
+    var onEditingChanged: (Bool) -> Void = { _ in }
+    @State private var advanced = false
+
+    private var pose: Binding<ScenePose> {
+        scenePoseBinding(settings: $settings, endpoint: endpoint)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 7) {
+                Text("Scene").font(.headline)
+                Text("Alpha")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.fgMuted)
+                    .padding(.horizontal, 6).padding(.vertical, 3)
+                    .background(Theme.overlay, in: Capsule())
+                    .accessibilityLabel("Scene is in alpha")
+                Spacer()
+                Button("Reset Scene") { settings = .identity; seek(0) }
+                    .font(.system(size: 10)).buttonStyle(.plain)
+            }.padding(.bottom, 8)
+            Text("Tilt your media and frame. Your background stays upright.")
+                .font(.system(size: 11)).foregroundStyle(Theme.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+
+            InspectorGroup(title: "Presets", symbolName: "square.grid.2x2", showsTopDivider: false) {
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
+                    ForEach(ScenePosePreset.allCases) { preset in
+                        Button { pose.wrappedValue = preset.pose } label: {
+                            VStack(spacing: 6) {
+                                Image(systemName: "rectangle.portrait.on.rectangle.portrait")
+                                    .rotationEffect(.degrees(preset.pose.rotation))
+                                Text(preset.rawValue).font(.system(size: 10))
+                            }.frame(maxWidth: .infinity).padding(.vertical, 10)
+                        }.buttonStyle(.bordered)
+                    }
+                }
+            }
+            InspectorGroup(title: "Transform", symbolName: "rotate.3d", onReset: { pose.wrappedValue = .identity }) {
+                if settings.motion.enabled {
+                    Picker("Edit pose", selection: $endpoint) {
+                        ForEach(SceneEndpoint.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                    }.pickerStyle(.segmented)
+                    .onChange(of: endpoint) { _, value in
+                        seek(value == .start ? settings.motion.startTime : settings.motion.endTime)
+                    }
+                }
+                poseSlider("Horizontal Tilt", keyPath: \.tiltY, range: -60...60, step: 1, suffix: "°")
+                poseSlider("Vertical Tilt", keyPath: \.tiltX, range: -60...60, step: 1, suffix: "°")
+                poseSlider("Rotation", keyPath: \.rotation, range: -180...180, step: 1, suffix: "°")
+                poseSlider("Scale", keyPath: \.scale, range: 0.25...2, step: 0.01, suffix: "×")
+                poseSlider("Position X", keyPath: \.x, range: -1...1, step: 0.01)
+                poseSlider("Position Y", keyPath: \.y, range: -1...1, step: 0.01)
+                DisclosureGroup("Advanced", isExpanded: $advanced) {
+                    poseSlider("Perspective", keyPath: \.perspective, range: 0...1, step: 0.01)
+                }.font(.system(size: 11))
+            }
+            InspectorGroup(title: "Mockup", symbolName: "macwindow", onReset: {
+                settings.mockup = .none; settings.edgeHighlight = false; settings.darkMockup = true
+            }) {
+                Picker("Frame", selection: $settings.mockup) {
+                    ForEach(MockupStyle.allCases) { Text($0.rawValue).tag($0) }
+                }
+                if settings.mockup != .none {
+                    Picker("Style", selection: $settings.darkMockup) {
+                        Text("Light").tag(false); Text("Dark").tag(true)
+                    }.pickerStyle(.segmented)
+                }
+                Toggle("Edge highlight", isOn: $settings.edgeHighlight).toggleStyle(.switch).controlSize(.small)
+            }
+            InspectorGroup(title: "Motion", symbolName: "play.rectangle", onReset: {
+                settings.motion = SceneMotion().clamped(to: duration); seek(0)
+            }) {
+                Toggle("Animate", isOn: Binding(get: { settings.motion.enabled }, set: { enabled in
+                    var next = settings
+                    next.motion.enabled = enabled
+                    next.motion = next.motion.clamped(to: duration)
+                    settings = next
+                    if enabled { endpoint = .start; seek(next.motion.startTime) }
+                })).toggleStyle(.switch).controlSize(.small)
+                if settings.motion.enabled {
+                    Menu("Motion preset") {
+                        ForEach(SceneMotionPreset.allCases) { preset in
+                            Button(preset.rawValue) {
+                                var next = settings
+                                (next.motion.startPose, next.motion.endPose) = preset.poses
+                                settings = next
+                                endpoint = .start; seek(next.motion.startTime)
+                            }
+                        }
+                    }.menuStyle(.borderlessButton)
+                    if isImage {
+                        InspectorSlider(title: "Duration", valueText: String(format: "%.2fs", settings.imageDuration),
+                            value: $settings.imageDuration, range: 0.25...60, step: 0.25, onEditingChanged: onEditingChanged)
+                    }
+                    SceneRangeControl(motion: $settings.motion, duration: duration, onEditingChanged: onEditingChanged)
+                    timeSlider("Start", start: true)
+                    timeSlider("End", start: false)
+                    Picker("Easing", selection: $settings.motion.easing) {
+                        ForEach(SceneEasing.allCases) { Text($0.rawValue).tag($0) }
+                    }
+                    Text("One movement; holds its pose before and after.")
+                        .font(.system(size: 10)).foregroundStyle(Theme.fgMuted)
+                }
+            }
+        }
+        .controlSize(.small)
+        .foregroundStyle(Theme.fg)
+    }
+
+    private func poseSlider(_ title: String, keyPath: WritableKeyPath<ScenePose, Double>, range: ClosedRange<Double>, step: Double, suffix: String = "") -> some View {
+        InspectorSlider(title: title, valueText: String(format: step >= 1 ? "%.0f%@" : "%.2f%@", pose.wrappedValue[keyPath: keyPath], suffix),
+            value: Binding(get: { pose.wrappedValue[keyPath: keyPath] }, set: { pose.wrappedValue[keyPath: keyPath] = $0 }),
+            range: range, step: step, onEditingChanged: onEditingChanged)
+    }
+
+    private func timeSlider(_ title: String, start: Bool) -> some View {
+        let binding = Binding<Double>(get: { start ? settings.motion.startTime : settings.motion.endTime }, set: { value in
+            var next = settings.motion
+            if start { next.startTime = min(value, max(0, next.endTime - 0.05)) }
+            else { next.endTime = max(value, next.startTime + 0.05) }
+            settings.motion = next.clamped(to: duration)
+        })
+        return InspectorSlider(title: title, valueText: String(format: "%.2fs", binding.wrappedValue),
+            value: binding, range: 0...max(0.05, duration), step: 0.05, onEditingChanged: onEditingChanged)
+    }
+}
+
+func scenePoseBinding(settings: Binding<SceneSettings>, endpoint: SceneEndpoint) -> Binding<ScenePose> {
+    Binding(get: {
+        let s = settings.wrappedValue
+        return s.motion.enabled ? (endpoint == .start ? s.motion.startPose : s.motion.endPose) : s.pose
+    }, set: { value in
+        var s = settings.wrappedValue
+        if s.motion.enabled {
+            if endpoint == .start { s.motion.startPose = value.clamped } else { s.motion.endPose = value.clamped }
+        } else { s.pose = value.clamped }
+        settings.wrappedValue = s
+    })
+}
+
+private struct SceneRangeControl: View {
+    @Binding var motion: SceneMotion
+    var duration: Double
+    var onEditingChanged: (Bool) -> Void
+    @State private var dragging = false
+    var body: some View {
+        GeometryReader { proxy in
+            let width = max(1, proxy.size.width - 12), total = max(0.05, duration)
+            ZStack(alignment: .leading) {
+                Capsule().fill(Theme.overlay)
+                Capsule().fill(Theme.accent.opacity(0.6))
+                    .frame(width: max(3, width * (motion.endTime - motion.startTime) / total))
+                    .offset(x: 6 + width * motion.startTime / total)
+                handle(start: true, width: width, total: total)
+                handle(start: false, width: width, total: total)
+            }.frame(height: 18)
+        }.frame(height: 20).coordinateSpace(name: "sceneRange")
+    }
+    private func handle(start: Bool, width: CGFloat, total: Double) -> some View {
+        Capsule().fill(.white).frame(width: 10, height: 20)
+            .offset(x: 1 + width * (start ? motion.startTime : motion.endTime) / total)
+            .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .named("sceneRange")).onChanged { event in
+                if !dragging { dragging = true; onEditingChanged(true) }
+                let t = (event.location.x - 6) / width * total
+                var next = motion
+                if start { next.startTime = min(max(0, t), max(0, next.endTime - 0.05)) }
+                else { next.endTime = max(t, next.startTime + 0.05) }
+                motion = next.clamped(to: duration)
+            }.onEnded { _ in dragging = false; onEditingChanged(false) })
+            .accessibilityHidden(true)
+    }
+}
+
+struct SceneCanvasTools: View {
+    @Binding var tool: SceneTool
+    var body: some View {
+        HStack(spacing: 10) {
+            Picker("Scene tool", selection: $tool) {
+                ForEach(SceneTool.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+            }.pickerStyle(.segmented).frame(width: 140)
+            Text("Drag to \(tool.rawValue.lowercased()) · ⇧ for precision")
+                .font(.system(size: 10)).foregroundStyle(Theme.fgMuted)
+        }.padding(.vertical, 6)
+    }
+}
+
+struct SceneCanvasGesture: ViewModifier {
+    var enabled: Bool
+    var tool: SceneTool
+    @Binding var pose: ScenePose
+    var onEditingChanged: (Bool) -> Void
+    @State private var original: ScenePose?
+
+    func body(content: Content) -> some View {
+        content.overlay {
+            if enabled {
+                GeometryReader { proxy in
+                    Color.clear.contentShape(Rectangle())
+                        .gesture(DragGesture(minimumDistance: 2).onChanged { event in
+                            if original == nil { original = pose; onEditingChanged(true) }
+                            guard var next = original else { return }
+                            let precision = NSEvent.modifierFlags.contains(.shift) ? 0.2 : 1.0
+                            let dx = event.translation.width / max(1, proxy.size.width) * precision
+                            let dy = event.translation.height / max(1, proxy.size.height) * precision
+                            if tool == .tilt { next.tiltY += dx * 120; next.tiltX += dy * 120 }
+                            else { next.x += dx; next.y += dy }
+                            pose = next.clamped
+                        }.onEnded { _ in original = nil; onEditingChanged(false) })
+                }
+            }
+        }
+        .onDisappear { if original != nil { original = nil; onEditingChanged(false) } }
+    }
+}
+
+struct CanvasAspectPicker: View {
+    @Binding var selection: VideoPreviewAspectPreset
+    var body: some View {
+        Picker("Canvas", selection: $selection) {
+            ForEach(VideoPreviewAspectPreset.allCases) { Text($0.title).tag($0) }
+        }.controlSize(.small)
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/SceneRenderer.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SceneRenderer.swift
@@ -1,0 +1,122 @@
+import CoreImage
+import CoreGraphics
+
+struct SceneMockupLayout {
+    var frame: CGRect
+    var content: CGRect
+    var radius: CGFloat
+
+    static func make(in rect: CGRect, mediaAspect: CGFloat, style: MockupStyle, radius: CGFloat) -> Self {
+        guard style != .none else { return Self(frame: rect, content: rect, radius: radius) }
+        let aspect: CGFloat
+        switch style {
+        case .phone: aspect = 0.5
+        case .tablet: aspect = 0.75
+        default: aspect = mediaAspect
+        }
+        let size = CGSize(width: min(rect.width, rect.height * aspect), height: min(rect.height, rect.width / aspect))
+        let frame = CGRect(x: rect.midX - size.width / 2, y: rect.midY - size.height / 2, width: size.width, height: size.height)
+        let edge = min(size.width, size.height) * (style == .phone || style == .tablet ? 0.045 : 0.015)
+        let top = style == .browser || style == .window ? min(size.width, size.height) * 0.085 : edge
+        let inner = CGRect(x: frame.minX + edge, y: frame.minY + edge,
+                           width: max(1, frame.width - 2 * edge), height: max(1, frame.height - edge - top))
+        let fit = CGSize(width: min(inner.width, inner.height * mediaAspect), height: min(inner.height, inner.width / mediaAspect))
+        let content = CGRect(x: inner.midX - fit.width / 2, y: inner.midY - fit.height / 2, width: fit.width, height: fit.height)
+        return Self(frame: frame, content: content, radius: min(size.width, size.height) * (style == .phone || style == .tablet ? 0.1 : 0.025))
+    }
+}
+
+/// Owned by one rendering queue. Caches are bounded to the current frame style and size.
+final class SceneRenderer {
+    private struct ArtworkKey: Equatable {
+        var frame: CGRect
+        var style: MockupStyle
+        var dark: Bool
+        var highlight: Bool
+        var radius: CGFloat
+    }
+    private var artworkCache: (ArtworkKey, CIImage)?
+    private var maskCache: (CGRect, CGFloat, CIImage)?
+
+    static func roundedMask(in rect: CGRect, radius: CGFloat) -> CIImage {
+        let filter = CIFilter(name: "CIRoundedRectangleGenerator", parameters: [
+            "inputExtent": CIVector(cgRect: rect), "inputRadius": max(0, radius), "inputColor": CIColor.white
+        ])!
+        return filter.outputImage!.cropped(to: rect)
+    }
+
+    func mask(_ image: CIImage, in rect: CGRect, radius: CGFloat) -> CIImage {
+        let shape: CIImage
+        if let cache = maskCache, cache.0 == rect, cache.1 == radius { shape = cache.2 }
+        else {
+            shape = Self.roundedMask(in: rect, radius: radius)
+            maskCache = (rect, radius, shape)
+        }
+        return image.applyingFilter("CIBlendWithAlphaMask", parameters: [
+            kCIInputBackgroundImageKey: CIImage.empty(), kCIInputMaskImageKey: shape
+        ]).cropped(to: rect)
+    }
+
+    func render(media: CIImage, mediaRect: CGRect, frame: CGRect, canvas: CGSize,
+                settings: SceneSettings, time: Double, radius: CGFloat, shadow: Double) -> CIImage {
+        let layout = SceneMockupLayout.make(in: frame, mediaAspect: mediaRect.width / max(1, mediaRect.height), style: settings.mockup, radius: radius)
+        let sx = layout.content.width / max(1, mediaRect.width), sy = layout.content.height / max(1, mediaRect.height)
+        let fitted = media.cropped(to: mediaRect)
+            .transformed(by: CGAffineTransform(translationX: -mediaRect.minX, y: -mediaRect.minY))
+            .transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+            .transformed(by: CGAffineTransform(translationX: layout.content.minX, y: layout.content.minY))
+        var card = mask(fitted, in: layout.content, radius: settings.mockup == .none ? radius : min(radius, layout.radius / 2))
+        let artwork = frameArtwork(layout: layout, settings: settings)
+        card = card.composited(over: artwork).cropped(to: layout.frame)
+        if settings.edgeHighlight {
+            card = edgeStroke(in: layout.frame, radius: layout.radius).composited(over: card)
+        }
+        let geometry = SceneGeometry.evaluate(frame: layout.frame, canvas: canvas, pose: settings.pose(at: time))
+        let projected = card.applyingFilter("CIPerspectiveTransform", parameters: [
+            "inputTopLeft": CIVector(cgPoint: geometry.topLeft), "inputTopRight": CIVector(cgPoint: geometry.topRight),
+            "inputBottomLeft": CIVector(cgPoint: geometry.bottomLeft), "inputBottomRight": CIVector(cgPoint: geometry.bottomRight)
+        ])
+        guard shadow > 0 else { return projected }
+        let amount = sceneClamp(shadow, 0...1)
+        let unit = min(canvas.width, canvas.height) / 1080
+        let drop = projected.applyingFilter("CIColorMatrix", parameters: [
+            "inputRVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+            "inputGVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+            "inputBVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+            "inputAVector": CIVector(x: 0, y: 0, z: 0, w: amount * 0.55)
+        ]).applyingFilter("CIGaussianBlur", parameters: [kCIInputRadiusKey: 38 * amount * unit])
+            .transformed(by: CGAffineTransform(translationX: 0, y: -18 * amount * unit))
+        return projected.composited(over: drop)
+    }
+
+    private func frameArtwork(layout: SceneMockupLayout, settings: SceneSettings) -> CIImage {
+        let key = ArtworkKey(frame: layout.frame, style: settings.mockup, dark: settings.darkMockup,
+                             highlight: settings.edgeHighlight, radius: layout.radius)
+        if let cache = artworkCache, cache.0 == key { return cache.1 }
+        let rect = layout.frame
+        let gray: CGFloat = settings.darkMockup ? 0.12 : 0.92
+        var image = settings.mockup == .none ? CIImage.empty() : CIImage(color: CIColor(red: gray, green: gray, blue: gray)).cropped(to: rect)
+        if settings.mockup == .browser || settings.mockup == .window {
+            let r = min(rect.width, rect.height) * 0.009
+            for (index, color) in [CIColor(red: 1, green: 0.36, blue: 0.32), CIColor(red: 1, green: 0.75, blue: 0.2), CIColor(red: 0.22, green: 0.78, blue: 0.35)].enumerated() {
+                let dot = CGRect(x: rect.minX + r * (3 + CGFloat(index) * 3), y: rect.maxY - r * 5, width: r * 2, height: r * 2)
+                image = CIImage(color: color).cropped(to: dot).applyingFilter("CIBlendWithAlphaMask", parameters: [
+                    kCIInputBackgroundImageKey: CIImage.empty(), kCIInputMaskImageKey: Self.roundedMask(in: dot, radius: r)
+                ]).composited(over: image)
+            }
+        }
+        image = image.applyingFilter("CIBlendWithAlphaMask", parameters: [
+            kCIInputBackgroundImageKey: CIImage.empty(), kCIInputMaskImageKey: Self.roundedMask(in: rect, radius: layout.radius)
+        ])
+        artworkCache = (key, image)
+        return image
+    }
+
+    private func edgeStroke(in rect: CGRect, radius: CGFloat) -> CIImage {
+        let outer = Self.roundedMask(in: rect, radius: radius)
+        let edge = max(1, min(rect.width, rect.height) / 400)
+        let inner = Self.roundedMask(in: rect.insetBy(dx: edge, dy: edge), radius: max(0, radius - edge))
+        return outer.applyingFilter("CISourceOutCompositing", parameters: [kCIInputBackgroundImageKey: inner])
+            .applyingFilter("CIColorMatrix", parameters: ["inputAVector": CIVector(x: 0, y: 0, z: 0, w: 0.35)])
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/SceneScreenshotPreview.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SceneScreenshotPreview.swift
@@ -1,0 +1,36 @@
+import AppKit
+import CoreImage
+import SwiftUI
+
+struct SceneScreenshotPreview: View {
+    var image: NSImage?
+    var state: ScreenshotEditorState
+    var time: Double
+    @State private var rendered: CGImage?
+    @State private var renderer = SceneRenderer()
+
+    private struct RenderKey: Equatable {
+        var state: ScreenshotEditorState
+        var time: Double
+        var image: ObjectIdentifier?
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                if let rendered {
+                    Image(decorative: rendered, scale: 1).resizable().interpolation(.high).scaledToFit()
+                } else if image == nil { EmptyEditorState() }
+                else { Text("Scene preview unavailable. Reset Scene to use the standard preview.").font(.callout).foregroundStyle(Theme.fgMuted).padding(20) }
+            }.frame(width: proxy.size.width, height: proxy.size.height)
+        }
+        .padding(32)
+        .task(id: RenderKey(state: state, time: time, image: image.map(ObjectIdentifier.init))) {
+            guard let image else { rendered = nil; return }
+            var configuration = ScreenshotExportConfiguration(screenshotState: state)
+            configuration.sceneTime = time
+            rendered = ScreenshotExportRenderer(configuration: configuration).renderImage(from: image, maxDimension: 1600, renderer: renderer)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/SceneSettings.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SceneSettings.swift
@@ -1,0 +1,163 @@
+import CoreGraphics
+import Foundation
+
+struct ScenePose: Codable, Equatable, Hashable {
+    var tiltX = 0.0
+    var tiltY = 0.0
+    var rotation = 0.0
+    var scale = 1.0
+    var x = 0.0
+    var y = 0.0
+    var perspective = 0.5
+
+    static let identity = ScenePose()
+
+    var clamped: Self {
+        Self(tiltX: sceneClamp(tiltX, -60...60), tiltY: sceneClamp(tiltY, -60...60),
+             rotation: sceneClamp(rotation, -180...180), scale: sceneClamp(scale, 0.25...2, fallback: 1),
+             x: sceneClamp(x, -1...1), y: sceneClamp(y, -1...1),
+             perspective: sceneClamp(perspective, 0...1, fallback: 0.5))
+    }
+
+    var isIdentity: Bool {
+        let p = clamped
+        return p.tiltX == 0 && p.tiltY == 0 && p.rotation == 0 && p.scale == 1 && p.x == 0 && p.y == 0
+    }
+
+    static func interpolate(_ start: Self, _ end: Self, progress: Double) -> Self {
+        let a = start.clamped, b = end.clamped, t = sceneClamp(progress, 0...1)
+        func mix(_ x: Double, _ y: Double) -> Double { x + (y - x) * t }
+        return Self(tiltX: mix(a.tiltX, b.tiltX), tiltY: mix(a.tiltY, b.tiltY),
+                    rotation: mix(a.rotation, b.rotation), scale: mix(a.scale, b.scale),
+                    x: mix(a.x, b.x), y: mix(a.y, b.y), perspective: mix(a.perspective, b.perspective))
+    }
+}
+
+enum ScenePosePreset: String, CaseIterable, Identifiable {
+    case flat = "Flat", left = "Tilt Left", right = "Tilt Right", elevated = "Elevated"
+    var id: String { rawValue }
+    var pose: ScenePose {
+        switch self {
+        case .flat: .identity
+        case .left: ScenePose(tiltX: 8, tiltY: -24, rotation: -4, scale: 0.85)
+        case .right: ScenePose(tiltX: 8, tiltY: 24, rotation: 4, scale: 0.85)
+        case .elevated: ScenePose(tiltX: 28, tiltY: -12, rotation: -6, scale: 0.85)
+        }
+    }
+}
+
+enum MockupStyle: String, Codable, CaseIterable, Identifiable {
+    case none = "None", browser = "Browser", window = "Desktop Window", phone = "Phone", tablet = "Tablet"
+    var id: String { rawValue }
+}
+
+enum SceneEasing: String, Codable, CaseIterable, Identifiable {
+    case linear = "Linear", easeIn = "Ease In", easeOut = "Ease Out", easeInOut = "Ease In Out"
+    var id: String { rawValue }
+    func evaluate(_ progress: Double) -> Double {
+        let t = sceneClamp(progress, 0...1)
+        switch self {
+        case .linear: return t
+        case .easeIn: return t * t
+        case .easeOut: return 1 - (1 - t) * (1 - t)
+        case .easeInOut: return t * t * (3 - 2 * t)
+        }
+    }
+}
+
+enum SceneMotionPreset: String, CaseIterable, Identifiable {
+    case pushIn = "Push In", pullOut = "Pull Out", tiltReveal = "Tilt Reveal", sideSweep = "Side Sweep"
+    var id: String { rawValue }
+    var poses: (ScenePose, ScenePose) {
+        switch self {
+        case .pushIn: (ScenePose(scale: 0.75), ScenePose(scale: 1))
+        case .pullOut: (ScenePose(scale: 1), ScenePose(scale: 0.75))
+        case .tiltReveal: (ScenePosePreset.left.pose, ScenePose(scale: 0.95))
+        case .sideSweep: (ScenePose(tiltY: -20, scale: 0.8, x: -0.12), ScenePose(tiltY: 20, scale: 0.8, x: 0.12))
+        }
+    }
+}
+
+struct SceneMotion: Codable, Equatable, Hashable {
+    var enabled = false
+    var startTime = 0.0
+    var endTime = 3.0
+    var startPose = ScenePose(scale: 0.8)
+    var endPose = ScenePose.identity
+    var easing = SceneEasing.easeInOut
+
+    func clamped(to duration: Double) -> Self {
+        var next = self
+        let duration = sceneClamp(duration, 0...86400)
+        let minimum = min(0.05, duration)
+        next.startTime = sceneClamp(startTime, 0...max(0, duration - minimum))
+        next.endTime = sceneClamp(endTime, (next.startTime + minimum)...duration, fallback: duration)
+        next.startPose = startPose.clamped
+        next.endPose = endPose.clamped
+        return next
+    }
+
+    func pose(at time: Double) -> ScenePose {
+        let progress = (time - startTime) / max(0.001, endTime - startTime)
+        return .interpolate(startPose, endPose, progress: easing.evaluate(progress))
+    }
+}
+
+struct SceneSettings: Codable, Equatable, Hashable {
+    var pose = ScenePose.identity
+    var mockup = MockupStyle.none
+    var darkMockup = true
+    var edgeHighlight = false
+    var motion = SceneMotion()
+    var imageDuration = 3.0
+
+    static let identity = SceneSettings()
+    var isActive: Bool { !pose.isIdentity || mockup != .none || edgeHighlight || motion.enabled }
+    func pose(at time: Double) -> ScenePose { motion.enabled ? motion.pose(at: time) : pose.clamped }
+    func clamped(to duration: Double) -> Self {
+        var next = self
+        next.pose = pose.clamped
+        next.imageDuration = sceneClamp(imageDuration, 0.25...60, fallback: 3)
+        next.motion = motion.clamped(to: duration)
+        return next
+    }
+    /// A still snapshot retains the displayed animated pose without changing editor state.
+    func still(at time: Double) -> Self {
+        var next = self
+        next.pose = pose(at: time)
+        next.motion.enabled = false
+        return next
+    }
+}
+
+func sceneClamp(_ value: Double, _ range: ClosedRange<Double>, fallback: Double = 0) -> Double {
+    min(range.upperBound, max(range.lowerBound, value.isFinite ? value : fallback))
+}
+
+/// Canonical geometry uses bottom-left image coordinates; position Y is positive downward in the UI.
+struct SceneGeometry {
+    var topLeft: CGPoint
+    var topRight: CGPoint
+    var bottomLeft: CGPoint
+    var bottomRight: CGPoint
+    var bounds: CGRect
+
+    static func evaluate(frame: CGRect, canvas: CGSize, pose: ScenePose) -> Self {
+        let p = pose.clamped
+        let rx = p.tiltX * .pi / 180, ry = p.tiltY * .pi / 180, rz = p.rotation * .pi / 180
+        let distance = max(frame.width, frame.height) * (4 - 2.5 * p.perspective)
+        func project(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+            let xx = x * cos(ry) + y * sin(rx) * sin(ry)
+            let yy = y * cos(rx)
+            let z = -x * sin(ry) + y * sin(rx) * cos(ry)
+            let factor = distance / max(distance * 0.1, distance - z)
+            return CGPoint(x: frame.midX + (xx * cos(rz) - yy * sin(rz)) * factor * p.scale + p.x * canvas.width,
+                           y: frame.midY + (xx * sin(rz) + yy * cos(rz)) * factor * p.scale - p.y * canvas.height)
+        }
+        let tl = project(-frame.width / 2, frame.height / 2), tr = project(frame.width / 2, frame.height / 2)
+        let bl = project(-frame.width / 2, -frame.height / 2), br = project(frame.width / 2, -frame.height / 2)
+        let xs = [tl.x, tr.x, bl.x, br.x], ys = [tl.y, tr.y, bl.y, br.y]
+        return Self(topLeft: tl, topRight: tr, bottomLeft: bl, bottomRight: br,
+                    bounds: CGRect(x: xs.min()!, y: ys.min()!, width: xs.max()! - xs.min()!, height: ys.max()! - ys.min()!))
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/SceneVideoPreview.swift
+++ b/apps/macos/Sources/OpenRecorderMac/SceneVideoPreview.swift
@@ -1,0 +1,182 @@
+import AVFoundation
+import CoreImage
+import MetalKit
+import SwiftUI
+
+/// Uses the same compositor as export, with the existing player's clock and decoded frames.
+struct SceneVideoPreview: NSViewRepresentable {
+    var player: AVPlayer?
+    var sourceSize: CGSize
+    var cropSelection: VideoCropSelection
+    var settings: SceneSettings
+    var styling: VideoBackgroundStyling
+    var edits: TimelineEditSnapshot
+    var duration: Double
+    var cursorTrack: CursorTelemetryTrack?
+    var cursorSettings: CursorOverlaySettings
+    var cameraSettings: FacecamSettings?
+    var onPreviewStatus: (String?) -> Void = { _ in }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> MTKView {
+        let view = MTKView(frame: .zero, device: MTLCreateSystemDefaultDevice())
+        view.framebufferOnly = false
+        view.colorPixelFormat = .bgra8Unorm
+        view.clearColor = MTLClearColorMake(0, 0, 0, 0)
+        view.isPaused = true
+        view.enableSetNeedsDisplay = true
+        view.delegate = context.coordinator
+        context.coordinator.view = view
+        context.coordinator.start()
+        return view
+    }
+
+    func updateNSView(_ view: MTKView, context: Context) {
+        context.coordinator.update(self)
+    }
+
+    static func dismantleNSView(_ view: MTKView, coordinator: Coordinator) {
+        coordinator.stop()
+        view.delegate = nil
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, MTKViewDelegate {
+        weak var view: MTKView?
+        private var configuration: SceneVideoPreview?
+        private var item: AVPlayerItem?
+        private var output: AVPlayerItemVideoOutput?
+        private var timer: Timer?
+        private var metadataTask: Task<Void, Never>?
+        private var frame: CVPixelBuffer?
+        private var frameTime = 0.0
+        private var transform = CGAffineTransform.identity
+        private var metadataReady = false
+        private var status: String?
+        private var dirty = true
+        private let compositor = VideoBackgroundCompositor()
+        private var context: CIContext?
+        private var commandQueue: MTLCommandQueue?
+
+        func start() {
+            if let device = view?.device {
+                context = CIContext(mtlDevice: device, options: [.cacheIntermediates: false])
+                commandQueue = device.makeCommandQueue()
+            }
+            timer = Timer.scheduledTimer(withTimeInterval: 1 / 60, repeats: true) { [weak self] _ in
+                MainActor.assumeIsolated { self?.tick() }
+            }
+            if let timer { RunLoop.main.add(timer, forMode: .common) }
+        }
+
+        func stop() {
+            timer?.invalidate(); timer = nil
+            metadataTask?.cancel(); metadataTask = nil
+            if let output { item?.remove(output) }
+            item = nil; output = nil; frame = nil
+        }
+
+        func update(_ next: SceneVideoPreview) {
+            configuration = next
+            guard view?.device != nil else {
+                report("Scene preview needs Metal. Reset Scene to use the standard preview.")
+                return
+            }
+            dirty = true
+            guard item !== next.player?.currentItem else { tick(); return }
+            if let output { item?.remove(output) }
+            item = next.player?.currentItem
+            frame = nil
+            metadataReady = false
+            transform = .identity
+            let newOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                kCVPixelBufferMetalCompatibilityKey as String: true
+            ])
+            output = newOutput
+            item?.add(newOutput)
+            metadataTask?.cancel()
+            let expected = item
+            metadataTask = Task { [weak self] in
+                guard let expected else { return }
+                do {
+                    guard let track = try await expected.asset.loadTracks(withMediaType: .video).first else { throw VideoExportRendererError.missingVideoTrack }
+                    let preferred = try await track.load(.preferredTransform)
+                    let size = try await track.load(.naturalSize)
+                    guard !Task.isCancelled, let self, self.item === expected else { return }
+                    let natural = CGRect(origin: .zero, size: size).applying(preferred)
+                    self.transform = preferred.concatenating(CGAffineTransform(translationX: -natural.minX, y: -natural.minY))
+                    self.metadataReady = true
+                    self.dirty = true
+                    self.tick()
+                } catch {
+                    guard !Task.isCancelled, let self, self.item === expected else { return }
+                    self.report("Scene preview could not load this video. Reset Scene to use the standard preview.")
+                }
+            }
+            tick()
+        }
+
+        private func tick() {
+            guard let configuration, let output, let player = configuration.player else { return }
+            let time = player.currentTime()
+            if output.hasNewPixelBuffer(forItemTime: time) {
+                var displayTime = CMTime.zero
+                if let next = output.copyPixelBuffer(forItemTime: time, itemTimeForDisplay: &displayTime) {
+                    frame = next
+                    frameTime = displayTime.isNumeric ? displayTime.seconds : time.seconds
+                    dirty = true
+                }
+            }
+            guard dirty, frame != nil else { return }
+            view?.needsDisplay = true
+        }
+
+        func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) { dirty = true }
+
+        func draw(in view: MTKView) {
+            guard dirty, metadataReady, let configuration, let frame, let drawable = view.currentDrawable,
+                  let context, let buffer = commandQueue?.makeCommandBuffer() else { return }
+            let canvas = CGSize(width: drawable.texture.width, height: drawable.texture.height)
+            guard canvas.width > 0, canvas.height > 0, configuration.sourceSize.width > 0 else { return }
+            let plan = TimelineExportEditPlan.build(duration: configuration.duration, edits: configuration.edits)
+            let time = plan.outputTime(forSourceTime: frameTime) ?? 0
+            let instruction = VideoBackgroundCompositionInstruction(
+                timeRange: CMTimeRange(start: .zero, duration: CMTime(seconds: plan.outputDuration, preferredTimescale: 600)),
+                trackID: 1, styling: configuration.styling, scene: configuration.settings,
+                preferredTransform: transform, normalizedSize: configuration.sourceSize,
+                cropRect: configuration.cropSelection.pixelRect(in: configuration.sourceSize),
+                renderSize: canvas, edits: configuration.edits, editPlan: plan,
+                cursorTrack: configuration.cursorTrack, cursorSettings: configuration.cursorSettings,
+                facecamFallbackSettings: configuration.cameraSettings)
+            do {
+                let image = try compositor.makeComposedImage(source: frame, facecam: nil, instruction: instruction, compositionTime: time)
+                SceneMetalDisplay.render(image, context: context, texture: drawable.texture, commandBuffer: buffer)
+                buffer.present(drawable)
+                buffer.commit()
+                dirty = false
+                report(nil)
+            } catch {
+                report("Scene preview could not render this frame. Reset Scene to use the standard preview.")
+            }
+        }
+
+        private func report(_ message: String?) {
+            guard status != message else { return }
+            status = message
+            let callback = configuration?.onPreviewStatus
+            Task { @MainActor in callback?(message) }
+        }
+    }
+}
+
+enum SceneMetalDisplay {
+    /// Drawable textures scan from the top left; Core Image geometry uses the bottom left.
+    static func render(_ image: CIImage, context: CIContext, texture: MTLTexture, commandBuffer: MTLCommandBuffer) {
+        let bounds = CGRect(x: 0, y: 0, width: texture.width, height: texture.height)
+        let displayed = image.transformed(by: CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: bounds.height))
+        context.render(displayed, to: texture, commandBuffer: commandBuffer, bounds: bounds,
+                       colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!)
+    }
+}

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorState.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorState.swift
@@ -4,6 +4,8 @@ import Observation
 import SwiftUI
 
 struct ScreenshotEditorState: Codable, Equatable, Hashable {
+    var scene: SceneSettings = .identity
+    var canvasAspect: VideoPreviewAspectPreset = .auto
     var background: BackgroundStyle = BackgroundPresets.default
     var padding = 56.0
     var backgroundRoundness = 0.0
@@ -30,6 +32,7 @@ struct ScreenshotEditorState: Codable, Equatable, Hashable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case scene, canvasAspect
         case background
         case padding
         case backgroundRoundness
@@ -41,6 +44,8 @@ struct ScreenshotEditorState: Codable, Equatable, Hashable {
     init(from decoder: Decoder) throws {
         let defaults = Self.default
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        scene = try container.decodeIfPresent(SceneSettings.self, forKey: .scene) ?? .identity
+        canvasAspect = try container.decodeIfPresent(VideoPreviewAspectPreset.self, forKey: .canvasAspect) ?? .auto
         background = try container.decodeIfPresent(BackgroundStyle.self, forKey: .background) ?? defaults.background
         padding = try container.decodeIfPresent(Double.self, forKey: .padding) ?? defaults.padding
         backgroundRoundness = try container.decodeIfPresent(Double.self, forKey: .backgroundRoundness) ?? defaults.backgroundRoundness
@@ -152,6 +157,7 @@ extension ScreenshotEditorMachineState {
 @MainActor
 final class ScreenshotEditorDriver {
     var state = ScreenshotEditorMachineState()
+    var scenePreviewTime = 0.0
     private var historyRevision = 0
 
     @ObservationIgnored private var history = EditorHistory<ScreenshotEditorState>()
@@ -300,14 +306,19 @@ final class ScreenshotEditorDriver {
         )
     }
 
-    func saveComposedPNG(image: NSImage?, suggestedFileName: String) {
-        let exportState = state.screenshot
+    func saveComposedPNG(image: NSImage?, suggestedFileName: String, sourceURL: URL? = nil) {
+        var exportState = state.screenshot
+        exportState.scene = exportState.scene.still(at: scenePreviewTime)
         guard let image, let data = renderPNG(image, exportState) else {
             send(.saveFailed("Failed to render screenshot."))
             return
         }
 
         guard let targetURL = presentSaveURL(suggestedFileName) else { return }
+        if let sourceURL, ExportFileSafety.sameFile(sourceURL, targetURL) {
+            send(.saveFailed("Choose a different filename to preserve the original image."))
+            return
+        }
 
         do {
             try writePNG(data, targetURL)
@@ -318,7 +329,8 @@ final class ScreenshotEditorDriver {
     }
 
     func copyComposedPNG(image: NSImage?) {
-        let exportState = state.screenshot
+        var exportState = state.screenshot
+        exportState.scene = exportState.scene.still(at: scenePreviewTime)
         guard let image, let data = renderPNG(image, exportState) else {
             send(.copyFailed("Failed to render screenshot."))
             return

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotEditorViews.swift
@@ -14,6 +14,13 @@ struct ScreenshotEditorStudioView: View {
     var editor: ScreenshotEditorDriver
     var exportRequest: EditorExportRequest?
     @State private var sidebarWidth: CGFloat = 320
+    @State private var activeInspector: InspectorTab = .appearance
+    @State private var sceneEndpoint: SceneEndpoint = .start
+    @State private var sceneTool: SceneTool = .tilt
+    @State private var image: NSImage?
+    @State private var animationPlaying = false
+    @State private var animationExportPresented = false
+    @State private var animationDraft = VideoExportDraftState()
 
     var body: some View {
         StudioSplitPane(
@@ -24,53 +31,122 @@ struct ScreenshotEditorStudioView: View {
             maxSecondarySize: 440,
             spacing: 0
         ) {
-            ScreenshotCanvas(
-                image: image,
-                background: editor.state.screenshot.background,
-                padding: editor.state.screenshot.padding,
-                backgroundRoundness: editor.state.screenshot.backgroundRoundness,
-                backgroundShadow: editor.state.screenshot.backgroundShadow,
-                imageRoundness: editor.state.screenshot.imageRoundness,
-                imageShadow: editor.state.screenshot.imageShadow
-            )
+            VStack(spacing: 0) {
+                if activeInspector == .scene { SceneCanvasTools(tool: $sceneTool) }
+                Group {
+                    if editor.state.screenshot.scene.isActive || editor.state.screenshot.canvasAspect != .auto {
+                        SceneScreenshotPreview(image: image, state: editor.state.screenshot, time: editor.scenePreviewTime)
+                    } else {
+                        ScreenshotCanvas(image: image, background: editor.state.screenshot.background,
+                            padding: editor.state.screenshot.padding, backgroundRoundness: editor.state.screenshot.backgroundRoundness,
+                            backgroundShadow: editor.state.screenshot.backgroundShadow,
+                            imageRoundness: editor.state.screenshot.imageRoundness, imageShadow: editor.state.screenshot.imageShadow)
+                    }
+                }
+                .modifier(SceneCanvasGesture(enabled: activeInspector == .scene, tool: sceneTool,
+                    pose: scenePoseBinding(settings: editor.binding(for: \.scene), endpoint: sceneEndpoint),
+                    onEditingChanged: handleUndoTransaction))
+                if editor.state.screenshot.scene.motion.enabled {
+                    HStack {
+                        Button { animationPlaying.toggle() } label: {
+                            Image(systemName: animationPlaying ? "pause.fill" : "play.fill")
+                        }.help(animationPlaying ? "Pause animation" : "Play animation")
+                        Slider(value: Binding(get: { editor.scenePreviewTime }, set: { animationPlaying = false; editor.scenePreviewTime = $0 }),
+                               in: 0...editor.state.screenshot.scene.imageDuration)
+                        Text(String(format: "%.2fs", editor.scenePreviewTime)).monospacedDigit().font(.caption)
+                    }.padding(12)
+                }
+            }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } secondary: {
-            ScreenshotSettingsPanel(
-                background: editor.binding(for: \.background),
-                padding: editor.binding(for: \.padding),
-                backgroundRoundness: editor.binding(for: \.backgroundRoundness),
-                backgroundShadow: editor.binding(for: \.backgroundShadow),
-                imageRoundness: editor.binding(for: \.imageRoundness),
-                imageShadow: editor.binding(for: \.imageShadow),
-                onEditingChanged: handleUndoTransaction,
-                onRevealFile: {
-                    if let screenshotURL {
-                        model.reveal(screenshotURL.path)
+            HStack(spacing: 0) {
+                VStack(spacing: 14) {
+                    ForEach([InspectorTab.appearance, .scene]) { tab in
+                        Button { activeInspector = tab } label: {
+                            VStack(spacing: 5) {
+                                Image(systemName: tab.symbolName).font(.system(size: 16))
+                                Text(tab.shortTitle).font(.system(size: 9.5))
+                            }.foregroundStyle(activeInspector == tab ? Theme.fg : Theme.fgMuted)
+                                .frame(width: 46, height: 46)
+                        }.buttonStyle(.plain).help(tab.helpText)
                     }
-                },
-                onExport: {
-                    editor.send(.exportRequested)
-                },
-                onSave: {
-                    editor.saveComposedPNG(image: image, suggestedFileName: suggestedExportFileName)
-                },
-                onCopy: {
-                    editor.copyComposedPNG(image: image)
+                    Spacer()
+                }.padding(.top, 14).frame(width: 50).background(Theme.railBg)
+                if activeInspector == .scene {
+                    VStack(spacing: 0) {
+                        ScrollView {
+                            SceneInspector(settings: editor.binding(for: \.scene), endpoint: $sceneEndpoint,
+                                duration: editor.state.screenshot.scene.imageDuration, isImage: true,
+                                seek: { animationPlaying = false; editor.scenePreviewTime = $0 }, onEditingChanged: handleUndoTransaction)
+                                .padding(14)
+                        }
+                        HStack {
+                            Button("Copy PNG") { editor.copyComposedPNG(image: image) }
+                            Spacer()
+                            Menu("Export") {
+                                Button("Save PNG…") { editor.saveComposedPNG(image: image, suggestedFileName: suggestedExportFileName, sourceURL: screenshotURL) }
+                                Button("Export Animation…") { presentAnimationExport() }
+                            }
+                        }.controlSize(.small).padding(10)
+                    }
+                } else {
+                    ScreenshotSettingsPanel(
+                        background: editor.binding(for: \.background),
+                        padding: editor.binding(for: \.padding),
+                        backgroundRoundness: editor.binding(for: \.backgroundRoundness),
+                        backgroundShadow: editor.binding(for: \.backgroundShadow),
+                        imageRoundness: editor.binding(for: \.imageRoundness),
+                        imageShadow: editor.binding(for: \.imageShadow),
+                        canvasAspect: editor.binding(for: \.canvasAspect),
+                        onAnimateExport: { presentAnimationExport() },
+                        onEditingChanged: handleUndoTransaction,
+                        onRevealFile: {
+                            if let screenshotURL {
+                                model.reveal(screenshotURL.path)
+                            }
+                        },
+                        onExport: {
+                            editor.send(.exportRequested)
+                        },
+                        onSave: {
+                            editor.saveComposedPNG(image: image, suggestedFileName: suggestedExportFileName, sourceURL: screenshotURL)
+                        },
+                        onCopy: {
+                            editor.copyComposedPNG(image: image)
+                        }
+                    )
                 }
-            )
+            }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(Theme.appBg)
         .sheet(isPresented: editor.exportDialogBinding) {
             ScreenshotExportDialog(
                 onSave: {
-                    editor.saveComposedPNG(image: image, suggestedFileName: suggestedExportFileName)
+                    editor.saveComposedPNG(image: image, suggestedFileName: suggestedExportFileName, sourceURL: screenshotURL)
                 },
                 onCopy: {
                     editor.copyComposedPNG(image: image)
                 }
             )
             .frame(width: 420)
+        }
+        .sheet(isPresented: $animationExportPresented) { animationExportDialog }
+        .task(id: screenshotURL) { image = screenshotURL.flatMap { NSImage(contentsOf: $0) }; editor.scenePreviewTime = 0; animationPlaying = false }
+        .task(id: animationPlaying) {
+            guard animationPlaying else { return }
+            if editor.scenePreviewTime >= editor.state.screenshot.scene.imageDuration { editor.scenePreviewTime = 0 }
+            let start = Date().timeIntervalSinceReferenceDate - editor.scenePreviewTime
+            while !Task.isCancelled && animationPlaying {
+                editor.scenePreviewTime = min(editor.state.screenshot.scene.imageDuration, Date().timeIntervalSinceReferenceDate - start)
+                if editor.scenePreviewTime >= editor.state.screenshot.scene.imageDuration { animationPlaying = false; break }
+                try? await Task.sleep(for: .milliseconds(33))
+            }
+        }
+        .onChange(of: editor.state.screenshot.scene) { _, _ in animationPlaying = false }
+        .onChange(of: editor.state.screenshot.scene.imageDuration) { _, duration in
+            editor.binding(for: \.scene).wrappedValue = editor.state.screenshot.scene.clamped(to: duration)
+            editor.scenePreviewTime = min(editor.scenePreviewTime, duration)
         }
         .onChange(of: exportRequest?.id) { _, requestID in
             guard requestID != nil, isScreenshotExportRequestTarget else { return }
@@ -106,9 +182,29 @@ struct ScreenshotEditorStudioView: View {
         }
     }
 
-    private var image: NSImage? {
-        guard let url = screenshotURL else { return nil }
-        return NSImage(contentsOf: url)
+    private func presentAnimationExport() {
+        animationPlaying = false
+        workspace.videoExport.clear()
+        animationDraft = VideoExportDraftState()
+        animationExportPresented = true
+    }
+
+    private var animationExportDialog: some View {
+        let exporter = workspace.videoExport
+        return VideoExportDialog(phase: exporter.state.phase, progress: exporter.state.progress,
+            errorMessage: exporter.state.errorMessage, exportedFileName: exporter.state.exportedFileName,
+            isExporting: exporter.state.isExporting, resolution: $animationDraft.resolution,
+            format: Binding(get: { animationDraft.format }, set: { animationDraft.setFormat($0) }),
+            frameRate: $animationDraft.frameRate, quality: $animationDraft.quality,
+            gifSize: $animationDraft.gifSize, gifLoops: $animationDraft.gifLoops,
+            mediaLabel: "Animation",
+            onExport: {
+                var options = animationDraft.currentOptions
+                options.screenshotState = editor.state.screenshot
+                exporter.export(sourceURL: screenshotURL, options: options, edits: .empty)
+            }, onRetrySave: { exporter.send(.retrySaveRequested) }, onShowInFinder: { exporter.send(.revealRequested) },
+            onCancelExport: { exporter.send(.cancelRequested) }, onClose: { animationExportPresented = false })
+            .frame(width: 520).interactiveDismissDisabled(exporter.state.phase.isBusy)
     }
 
     private var suggestedExportFileName: String {
@@ -117,6 +213,7 @@ struct ScreenshotEditorStudioView: View {
 
     private func handleUndoTransaction(_ isEditing: Bool) {
         if isEditing {
+            animationPlaying = false
             editor.beginUndoTransaction()
         } else {
             editor.endUndoTransaction()
@@ -412,6 +509,8 @@ struct ScreenshotSettingsPanel: View {
     @Binding var backgroundShadow: Double
     @Binding var imageRoundness: Double
     @Binding var imageShadow: Double
+    @Binding var canvasAspect: VideoPreviewAspectPreset
+    var onAnimateExport: () -> Void = {}
     var onEditingChanged: (Bool) -> Void = { _ in }
     var onRevealFile: () -> Void = {}
     var onExport: () -> Void
@@ -423,6 +522,7 @@ struct ScreenshotSettingsPanel: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
                     header
+                    CanvasAspectPicker(selection: $canvasAspect)
                     BackgroundPickerView(selection: $background)
                     InspectorGroup(title: "Background Layer", symbolName: "rectangle.fill") {
                         InspectorSlider(title: "Padding", valueText: "\(Int(padding))px", value: $padding, range: 0...140, step: 1, onEditingChanged: onEditingChanged)
@@ -446,7 +546,7 @@ struct ScreenshotSettingsPanel: View {
                     onRevealFile()
                 }
                 if let onSave, let onCopy {
-                    ScreenshotExportMenu(onSave: onSave, onCopy: onCopy)
+                    ScreenshotExportMenu(onAnimate: onAnimateExport, onSave: onSave, onCopy: onCopy)
                 } else {
                     InspectorFooterButton(title: "Export", symbolName: "square.and.arrow.up") {
                         onExport()
@@ -489,11 +589,14 @@ struct ScreenshotSettingsPanel: View {
 }
 
 private struct ScreenshotExportMenu: View {
+    var onAnimate: () -> Void = {}
     var onSave: () -> Void
     var onCopy: () -> Void
 
     var body: some View {
         Menu {
+            Button("Export Animation…", action: onAnimate)
+            Divider()
             Button(action: onSave) {
                 Label("Save PNG…", systemImage: "square.and.arrow.down")
             }

--- a/apps/macos/Sources/OpenRecorderMac/ScreenshotExportRenderer.swift
+++ b/apps/macos/Sources/OpenRecorderMac/ScreenshotExportRenderer.swift
@@ -1,8 +1,13 @@
 import AppKit
 import CoreGraphics
+import CoreImage
+import Metal
 import Foundation
 
 struct ScreenshotExportConfiguration {
+    var scene: SceneSettings = .identity
+    var canvasAspect: VideoPreviewAspectPreset = .auto
+    var sceneTime = 0.0
     var background: BackgroundStyle
     var padding: Double
     var backgroundRoundness: Double
@@ -35,6 +40,8 @@ struct ScreenshotExportConfiguration {
             imageRoundness: screenshotState.imageRoundness,
             imageShadow: screenshotState.imageShadow
         )
+        scene = screenshotState.scene
+        canvasAspect = screenshotState.canvasAspect
     }
 }
 
@@ -82,6 +89,16 @@ struct ScreenshotCompositionLayout {
             width: backgroundRect.width + shadowMargin * 2,
             height: backgroundRect.height + shadowMargin * 2
         )
+        if configuration.canvasAspect != .auto {
+            let ratio = configuration.canvasAspect.aspectRatio(forExportSourceSize: canvasSize)
+            let previous = canvasSize
+            canvasSize = CGSize(width: max(previous.width, previous.height * ratio),
+                                height: max(previous.height, previous.width / ratio))
+            let dx = (canvasSize.width - previous.width) / 2, dy = (canvasSize.height - previous.height) / 2
+            imageRect = imageRect.offsetBy(dx: dx, dy: dy)
+            backgroundRect = CGRect(x: shadowMargin, y: shadowMargin,
+                                    width: canvasSize.width - 2 * shadowMargin, height: canvasSize.height - 2 * shadowMargin)
+        }
     }
 
     func displayScale(toFit availableSize: CGSize) -> CGFloat {
@@ -104,6 +121,11 @@ struct ScreenshotExportRenderer {
     }
 
     func renderPNG(from image: NSImage) -> Data? {
+        guard let rendered = renderImage(from: image) else { return nil }
+        return NSBitmapImageRep(cgImage: rendered).representation(using: .png, properties: [:])
+    }
+
+    func renderImage(from image: NSImage, maxDimension: CGFloat? = nil, renderer: SceneRenderer = SceneRenderer(), ciContext: CIContext = SceneImageContext.shared) -> CGImage? {
         guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             return nil
         }
@@ -135,6 +157,23 @@ struct ScreenshotExportRenderer {
         context.scaleBy(x: 1, y: -1)
 
         drawExportBackground(in: context, rect: layout.backgroundRect, layout: layout)
+        if configuration.scene.isActive {
+            guard let backdrop = context.makeImage() else { return nil }
+            let rect = CGRect(x: layout.imageRect.minX, y: CGFloat(height) - layout.imageRect.maxY,
+                              width: layout.imageRect.width, height: layout.imageRect.height)
+            let media = CIImage(cgImage: cgImage).transformed(by: CGAffineTransform(translationX: rect.minX, y: rect.minY))
+            var composed = renderer.render(media: media, mediaRect: rect, frame: rect, canvas: layout.canvasSize,
+                settings: configuration.scene, time: configuration.sceneTime,
+                radius: layout.imageRoundness, shadow: configuration.imageShadow)
+                .composited(over: CIImage(cgImage: backdrop))
+            var bounds = CGRect(x: 0, y: 0, width: width, height: height)
+            if let maxDimension {
+                let scale = min(1, maxDimension / max(bounds.width, bounds.height))
+                composed = composed.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+                bounds = bounds.applying(CGAffineTransform(scaleX: scale, y: scale)).integral
+            }
+            return ciContext.createCGImage(composed, from: bounds)
+        }
         drawExportImageShadow(in: context, rect: layout.imageRect, layout: layout)
 
         context.saveGState()
@@ -152,8 +191,7 @@ struct ScreenshotExportRenderer {
             return nil
         }
 
-        let bitmap = NSBitmapImageRep(cgImage: exportedImage)
-        return bitmap.representation(using: .png, properties: [:])
+        return exportedImage
     }
 
     private static func styleScale(for image: NSImage, cgImage: CGImage) -> CGFloat {
@@ -308,4 +346,12 @@ struct ScreenshotExportRenderer {
         context.draw(cgImage, in: CGRect(origin: .zero, size: rect.size))
         context.restoreGState()
     }
+}
+
+// CIContext is thread-safe and expensive to create; share the Metal-backed image context.
+enum SceneImageContext {
+    static let shared: CIContext = {
+        if let device = MTLCreateSystemDefaultDevice() { return CIContext(mtlDevice: device, options: [.cacheIntermediates: false]) }
+        return CIContext(options: [.cacheIntermediates: false])
+    }()
 }

--- a/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoBackgroundCompositor.swift
@@ -118,6 +118,7 @@ final class VideoBackgroundCompositionInstruction: NSObject, AVVideoCompositionI
 
     let sourceTrackID: CMPersistentTrackID
     let facecamTrackID: CMPersistentTrackID?
+    let scene: SceneSettings
     let styling: VideoBackgroundStyling
     let preferredTransform: CGAffineTransform
     let normalizedSize: CGSize
@@ -136,6 +137,7 @@ final class VideoBackgroundCompositionInstruction: NSObject, AVVideoCompositionI
         trackID: CMPersistentTrackID,
         facecamTrackID: CMPersistentTrackID? = nil,
         styling: VideoBackgroundStyling,
+        scene: SceneSettings = .identity,
         preferredTransform: CGAffineTransform,
         normalizedSize: CGSize,
         facecamPreferredTransform: CGAffineTransform = .identity,
@@ -152,6 +154,7 @@ final class VideoBackgroundCompositionInstruction: NSObject, AVVideoCompositionI
         self.sourceTrackID = trackID
         self.facecamTrackID = facecamTrackID
         self.requiredSourceTrackIDs = ([trackID] + (facecamTrackID.map { [$0] } ?? [])).map { NSNumber(value: $0) }
+        self.scene = scene
         self.styling = styling
         self.preferredTransform = preferredTransform
         self.normalizedSize = normalizedSize
@@ -209,6 +212,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
     #endif
     private var renderContext: AVVideoCompositionRenderContext?
     private let renderContextLock = NSLock()
+    private let sceneRenderer = SceneRenderer()
     private var annotationCache: [String: CIImage] = [:]
     private var cursorGlyphCache: [CursorGlyphCacheKey: CursorGlyphImage] = [:]
     private static let pixelBufferAttributes: VideoCompositorPixelBufferAttributes = [
@@ -324,7 +328,7 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
         return outputBuffer
     }
 
-    private func makeComposedImage(
+    func makeComposedImage(
         source: CVPixelBuffer,
         facecam: CVPixelBuffer?,
         instruction: VideoBackgroundCompositionInstruction,
@@ -395,6 +399,50 @@ final class VideoBackgroundCompositor: NSObject, AVVideoCompositing, @unchecked 
                 image = applyGaussianBlur(image, radius: blurRadius).cropped(to: renderRect)
             }
             return image
+        }
+
+        if instruction.scene.isActive {
+            // Scene zooms happen within the screen surface; the stage remains upright.
+            var media = maskedSource
+            if let cursor = makeCursorLayer(for: instruction, compositionTime: compositionTime, contentRect: contentRect) {
+                media = cursor.composited(over: media)
+            }
+            media = applyZoomTransform(to: media, renderRect: renderRect, instruction: instruction,
+                                       compositionTime: compositionTime, placedRect: placedRect).cropped(to: placedRect)
+            var surface = media
+            if instruction.styling.inset.isEnabled && instruction.styling.inset.opacity > 0 {
+                surface = media.composited(over: makeInsetLayer(for: instruction.styling.inset,
+                    in: sourceLayout.frameRect, cornerRadius: cornerRadius))
+            }
+            var result = sceneRenderer.render(media: surface, mediaRect: sourceLayout.frameRect,
+                frame: sourceLayout.frameRect, canvas: renderSize,
+                settings: instruction.scene.clamped(to: instruction.editPlan.outputDuration),
+                time: compositionTime, radius: cornerRadius, shadow: instruction.styling.shadowIntensity)
+                .composited(over: background)
+            // Canvas annotations and facecam are deliberately outside the tilted surface.
+            for annotation in instruction.edits.annotationRegions {
+                guard let span = instruction.editPlan.outputSpans(forSourceSpan: annotation.span).first(where: { $0.contains(compositionTime) }),
+                      let layer = annotationImage(annotation, canvasSize: renderSize) else { continue }
+                let progress = (compositionTime - span.start) / max(0.001, span.duration)
+                let opacity = min(1, min(progress / 0.08, (1 - progress) / 0.08))
+                let positioned = layer.transformed(by: CGAffineTransform(
+                    translationX: renderSize.width * annotation.x - layer.extent.width / 2,
+                    y: renderSize.height * (1 - annotation.y) - layer.extent.height / 2))
+                    .applyingFilter("CIColorMatrix", parameters: ["inputAVector": CIVector(x: 0, y: 0, z: 0, w: opacity)])
+                result = positioned.composited(over: result)
+            }
+            if var camera = makeFacecamLayer(facecam, for: instruction, compositionTime: compositionTime) {
+                let sourceTime = instruction.editPlan.sourceTime(forOutputTime: compositionTime) ?? compositionTime
+                let fixed = instruction.edits.activeCameraSettings(at: sourceTime,
+                    duration: instruction.editPlan.segments.last?.sourceEnd ?? 0,
+                    fallback: instruction.facecamFallbackSettings)?.fixedDuringZoom == true
+                if !fixed {
+                    camera = applyZoomTransform(to: camera, renderRect: renderRect, instruction: instruction,
+                        compositionTime: compositionTime, placedRect: placedRect)
+                }
+                result = camera.composited(over: result)
+            }
+            return result.cropped(to: renderRect)
         }
 
         var composed = background

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportDialog.swift
@@ -12,6 +12,7 @@ struct VideoExportDialog: View {
     @Binding var quality: VideoExportQuality
     @Binding var gifSize: VideoExportGIFSize
     @Binding var gifLoops: Bool
+    var mediaLabel: String = "Video"
     var onExport: () -> Void
     var onRetrySave: () -> Void
     var onShowInFinder: () -> Void
@@ -322,7 +323,7 @@ struct VideoExportDialog: View {
             Spacer(minLength: 0)
 
             ExportDialogButton(
-                title: isExporting ? "Exporting…" : "Export Video",
+                title: isExporting ? "Exporting…" : "Export \(mediaLabel)",
                 systemImage: "square.and.arrow.down",
                 kind: .primary,
                 minWidth: 136,
@@ -364,11 +365,11 @@ struct VideoExportDialog: View {
         case .saving:
             "Ready to Save"
         case .exporting where displayedProgress <= 0.01:
-            "Preparing Video"
+            "Preparing \(mediaLabel)"
         case .exporting:
-            "Rendering Video"
+            "Rendering \(mediaLabel)"
         case .idle, .savePending, .success, .failed:
-            "Export Video"
+            "Export \(mediaLabel)"
         }
     }
 
@@ -390,12 +391,12 @@ struct VideoExportDialog: View {
 
     private var headerTitle: String {
         switch phase {
-        case .exporting: "Exporting Video"
+        case .exporting: "Exporting \(mediaLabel)"
         case .saving: "Save Export"
         case .savePending: "Export Ready"
         case .success: "Export Complete"
         case .failed: "Export Failed"
-        case .idle: "Export Video"
+        case .idle: "Export \(mediaLabel)"
         }
     }
 

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportOptions.swift
@@ -316,6 +316,8 @@ struct VideoExportOptions: Equatable {
     var quality: VideoExportQuality = .defaultExportOption
     var gifSize: VideoExportGIFSize = .defaultExportOption
     var gifLoops = true
+    var screenshotState: ScreenshotEditorState? = nil
+    var scene: SceneSettings = .identity
     var aspectPreset: VideoPreviewAspectPreset = .auto
     var styling: VideoBackgroundStyling
     var cropSelection: VideoCropSelection?
@@ -385,6 +387,12 @@ struct VideoExportOptions: Equatable {
             copy.resolution = .custom
             copy.customOutputSize = CGSize(width: width, height: height)
         }
+        return copy
+    }
+
+    func withScene(_ settings: SceneSettings) -> VideoExportOptions {
+        var copy = self
+        copy.scene = settings
         return copy
     }
 
@@ -509,6 +517,12 @@ enum VideoExportRenderer {
         diagnostics: VideoExportDiagnostics? = nil,
         progressHandler: @escaping @MainActor (Double) -> Void = { _ in }
     ) async throws {
+        guard !ExportFileSafety.sameFile(sourceURL, targetURL) else { throw ExportFileSafety.Failure.originalFile }
+        if let screenshot = options.screenshotState {
+            try await SceneImageAnimationExporter.export(sourceURL: sourceURL, targetURL: targetURL, state: screenshot,
+                options: options, cancellationToken: cancellationToken, progressHandler: progressHandler)
+            return
+        }
         if FileManager.default.fileExists(atPath: targetURL.path) {
             try FileManager.default.removeItem(at: targetURL)
         }
@@ -566,6 +580,7 @@ enum VideoExportRenderer {
             duration: CMTime(seconds: duration, preferredTimescale: 600),
             frameDuration: frameDuration,
             styling: options.styling,
+            scene: options.scene,
             edits: edits,
             editPlan: exportAsset.plan,
             cursorTrack: cursorTrack,
@@ -956,6 +971,7 @@ enum VideoExportRenderer {
         duration: CMTime,
         frameDuration: CMTime,
         styling: VideoBackgroundStyling,
+        scene: SceneSettings = .identity,
         edits: TimelineEditSnapshot = .empty,
         editPlan: TimelineExportEditPlan = TimelineExportEditPlan(segments: [], outputDuration: 0),
         cursorTrack: CursorTelemetryTrack? = nil,
@@ -982,7 +998,7 @@ enum VideoExportRenderer {
             .concatenating(CGAffineTransform(scaleX: scale, y: scale))
             .concatenating(translation)
 
-        if styling.isPassthrough, facecamTrack == nil {
+        if styling.isPassthrough, facecamTrack == nil, !scene.isActive {
             let instruction = AVMutableVideoCompositionInstruction()
             instruction.timeRange = CMTimeRange(start: .zero, duration: duration)
 
@@ -1019,6 +1035,7 @@ enum VideoExportRenderer {
             trackID: videoTrack.trackID,
             facecamTrackID: facecamTrack?.trackID,
             styling: styling,
+            scene: scene,
             preferredTransform: normalizedTransform,
             normalizedSize: normalizedSize,
             facecamPreferredTransform: facecamPreferredTransform,

--- a/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoExportStateMachines.swift
@@ -191,10 +191,7 @@ final class VideoExportDriver {
     }
     @ObservationIgnored private var saveDestination: (URL, VideoExportOptions) -> URL? = { _, _ in nil }
     @ObservationIgnored private var copyFile: (URL, URL) throws -> Void = { sourceURL, targetURL in
-        if FileManager.default.fileExists(atPath: targetURL.path) {
-            try FileManager.default.removeItem(at: targetURL)
-        }
-        try FileManager.default.copyItem(at: sourceURL, to: targetURL)
+        try ExportFileSafety.install(source: sourceURL, destination: targetURL)
     }
     @ObservationIgnored private var deleteFile: (URL) -> Void = { url in
         try? FileManager.default.removeItem(at: url)
@@ -298,8 +295,9 @@ final class VideoExportDriver {
                 }
                 perform([.copyFile(sourceURL: sourceURL, targetURL: targetURL, tempURL: tempURL)])
 
-            case .copyFile(_, let targetURL, let tempURL):
+            case .copyFile(let sourceURL, let targetURL, let tempURL):
                 do {
+                    guard !ExportFileSafety.sameFile(sourceURL, targetURL) else { throw ExportFileSafety.Failure.originalFile }
                     try copyFile(tempURL, targetURL)
                     deleteFile(tempURL)
                     send(.saveSucceeded(targetURL))

--- a/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
+++ b/apps/macos/Sources/OpenRecorderMac/VideoPlaybackViews.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 import SwiftUI
 import UniformTypeIdentifiers
 
-enum VideoPreviewAspectPreset: String, CaseIterable, Identifiable {
+enum VideoPreviewAspectPreset: String, Codable, CaseIterable, Identifiable {
     case auto
     case wide
     case square
@@ -108,8 +108,14 @@ struct VideoPreviewPanel: View {
     var facecamSettings: FacecamSettings?
     var cameraTimelineFallback: FacecamSettings?
     @Binding var previewAspectPreset: VideoPreviewAspectPreset
+    @Binding var scene: SceneSettings
+    var sceneEndpoint: SceneEndpoint
+    @Binding var sceneTool: SceneTool
+    var showsSceneTools = false
+    var onSceneEditingChanged: (Bool) -> Void = { _ in }
     var onCropVideo: () -> Void = {}
     var onRequestClearSelection: () -> Void = {}
+    @State private var scenePreviewStatus: String?
     @State private var isPreviewAspectDropdownPresented = false
     @State private var cursorTrack: CursorTelemetryTrack?
     @State private var loadedCursorTelemetryPath: String?
@@ -123,10 +129,15 @@ struct VideoPreviewPanel: View {
                     .padding(.bottom, 7)
             }
 
+            if showsSceneTools { SceneCanvasTools(tool: $sceneTool) }
             ZStack {
                 if videoURL != nil {
                     AspectRatioFitContainer(aspectRatio: previewAspectRatio) {
-                        styledStage
+                        Group {
+                            if scene.isActive { sceneStage } else { styledStage }
+                        }
+                        .modifier(SceneCanvasGesture(enabled: showsSceneTools, tool: sceneTool,
+                            pose: scenePoseBinding(settings: $scene, endpoint: sceneEndpoint), onEditingChanged: onSceneEditingChanged))
                     } overlay: {
                         recordingSessionBadges
                     }
@@ -229,6 +240,38 @@ struct VideoPreviewPanel: View {
                 }
             )
         }
+    }
+
+    private var sceneStyling: VideoBackgroundStyling {
+        VideoExportOptions.default.with(background: background, padding: padding, borderRadius: borderRadius,
+            shadow: shadow, backgroundBlur: backgroundBlur, inset: inset, insetColor: insetColor,
+            insetOpacity: insetOpacity, insetBalance: insetBalance).styling
+    }
+
+    private var sceneStage: some View {
+        GeometryReader { proxy in
+            SceneVideoPreview(player: playback.player, sourceSize: playback.naturalVideoSize,
+                cropSelection: cropSelection, settings: scene, styling: sceneStyling,
+                edits: timelineEdits.snapshot, duration: playback.duration, cursorTrack: cursorTrack,
+                cursorSettings: cursorSettings, cameraSettings: activeFacecamSettings,
+                onPreviewStatus: { scenePreviewStatus = $0 })
+                .overlay {
+                    if let scenePreviewStatus { Text(scenePreviewStatus).font(.callout).padding(20).background(Theme.sidebarBg) }
+                }
+                .overlay(alignment: .topLeading) {
+                    if let url = facecamVideoURL, let settings = activeFacecamSettings {
+                        let effect = timelineEdits.snapshot.activeZoomEffect(at: playback.currentTime, cursorTrack: cursorTrack)
+                        let frame = PreviewStageLayout.recordingFrameRect(forAspectRatio: cropSelection.previewAspectRatio(in: playback.naturalVideoSize),
+                            in: proxy.size, paddingValue: padding)
+                        FacecamPlaybackOverlay(facecamURL: url, screenPlayback: playback,
+                            offsetMs: recordingSession?.facecamOffsetMs, settings: settings)
+                            .frame(width: proxy.size.width, height: proxy.size.height)
+                            .transformEffect(settings.fixedDuringZoom == true ? .identity : PreviewStageLayout.previewFullStageZoomTransform(
+                                effect: effect, stageSize: proxy.size, recordingFrame: frame, sourceSize: playback.naturalVideoSize,
+                                cropSelection: cropSelection, inset: inset, insetBalance: insetBalance, cameraSettings: settings))
+                    }
+                }
+        }.clipped()
     }
 
     private var styledStage: some View {

--- a/apps/macos/Tests/OpenRecorderMacTests/EditorInteractionSemanticsTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/EditorInteractionSemanticsTests.swift
@@ -220,7 +220,7 @@ final class PreviewPlaybackSpeedSelectionTests: XCTestCase {
 final class InspectorAvailabilityTests: XCTestCase {
     func testHidesInertAudioTabWithoutRemovingCompatibilityCase() {
         XCTAssertFalse(InspectorTab.availableCases.contains(.audio))
-        XCTAssertEqual(InspectorTab.availableCases, [.appearance, .cursor, .camera])
+        XCTAssertEqual(InspectorTab.availableCases, [.appearance, .scene, .cursor, .camera])
         XCTAssertTrue(InspectorTab.allCases.contains(.audio))
     }
 }
@@ -252,6 +252,7 @@ final class EditorControlCompatibilityTests: XCTestCase {
             backgroundShadow: .constant(0.35),
             imageRoundness: .constant(0),
             imageShadow: .constant(0),
+            canvasAspect: .constant(.auto),
             onExport: {}
         )
 

--- a/apps/macos/Tests/OpenRecorderMacTests/SceneTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/SceneTests.swift
@@ -119,12 +119,17 @@ final class SceneTests: XCTestCase {
         let queue = try XCTUnwrap(device.makeCommandQueue())
         let descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm, width: 320, height: 180, mipmapped: false)
         descriptor.usage = [.shaderRead, .shaderWrite, .renderTarget]
-        descriptor.storageMode = .shared
+        descriptor.storageMode = device.hasUnifiedMemory ? .shared : .managed
         let texture = try XCTUnwrap(device.makeTexture(descriptor: descriptor))
         let context = CIContext(mtlDevice: device)
         let cg = try XCTUnwrap(try fixtureImage().cgImage(forProposedRect: nil, context: nil, hints: nil))
         let command = try XCTUnwrap(queue.makeCommandBuffer())
         SceneMetalDisplay.render(CIImage(cgImage: cg), context: context, texture: texture, commandBuffer: command)
+        if !device.hasUnifiedMemory {
+            let blit = try XCTUnwrap(command.makeBlitCommandEncoder())
+            blit.synchronize(resource: texture)
+            blit.endEncoding()
+        }
         command.commit(); command.waitUntilCompleted()
         var pixel = [UInt8](repeating: 0, count: 4)
         texture.getBytes(&pixel, bytesPerRow: 4, from: MTLRegionMake2D(80, 45, 1, 1), mipmapLevel: 0)

--- a/apps/macos/Tests/OpenRecorderMacTests/SceneTests.swift
+++ b/apps/macos/Tests/OpenRecorderMacTests/SceneTests.swift
@@ -1,0 +1,325 @@
+import AVFoundation
+import AppKit
+import CoreImage
+import ImageIO
+import Metal
+import SwiftUI
+import XCTest
+@testable import OpenRecorderMac
+
+@MainActor
+final class SceneTests: XCTestCase {
+    func testLegacyProjectsRemainFlatAndUseAutomaticCanvas() throws {
+        for data in [Data("{}".utf8)] {
+            let video = try JSONDecoder().decode(ProjectVideoEditorState.self, from: data)
+            let image = try JSONDecoder().decode(ScreenshotEditorState.self, from: data)
+            XCTAssertFalse(video.scene.isActive)
+            XCTAssertFalse(image.scene.isActive)
+            XCTAssertEqual(video.canvasAspect, .auto)
+            XCTAssertEqual(image.canvasAspect, .auto)
+        }
+        var video = ProjectVideoEditorState.default
+        video.scene.pose = ScenePosePreset.elevated.pose
+        video.scene.motion.enabled = true
+        video.canvasAspect = .vertical
+        XCTAssertEqual(try JSONDecoder().decode(ProjectVideoEditorState.self, from: JSONEncoder().encode(video)), video)
+        var image = ScreenshotEditorState.default
+        image.scene = video.scene
+        image.canvasAspect = .square
+        XCTAssertEqual(try JSONDecoder().decode(ScreenshotEditorState.self, from: JSONEncoder().encode(image)), image)
+    }
+
+    func testMotionHoldsEndpointsAndClampsShortenedOutput() {
+        var motion = SceneMotion(enabled: true, startTime: 2, endTime: 6,
+                                 startPose: ScenePose(tiltY: -20, x: -0.2), endPose: ScenePose(tiltY: 20, x: 0.2), easing: .linear)
+        XCTAssertEqual(motion.pose(at: 0), motion.startPose)
+        XCTAssertEqual(motion.pose(at: 7), motion.endPose)
+        XCTAssertEqual(motion.pose(at: 4).tiltY, 0, accuracy: 0.0001)
+        motion = motion.clamped(to: 1)
+        XCTAssertGreaterThan(motion.endTime, motion.startTime)
+        XCTAssertEqual(motion.endTime, 1)
+        XCTAssertEqual(motion.clamped(to: 0).endTime, 0)
+        for easing in SceneEasing.allCases {
+            XCTAssertEqual(easing.evaluate(-1), 0)
+            XCTAssertEqual(easing.evaluate(2), 1)
+        }
+    }
+
+    func testMotionUsesOutputTimeAcrossCutsAndSpeedChanges() {
+        var edits = TimelineEditSnapshot.empty
+        edits.trimRegions = [TimelineTrimRegion(span: TimelineSpan(start: 2, end: 4))]
+        edits.clipSplitTimes = [4]
+        edits.clipSpeeds = [1: 2]
+        let plan = TimelineExportEditPlan.build(duration: 8, edits: edits)
+        XCTAssertEqual(plan.outputDuration, 4)
+        XCTAssertEqual(plan.sourceTime(forOutputTime: 2), 4)
+        XCTAssertEqual(plan.outputTime(forSourceTime: 6), 3)
+        let motion = SceneMotion(enabled: true, startTime: 0, endTime: 4,
+                                 startPose: ScenePose(x: 0), endPose: ScenePose(x: 1), easing: .linear)
+        XCTAssertEqual(motion.pose(at: plan.outputTime(forSourceTime: 6)!).x, 0.75, accuracy: 0.0001)
+    }
+
+    func testVideoAndImageDragsAreSingleUndoSteps() {
+        let video = VideoEditorDriver()
+        video.beginUndoTransaction()
+        for angle in [5.0, 10, 20] { video.binding(\.scene.pose.tiltY).wrappedValue = angle }
+        video.endUndoTransaction()
+        video.undo()
+        XCTAssertEqual(video.state.video.scene.pose.tiltY, 0)
+        XCTAssertFalse(video.canUndo)
+        video.redo()
+        XCTAssertEqual(video.state.video.scene.pose.tiltY, 20)
+        let image = ScreenshotEditorDriver()
+        image.beginUndoTransaction()
+        for angle in [5.0, 10, 20] { image.binding(for: \.scene.pose.tiltY).wrappedValue = angle }
+        image.endUndoTransaction()
+        image.undo()
+        XCTAssertEqual(image.state.screenshot.scene.pose.tiltY, 0)
+        XCTAssertFalse(image.canUndo)
+    }
+
+    func testSafeProjectionAndMockupFit() {
+        let frame = CGRect(x: 40, y: 40, width: 320, height: 180)
+        let canvas = CGSize(width: 400, height: 260)
+        let identity = SceneGeometry.evaluate(frame: frame, canvas: canvas, pose: .identity)
+        XCTAssertEqual(identity.bounds, frame)
+        for x in stride(from: -60.0, through: 60, by: 15) {
+            for y in stride(from: -60.0, through: 60, by: 15) {
+                let geometry = SceneGeometry.evaluate(frame: frame, canvas: canvas, pose: ScenePose(tiltX: x, tiltY: y, perspective: 1))
+                XCTAssertTrue(geometry.bounds.width.isFinite)
+                XCTAssertTrue(geometry.bounds.height.isFinite)
+                XCTAssertGreaterThan(geometry.bounds.width, 0)
+            }
+        }
+        for mockup in MockupStyle.allCases {
+            let layout = SceneMockupLayout.make(in: frame, mediaAspect: 16 / 9, style: mockup, radius: 0)
+            XCTAssertEqual(layout.content.width / layout.content.height, 16 / 9, accuracy: 0.001)
+            XCTAssertTrue(frame.contains(layout.frame))
+        }
+        XCTAssertTrue(ScenePose(tiltX: .infinity, tiltY: .nan, scale: .nan).clamped.isIdentity)
+    }
+
+    func testSceneScreenshotPreservesOrientationAndTransparentCorners() throws {
+        let image = try fixtureImage()
+        var state = bareImageState()
+        state.scene.pose.scale = 0.8
+        let cg = try XCTUnwrap(ScreenshotExportRenderer(configuration: ScreenshotExportConfiguration(screenshotState: state)).renderImage(from: image))
+        let bitmap = NSBitmapImageRep(cgImage: cg)
+        let topLeft = try XCTUnwrap(bitmap.colorAt(x: 90, y: 55)?.usingColorSpace(.deviceRGB))
+        let bottomRight = try XCTUnwrap(bitmap.colorAt(x: 225, y: 125)?.usingColorSpace(.deviceRGB))
+        XCTAssertGreaterThan(topLeft.redComponent, 0.8)
+        XCTAssertLessThan(topLeft.blueComponent, 0.2)
+        XCTAssertGreaterThan(bottomRight.blueComponent, 0.8)
+        XCTAssertLessThan(bottomRight.redComponent, 0.2)
+        XCTAssertLessThan(try XCTUnwrap(bitmap.colorAt(x: 0, y: 0)).alphaComponent, 0.05)
+    }
+
+    func testMetalPreviewOrientationMatchesPNG() throws {
+        let device = try XCTUnwrap(MTLCreateSystemDefaultDevice())
+        let queue = try XCTUnwrap(device.makeCommandQueue())
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm, width: 320, height: 180, mipmapped: false)
+        descriptor.usage = [.shaderRead, .shaderWrite, .renderTarget]
+        descriptor.storageMode = .shared
+        let texture = try XCTUnwrap(device.makeTexture(descriptor: descriptor))
+        let context = CIContext(mtlDevice: device)
+        let cg = try XCTUnwrap(try fixtureImage().cgImage(forProposedRect: nil, context: nil, hints: nil))
+        let command = try XCTUnwrap(queue.makeCommandBuffer())
+        SceneMetalDisplay.render(CIImage(cgImage: cg), context: context, texture: texture, commandBuffer: command)
+        command.commit(); command.waitUntilCompleted()
+        var pixel = [UInt8](repeating: 0, count: 4)
+        texture.getBytes(&pixel, bytesPerRow: 4, from: MTLRegionMake2D(80, 45, 1, 1), mipmapLevel: 0)
+        XCTAssertGreaterThan(pixel[2], 200, "Metal's displayed top-left must match the red top-left in PNG")
+        XCTAssertLessThan(pixel[0], 30)
+    }
+
+    func testAnimatedStillCopyUsesDisplayedPose() {
+        let driver = ScreenshotEditorDriver()
+        var received: ScreenshotEditorState?
+        driver.configure(saveHandler: { _ in throw CancellationError() }, statusHandler: { _ in }, setWorkspaceStatus: { _ in },
+            renderPNG: { _, state in received = state; return Data([1]) }, copyPNG: { _ in true })
+        var scene = SceneSettings()
+        scene.motion.enabled = true
+        scene.motion.easing = .linear
+        driver.binding(for: \.scene).wrappedValue = scene
+        driver.scenePreviewTime = 1.5
+        driver.copyComposedPNG(image: NSImage(size: CGSize(width: 1, height: 1)))
+        XCTAssertEqual(received?.scene.pose.scale ?? 0, 0.9, accuracy: 0.001)
+        XCTAssertFalse(received?.scene.motion.enabled ?? true)
+        XCTAssertTrue(driver.state.screenshot.scene.motion.enabled)
+    }
+
+    func testImageExportsFormatsAndCancellationPreserveSource() async throws {
+        let root = try fixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source.png")
+        let image = try fixtureImage()
+        let original = try XCTUnwrap(ScreenshotExportRenderer(configuration: ScreenshotExportConfiguration(screenshotState: bareImageState())).renderPNG(from: image))
+        try original.write(to: source)
+        var state = bareImageState()
+        state.scene.imageDuration = 0.4
+        state.scene.motion.enabled = true
+        state.scene.motion = state.scene.motion.clamped(to: 0.4)
+        state.scene.mockup = .browser
+        state.scene.motion.startPose = ScenePosePreset.left.pose
+        var options = VideoExportOptions.default
+        options.resolution = .source
+        options.frameRate = .fps15
+        options.gifSize = .original
+        options.screenshotState = state
+        for format in VideoExportFormat.allCases {
+            options.format = format
+            let target = root.appendingPathComponent("scene.\(format.fileExtension)")
+            try await VideoExportRenderer.export(sourceURL: source, targetURL: target, options: options)
+            if format == .gif {
+                let gif = try XCTUnwrap(CGImageSourceCreateWithURL(target as CFURL, nil))
+                XCTAssertEqual(CGImageSourceGetCount(gif), 6)
+            } else {
+                let duration = try await AVURLAsset(url: target).load(.duration).seconds
+                XCTAssertEqual(duration, 0.4, accuracy: 0.01)
+            }
+        }
+        XCTAssertEqual(try Data(contentsOf: source), original)
+        let cancelled = root.appendingPathComponent("cancelled.mov")
+        let token = VideoExportCancellationToken()
+        options.format = .mov
+        do {
+            try await VideoExportRenderer.export(sourceURL: source, targetURL: cancelled, options: options, cancellationToken: token) { progress in
+                if progress > 0 { token.cancel() }
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError { }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cancelled.path))
+        do {
+            try await VideoExportRenderer.export(sourceURL: source, targetURL: source, options: options)
+            XCTFail("Original must be protected")
+        } catch ExportFileSafety.Failure.originalFile { }
+        XCTAssertEqual(try Data(contentsOf: source), original)
+        let alias = root.appendingPathComponent("alias.png")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: source)
+        XCTAssertTrue(ExportFileSafety.sameFile(alias, source))
+    }
+
+    func testAtomicExportReplacementAndFailure() throws {
+        let root = try fixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("new"), target = root.appendingPathComponent("export")
+        try Data("old".utf8).write(to: target)
+        XCTAssertThrowsError(try ExportFileSafety.install(source: source, destination: target))
+        XCTAssertEqual(try Data(contentsOf: target), Data("old".utf8))
+        try Data("new".utf8).write(to: source)
+        try ExportFileSafety.install(source: source, destination: target)
+        XCTAssertEqual(try Data(contentsOf: target), Data("new".utf8))
+    }
+
+    func testVideoSceneExportWithAudioCutsZoomAndFacecam() async throws {
+        guard let path = ProcessInfo.processInfo.environment["OPEN_RECORDER_SCENE_QA_ROOT"] else {
+            throw XCTSkip("Set OPEN_RECORDER_SCENE_QA_ROOT to a directory containing source.mp4 for native media QA")
+        }
+        let root = URL(fileURLWithPath: path)
+        let source = root.appendingPathComponent("source.mp4")
+        var edits = TimelineEditSnapshot.empty
+        edits.trimRegions = [TimelineTrimRegion(span: TimelineSpan(start: 1, end: 2))]
+        edits.clipSplitTimes = [4]
+        edits.clipSpeeds = [1: 2]
+        edits.zoomRegions = [TimelineZoomRegion(span: TimelineSpan(start: 2.5, end: 4), depth: 1.5)]
+        var options = VideoExportOptions.default
+        options.resolution = .p720
+        options.frameRate = .fps30
+        options.styling = VideoBackgroundStyling(background: .solid(SerializableColor(hex: "#123456")),
+            paddingRatio: 0.08, borderRadiusRatio: 0.025, shadowIntensity: 0.5, backgroundBlurRatio: 0, inset: .none)
+        options.scene.mockup = .browser
+        options.scene.motion.enabled = true
+        options.scene.motion.startPose = ScenePosePreset.left.pose
+        options.scene.motion.endPose = ScenePosePreset.right.pose
+        options.scene.motion.endTime = 3
+        options.facecamVideoURL = source
+        options.facecamFallbackSettings = defaultFacecamSettings(enabled: true)
+        let captures = root.appendingPathComponent("frames")
+        try FileManager.default.createDirectory(at: captures, withIntermediateDirectories: true)
+        let capture = VideoExportBenchmarkTests.FrameCapture(captures)
+        let diagnostics = VideoExportDiagnostics(detailed: true, frameObserver: { buffer, time in capture.capture(buffer, time: time) })
+        let start = ContinuousClock.now
+        let target = root.appendingPathComponent("scene-video.mov")
+        try await VideoExportRenderer.export(sourceURL: source, targetURL: target, options: options, edits: edits, diagnostics: diagnostics)
+        let elapsed = start.duration(to: .now)
+        let asset = AVURLAsset(url: target)
+        let duration = try await asset.load(.duration).seconds
+        let audio = try await asset.loadTracks(withMediaType: .audio)
+        XCTAssertEqual(duration, 4, accuracy: 0.05)
+        XCTAssertEqual(audio.count, 1)
+        XCTAssertGreaterThan(diagnostics.snapshot().renderedFrames, 100)
+        print("SCENE_VIDEO_QA elapsed=\(elapsed) frames=\(diagnostics.snapshot().renderedFrames) kernelSeconds=\(diagnostics.snapshot().kernelSeconds)")
+        // Transparent, unpadded scenes must still select the custom compositor.
+        options.styling = .none
+        options.facecamVideoURL = nil
+        options.facecamFallbackSettings = nil
+        options.scene.motion.enabled = false
+        options.scene.pose = ScenePosePreset.elevated.pose
+        let plainDiagnostics = VideoExportDiagnostics()
+        options.format = .mp4
+        try await VideoExportRenderer.export(sourceURL: source, targetURL: root.appendingPathComponent("scene-unpadded.mp4"),
+            options: options, diagnostics: plainDiagnostics)
+        XCTAssertGreaterThan(plainDiagnostics.snapshot().renderedFrames, 150)
+        options.format = .gif
+        options.gifSize = .medium
+        options.frameRate = .fps15
+        try await VideoExportRenderer.export(sourceURL: source, targetURL: root.appendingPathComponent("scene-video.gif"), options: options)
+        let gif = try XCTUnwrap(CGImageSourceCreateWithURL(root.appendingPathComponent("scene-video.gif") as CFURL, nil))
+        XCTAssertGreaterThan(CGImageSourceGetCount(gif), 80)
+    }
+
+    func testSceneInspectorLayoutAndImageRenderTiming() throws {
+        guard let path = ProcessInfo.processInfo.environment["OPEN_RECORDER_SCENE_QA_ROOT"] else {
+            throw XCTSkip("Set OPEN_RECORDER_SCENE_QA_ROOT for offscreen layout and render measurements")
+        }
+        let root = URL(fileURLWithPath: path)
+        var scene = SceneSettings()
+        scene.pose = ScenePosePreset.left.pose
+        scene.mockup = .browser
+        scene.motion.enabled = true
+        let host = NSHostingView(rootView: SceneInspector(settings: .constant(scene), endpoint: .constant(.start), duration: 3)
+            .padding(14).frame(width: 230).background(Theme.sidebarBg).environment(\.colorScheme, .dark))
+        host.setFrameSize(host.fittingSize)
+        host.layoutSubtreeIfNeeded()
+        if let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) {
+            host.cacheDisplay(in: host.bounds, to: bitmap)
+            try bitmap.representation(using: .png, properties: [:])?.write(to: root.appendingPathComponent("scene-inspector.png"))
+        }
+        let image = try XCTUnwrap(NSImage(contentsOf: root.appendingPathComponent("source.png")))
+        var state = bareImageState()
+        state.scene = scene
+        state.padding = 80
+        state.imageShadow = 0.4
+        state.background = .solid(SerializableColor(hex: "#123456"))
+        let renderer = SceneRenderer()
+        let start = ContinuousClock.now
+        for frame in 0..<120 {
+            try autoreleasepool {
+                var config = ScreenshotExportConfiguration(screenshotState: state)
+                config.sceneTime = Double(frame) / 40
+                let output = try XCTUnwrap(ScreenshotExportRenderer(configuration: config).renderImage(from: image, maxDimension: 1600, renderer: renderer))
+                if [0, 60, 119].contains(frame) {
+                    try NSBitmapImageRep(cgImage: output).representation(using: .png, properties: [:])?.write(to: root.appendingPathComponent("image-frame-\(frame).png"))
+                }
+            }
+        }
+        print("SCENE_IMAGE_QA frames=120 elapsed=\(start.duration(to: .now))")
+    }
+
+    private func bareImageState() -> ScreenshotEditorState {
+        ScreenshotEditorState(background: .transparent, padding: 0, backgroundRoundness: 0, backgroundShadow: 0, imageRoundness: 0, imageShadow: 0)
+    }
+    private func fixtureDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("scene-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+    private func fixtureImage() throws -> NSImage {
+        let context = try XCTUnwrap(CGContext(data: nil, width: 320, height: 180, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 1, alpha: 1)); context.fill(CGRect(x: 0, y: 0, width: 320, height: 180))
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1)); context.fill(CGRect(x: 0, y: 90, width: 160, height: 90))
+        let image = try XCTUnwrap(context.makeImage())
+        return NSImage(cgImage: image, size: CGSize(width: 320, height: 180))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a shared Scene inspector to the video and image editors for 3D tilt, position, perspective, device mockups, and one adjustable motion interval. Scene is marked Alpha, defaults to disabled, and keeps backgrounds, facecam, and annotations upright.

Uses one deterministic Core Image scene renderer for previews and exports, with Metal-backed video preview for active scenes. Animated images can export as MP4, MOV, or GIF while PNG Save and Copy capture the displayed pose.

Adds legacy-safe persistence, autosave and undo integration, finished-timeline motion mapping, identity-scene passthrough, and guarded atomic export writes so source media and existing destinations are preserved on failures.

## Test coverage

- Scene state legacy decoding, persistence, clamping, interpolation, and undo transactions
- Preview/export parity at start, middle, and end poses
- Cut and speed mapping, audio retention, facecam composition, transparency, and portrait canvases
- Image MP4, MOV, and GIF animation export, cancellation, failed writes, and source-file protection
- Metal orientation parity and native inspector rendering at minimum width

## Validation

- `make test-macos`: 32 Rust tests passed; 719 macOS tests passed; 5 existing opt-in tests skipped
- Development app packaged, launched with synthetic media, and passed strict code-sign verification
- Sustained synthetic QA: 120 video frames in 0.704s and 120 image frames in 0.892s

## Manual QA note

The packaged QA app launched and was visible to the native automation bridge, but the bridge timed out attaching to its window. Minimum-width native layout was verified through the offscreen SwiftUI render test and saved inspector artifact.
