### PR TITLE
docs: list root landing demo GIF in repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Open Recorder includes a native editor for turning raw captures into shareable v
 - `.all-contributorsrc` - All Contributors configuration that generates the README contributor table
 - `docs` - project documentation and supporting artifacts
 - `open-recorder-ui.png` - root-level preview of the Open Recorder Editor UI embedded above
+- `open-recorder-demo.gif` - root-level copy of the landing hero demo GIF (byte-identical to `apps/landing/public/open-recorder-demo.gif`)
 - `.github` - GitHub templates and repository automation configuration
 - `licenses` - secondary MIT license notices for OpenScreen and RECORDLY
 - `scripts` - repository build, packaging, verification, and maintenance tooling


### PR DESCRIPTION
## Summary

- Document the root-level `open-recorder-demo.gif` in the README Repository Layout section.
- State that it is byte-identical to the landing hero asset at `apps/landing/public/open-recorder-demo.gif`.

## Validation

- `git diff --check`
- Verified both tracked GIF paths resolve to blob `3ff0ae37baa8de8eac222f7116f1a7df71678f13` (8,865,179 bytes).
- Documentation-only change; no runtime or package tests are applicable.

Closes #1205
